### PR TITLE
Let compiler decide list assemblies for CLI import

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenTestBase.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTestBase.cs
@@ -17,7 +17,8 @@ public abstract class CodeGenTestBase : VerifyTestBase
             translationUnit,
             new AssemblyNameDefinition("test", new Version()),
             ModuleKind.Console,
-            targetRuntime);
+            targetRuntime,
+            new [] { typeof(Console).Assembly });
 
         // To resolve IL labels:
         using var stream = new MemoryStream();

--- a/Cesium.CodeGen/Contexts/AssemblyContext.cs
+++ b/Cesium.CodeGen/Contexts/AssemblyContext.cs
@@ -1,10 +1,11 @@
 using System.Diagnostics;
 using System.Text;
 using Mono.Cecil;
+using Assembly = System.Reflection.Assembly;
 
 namespace Cesium.CodeGen.Contexts;
 
-public record AssemblyContext(AssemblyDefinition Assembly, ModuleDefinition Module)
+public record AssemblyContext(AssemblyDefinition Assembly, ModuleDefinition Module, Assembly[] ImportAssemblies)
 {
     public const string ConstantPoolTypeName = "<ConstantPool>";
 

--- a/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
+++ b/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
@@ -1,8 +1,9 @@
+using System.Reflection;
 using Mono.Cecil;
 
 namespace Cesium.CodeGen.Contexts;
 
-public record TranslationUnitContext(AssemblyContext AssemblyContext)
+public record TranslationUnitContext(AssemblyContext AssemblyContext, Assembly[] ImportAssemblies)
 {
     public AssemblyDefinition Assembly => AssemblyContext.Assembly;
     public ModuleDefinition Module => AssemblyContext.Module;

--- a/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
+++ b/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
@@ -1,9 +1,8 @@
-using System.Reflection;
 using Mono.Cecil;
 
 namespace Cesium.CodeGen.Contexts;
 
-public record TranslationUnitContext(AssemblyContext AssemblyContext, Assembly[] ImportAssemblies)
+public record TranslationUnitContext(AssemblyContext AssemblyContext)
 {
     public AssemblyDefinition Assembly => AssemblyContext.Assembly;
     public ModuleDefinition Module => AssemblyContext.Module;

--- a/Cesium.CodeGen/Extensions/TypeSystemEx.cs
+++ b/Cesium.CodeGen/Extensions/TypeSystemEx.cs
@@ -17,17 +17,17 @@ public static class TypeSystemEx
         var typeName = components[0];
         var methodName = components[1];
 
-        var method = FindType(context.ImportAssemblies, typeName, methodName);
+        var method = FindMethod(context.AssemblyContext.ImportAssemblies, typeName, methodName);
         if (method == null) return null;
 
         return context.Module.ImportReference(method);
     }
 
-    private static MethodInfo? FindType(Assembly[] assemblies, string typeName, string methodName)
+    private static MethodInfo? FindMethod(Assembly[] assemblies, string typeName, string methodName)
     {
         foreach (var assembly in assemblies)
         {
-            var method = FindType(assembly, typeName, methodName);
+            var method = FindMethod(assembly, typeName, methodName);
             if (method != null)
                 return method;
         }
@@ -35,7 +35,7 @@ public static class TypeSystemEx
         return null;
     }
 
-    private static MethodInfo? FindType(Assembly assembly, string typeName, string methodName)
+    private static MethodInfo? FindMethod(Assembly assembly, string typeName, string methodName)
     {
         var type = assembly.GetType(typeName);
         if (type == null) return null;

--- a/Cesium.CodeGen/Extensions/TypeSystemEx.cs
+++ b/Cesium.CodeGen/Extensions/TypeSystemEx.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Cesium.Ast;
 using Cesium.CodeGen.Contexts;
 using Mono.Cecil;
@@ -16,13 +17,30 @@ public static class TypeSystemEx
         var typeName = components[0];
         var methodName = components[1];
 
-        // TODO: Lookup in referenced assemblies.
-        var runtimeAssembly = typeof(Console).Assembly;
-        var type = runtimeAssembly.GetType(typeName);
-        if (type == null) return null;
-        var method = type.GetMethod(methodName);
+        var method = FindType(context.ImportAssemblies, typeName, methodName);
         if (method == null) return null;
 
         return context.Module.ImportReference(method);
+    }
+
+    private static MethodInfo? FindType(Assembly[] assemblies, string typeName, string methodName)
+    {
+        foreach (var assembly in assemblies)
+        {
+            var method = FindType(assembly, typeName, methodName);
+            if (method != null)
+                return method;
+        }
+
+        return null;
+    }
+
+    private static MethodInfo? FindType(Assembly assembly, string typeName, string methodName)
+    {
+        var type = assembly.GetType(typeName);
+        if (type == null) return null;
+
+        var method = type.GetMethod(methodName);
+        return method;
     }
 }

--- a/Cesium.CodeGen/Generators/Assemblies.cs
+++ b/Cesium.CodeGen/Generators/Assemblies.cs
@@ -1,4 +1,5 @@
-﻿using Cesium.Ast;
+﻿using System.Reflection;
+using Cesium.Ast;
 using Cesium.CodeGen.Contexts;
 using Mono.Cecil;
 using static Cesium.CodeGen.Generators.Declarations;
@@ -12,7 +13,8 @@ public static class Assemblies
         TranslationUnit translationUnit,
         AssemblyNameDefinition name,
         ModuleKind kind,
-        TargetRuntimeDescriptor? targetRuntime)
+        TargetRuntimeDescriptor? targetRuntime,
+        Assembly[] importAssemblies)
     {
         var assembly = AssemblyDefinition.CreateAssembly(name, "Primary", kind);
         var module = assembly.MainModule;
@@ -22,7 +24,7 @@ public static class Assemblies
         assembly.CustomAttributes.Add(targetRuntime.GetTargetFrameworkAttribute(module));
         module.AssemblyReferences.Add(targetRuntime.GetSystemAssemblyReference());
 
-        var context = new TranslationUnitContext(assemblyContext);
+        var context = new TranslationUnitContext(assemblyContext, importAssemblies);
         foreach (var declaration in translationUnit.Declarations)
         {
             switch (declaration)

--- a/Cesium.CodeGen/Generators/Assemblies.cs
+++ b/Cesium.CodeGen/Generators/Assemblies.cs
@@ -18,13 +18,13 @@ public static class Assemblies
     {
         var assembly = AssemblyDefinition.CreateAssembly(name, "Primary", kind);
         var module = assembly.MainModule;
-        var assemblyContext = new AssemblyContext(assembly, module);
+        var assemblyContext = new AssemblyContext(assembly, module, importAssemblies);
 
         targetRuntime ??= TargetRuntimeDescriptor.Net60;
         assembly.CustomAttributes.Add(targetRuntime.GetTargetFrameworkAttribute(module));
         module.AssemblyReferences.Add(targetRuntime.GetSystemAssemblyReference());
 
-        var context = new TranslationUnitContext(assemblyContext, importAssemblies);
+        var context = new TranslationUnitContext(assemblyContext);
         foreach (var declaration in translationUnit.Declarations)
         {
             switch (declaration)

--- a/Cesium.Compiler/Program.cs
+++ b/Cesium.Compiler/Program.cs
@@ -94,7 +94,8 @@ return await Parser.Default.ParseArguments<Arguments>(args).MapResult(async args
             translationUnit,
             new AssemblyNameDefinition(assemblyName, new Version()),
             moduleKind,
-            targetRuntime);
+            targetRuntime,
+            new [] { typeof(Console).Assembly });
         assembly.Write(args.OutputFilePath);
 
         if (moduleKind == ModuleKind.Console && args.Framework == TargetFrameworkKind.Net)


### PR DESCRIPTION
I put list of assemblies for resolving CLI import in the `TranslationUnitContext`. I need this for basic runtime library support, since resolution should happens from runtime library, and I do not want to use `Assembly.GetReferencesAssemblies()` purely, because then I cannot run this compiler via NativeAOT.

Other benefit, is that way we explicitly control list of assemblies to resolve CLI import and then this can be controller by developer via command line arguments.