### PR TITLE
Supported different target frameworks

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenTests.DefaultedFrameworkTest.verified.txt
+++ b/Cesium.CodeGen.Tests/CodeGenTests.DefaultedFrameworkTest.verified.txt
@@ -1,0 +1,1 @@
+﻿netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

--- a/Cesium.CodeGen.Tests/CodeGenTests.FrameworkTest_targetFramework=SystemRuntime_versionString=4.2.2.0.verified.txt
+++ b/Cesium.CodeGen.Tests/CodeGenTests.FrameworkTest_targetFramework=SystemRuntime_versionString=4.2.2.0.verified.txt
@@ -1,0 +1,1 @@
+﻿System.Runtime, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

--- a/Cesium.CodeGen.Tests/CodeGenTests.FrameworkTest_targetFramework=mscorlib_versionString=4.0.0.0.verified.txt
+++ b/Cesium.CodeGen.Tests/CodeGenTests.FrameworkTest_targetFramework=mscorlib_versionString=4.0.0.0.verified.txt
@@ -1,0 +1,1 @@
+﻿mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089

--- a/Cesium.CodeGen.Tests/CodeGenTests.FrameworkTest_targetFramework=netstandard_versionString=2.1.0.0.verified.txt
+++ b/Cesium.CodeGen.Tests/CodeGenTests.FrameworkTest_targetFramework=netstandard_versionString=2.1.0.0.verified.txt
@@ -1,0 +1,1 @@
+﻿netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

--- a/Cesium.CodeGen/Generator.cs
+++ b/Cesium.CodeGen/Generator.cs
@@ -6,13 +6,47 @@ namespace Cesium.CodeGen;
 
 public class Generator
 {
+    public enum TargetFrameworks
+    {
+        mscorlib,
+        SystemRuntime,
+        netstandard,
+    }
+
+    public record TargetRuntimeIdentifier(
+        TargetFrameworks targetFramework,
+        Version version);
+
+    private static readonly TargetRuntimeIdentifier defaultTargetRuntime =
+        new(TargetFrameworks.netstandard, new Version(2, 1, 0, 0));
+
     public static AssemblyDefinition GenerateAssembly(
         TranslationUnit translationUnit,
         AssemblyNameDefinition name,
-        ModuleKind kind)
+        ModuleKind kind,
+        TargetRuntimeIdentifier? targetRuntime = default)
     {
         var assembly = AssemblyDefinition.CreateAssembly(name, "Primary", kind);
         var module = assembly.MainModule;
+
+        var tr = targetRuntime ?? defaultTargetRuntime;
+        var (assemblyName, publicKeyToken) =
+            tr.targetFramework switch
+            {
+                TargetFrameworks.mscorlib =>
+                    ("mscorlib", new byte[] { 0xb7, 0x7a, 0x5c, 0x56, 0x19, 0x34, 0xe0, 0x89 }),
+                TargetFrameworks.SystemRuntime =>
+                    ("System.Runtime", new byte[] { 0xb0, 0x3f, 0x5f, 0x7f, 0x11, 0xd5, 0x0a, 0x3a }),
+                _ =>
+                    ("netstandard", new byte[] { 0xb0, 0x3f, 0x5f, 0x7f, 0x11, 0xd5, 0x0a, 0x3a })
+            };
+        var corlibReference = new AssemblyNameReference(
+            assemblyName, tr.version)
+        {
+            PublicKeyToken = publicKeyToken
+        };
+        module.AssemblyReferences.Add(corlibReference);
+
         var moduleType = module.GetType("<Module>");
 
         foreach (var declaration in translationUnit.Declarations)


### PR DESCRIPTION
I tried implementing #10 .

```csharp
    public enum TargetFrameworks
    {
        mscorlib,
        SystemRuntime,
        netstandard,
    }

    public record TargetRuntimeIdentifier(
        TargetFrameworks targetFramework,
        Version version);

    public static AssemblyDefinition GenerateAssembly(
        TranslationUnit translationUnit,
        AssemblyNameDefinition name,
        ModuleKind kind,
        TargetRuntimeIdentifier? targetRuntime = default) { ... }
```

`TargetRuntimeIdentifier` is producing our target framework identity to cecil.
Defaulted target framework (`default`) is netstandard2.1 .

Is issue right for meaning it?
