### PR TITLE
Tests include path resolution

### DIFF
--- a/Cesium.IntegrationTests/Cesium.IntegrationTests.proj
+++ b/Cesium.IntegrationTests/Cesium.IntegrationTests.proj
@@ -1,6 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
     <ItemGroup>
         <Content Include="*.c" />
+        <Content Include="*.h" />
         <Content Include="Run-Tests.ps1" />
     </ItemGroup>
 </Project>

--- a/Cesium.IntegrationTests/empty_include.c
+++ b/Cesium.IntegrationTests/empty_include.c
@@ -1,0 +1,6 @@
+#include "empty_include.h"
+
+int main()
+{
+    return 42;
+}


### PR DESCRIPTION
Right now includes works a bit strange. I assume that `""` resolution should start from location of main compilation file, not from current directory. 