### PR TITLE
IntegrationTests: prevent false positives

### DIFF
--- a/Cesium.IntegrationTests/Run-Tests.ps1
+++ b/Cesium.IntegrationTests/Run-Tests.ps1
@@ -54,11 +54,13 @@ function buildFileWithCesium($inputFile, $outputFile) {
 }
 
 function validateTestCase($testCase) {
-    $nativeCompilerBinOutput = "$outDir/out_native.exe"
-    $cesiumBinOutput = "$outDir/out_cs.exe"
+    $testName = [IO.Path]::GetFileNameWithoutExtension($testCase)
 
-    $nativeCompilerRunLog = "$outDir/out_native.log"
-    $cesiumRunLog = "$outDir/out_cs.log"
+    $nativeCompilerBinOutput = "$outDir/$testName_native.exe"
+    $cesiumBinOutput = "$outDir/$testName_cs.exe"
+
+    $nativeCompilerRunLog = "$outDir/$testName_native.log"
+    $cesiumRunLog = "$outDir/$testName_cs.log"
 
     $expectedExitCode = 42
 


### PR DESCRIPTION
Turns out that, by default, PowerShell will pipe the stdout from the called binaries to the function's return values. This means that our compilation functions were returning the stdout plus the last bool value.

The caller was interpreting the resulting non-empty arrays as truthy, and wasn't properly calculating the test states.