### PR TITLE
(#69) CodeGen: internal linkage function declaration support

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,6 +13,7 @@ jobs:
   main:
     runs-on: ${{ matrix.environment }}
     strategy:
+      fail-fast: false
       matrix:
         environment:
           - ubuntu-latest

--- a/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
@@ -10,12 +10,6 @@ public class CodeGenMethodTests : CodeGenTestBase
         return VerifyMethods(moduleType);
     }
 
-    private static void DoesNotCompile(string source, string expectedMessage)
-    {
-        var ex = Assert.Throws<NotSupportedException>(() => GenerateAssembly(default, source));
-        Assert.Contains(expectedMessage, ex.Message);
-    }
-
     [Fact]
     public Task EmptyMainTest() => DoTest("int main() {}");
 
@@ -97,4 +91,25 @@ int main()
     return x + 2;
 }
 ");
+
+    [Fact]
+    public void IncorrectReturnTypeDoesNotCompile() => DoesNotCompile(@"int foo(void);
+void foo(void) {}", "Incorrect return type");
+
+    [Fact]
+    public void IncorrectParameterTypeDoesNotCompile() => DoesNotCompile(@"int foo(int bar);
+int foo(char *x) {}", "Incorrect type for parameter x");
+
+    [Fact]
+    public void IncorrectParameterCountDoesNotCompile() => DoesNotCompile(@"int foo(int bar, int baz);
+int foo(int bar) {}", "Incorrect parameter count");
+
+    [Fact]
+    public void IncorrectOverrideCliImport() => DoesNotCompile(@"__cli_import(""System.Console::Read"")
+int console_read();
+int console_read() { return 0; }", "Function console_read already defined as immutable.");
+
+    [Fact]
+    public void DoubleDefinition() => DoesNotCompile(@"int console_read() { return 1; }
+int console_read() { return 2; }", "Double definition of function console_read.");
 }

--- a/Cesium.CodeGen.Tests/CodeGenTestBase.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTestBase.cs
@@ -19,6 +19,12 @@ public abstract class CodeGenTestBase : VerifyTestBase
         return EmitAssembly(context);
     }
 
+    protected static void DoesNotCompile(string source, string expectedMessage)
+    {
+        var ex = Assert.Throws<NotSupportedException>(() => GenerateAssembly(default, source));
+        Assert.Contains(expectedMessage, ex.Message);
+    }
+
     private static AssemblyContext CreateAssembly(TargetRuntimeDescriptor? targetRuntime) =>
         AssemblyContext.Create(
             new AssemblyNameDefinition("test", new Version()),

--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.FunctionForwardDeclaration.received.txt
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.FunctionForwardDeclaration.received.txt
@@ -1,0 +1,10 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::bar()
+      IL_0000: ldc.i4 0
+      IL_0005: ret
+
+    System.Int32 <Module>::foo()
+      IL_0000: call System.Int32 <Module>::bar()
+      IL_0005: ret

--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
@@ -21,4 +21,28 @@ public class CodeGenTypeTests : CodeGenTestBase
     const char *test2 = ""hellow1"";
     const char *test3 = ""hellow"";
 }");
+
+    [Fact]
+    public void AbsentForwardDeclaration() => DoesNotCompile(@"int foo()
+{
+    return bar();
+}
+
+int bar()
+{
+    return 0;
+}", "Function \"bar\" was not found.");
+
+    [Fact]
+    public void FunctionForwardDeclaration() => DoTest(@"int bar(void);
+
+int foo(void)
+{
+    return bar();
+}
+
+int bar(void)
+{
+    return 0;
+}");
 }

--- a/Cesium.CodeGen/Contexts/FunctionScope.cs
+++ b/Cesium.CodeGen/Contexts/FunctionScope.cs
@@ -1,15 +1,26 @@
+using Cesium.CodeGen.Contexts.Meta;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Contexts;
 
-public record FunctionScope(TranslationUnitContext Context, MethodDefinition Method)
+internal record FunctionScope(TranslationUnitContext Context, MethodDefinition Method)
 {
     public AssemblyContext AssemblyContext => Context.AssemblyContext;
     public ModuleDefinition Module => Context.Module;
     public TypeSystem TypeSystem => Context.TypeSystem;
-    public IReadOnlyDictionary<string, MethodReference> Functions => Context.Functions;
+    public IReadOnlyDictionary<string, FunctionInfo> Functions => Context.Functions;
 
     public Dictionary<string, VariableDefinition> Variables { get; } = new();
-    public Dictionary<string, ParameterDefinition> Parameters { get; } = new();
+
+    private readonly Dictionary<string, ParameterDefinition> _parameterCache = new();
+    public ParameterDefinition? GetParameter(string name)
+    {
+        if (_parameterCache.TryGetValue(name, out var parameter))
+            return parameter;
+
+        parameter = Method.Parameters.FirstOrDefault(p => p.Name == name);
+        if (parameter != null) _parameterCache.Add(name, parameter);
+        return parameter;
+    }
 }

--- a/Cesium.CodeGen/Contexts/Meta/FunctionInfo.cs
+++ b/Cesium.CodeGen/Contexts/Meta/FunctionInfo.cs
@@ -1,0 +1,11 @@
+using Cesium.CodeGen.Ir;
+using Cesium.CodeGen.Ir.Types;
+using Mono.Cecil;
+
+namespace Cesium.CodeGen.Contexts.Meta;
+
+internal record FunctionInfo(
+    ParametersInfo? Parameters,
+    IType ReturnType,
+    MethodReference MethodReference,
+    bool IsDefined = false);

--- a/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
+++ b/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
@@ -1,3 +1,4 @@
+using Cesium.CodeGen.Contexts.Meta;
 using Mono.Cecil;
 
 namespace Cesium.CodeGen.Contexts;
@@ -8,5 +9,5 @@ public record TranslationUnitContext(AssemblyContext AssemblyContext)
     public ModuleDefinition Module => AssemblyContext.Module;
     public TypeSystem TypeSystem => Module.TypeSystem;
     public TypeDefinition ModuleType => Module.GetType("<Module>");
-    public Dictionary<string, MethodReference> Functions { get; } = new();
+    internal Dictionary<string, FunctionInfo> Functions { get; } = new();
 }

--- a/Cesium.CodeGen/Extensions/CodeGenEx.cs
+++ b/Cesium.CodeGen/Extensions/CodeGenEx.cs
@@ -3,7 +3,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Extensions;
 
-public static class CodeGenEx
+internal static class CodeGenEx
 {
     public static void StLoc(this FunctionScope scope, VariableDefinition variable)
     {

--- a/Cesium.CodeGen/Extensions/TypeDefinitionEx.cs
+++ b/Cesium.CodeGen/Extensions/TypeDefinitionEx.cs
@@ -1,0 +1,44 @@
+using Cesium.CodeGen.Ir;
+using Mono.Cecil;
+
+namespace Cesium.CodeGen.Extensions;
+
+internal static class TypeDefinitionEx
+{
+    public static MethodDefinition DefineMethod(
+        this TypeDefinition type,
+        TypeSystem typeSystem,
+        string name,
+        TypeReference returnType,
+        ParametersInfo? parameters)
+    {
+        var method = new MethodDefinition(
+            name,
+            MethodAttributes.Public | MethodAttributes.Static,
+            returnType);
+        AddParameters(typeSystem, method, parameters);
+        type.Methods.Add(method);
+        return method;
+    }
+
+    private static void AddParameters(TypeSystem typeSystem, MethodDefinition method, ParametersInfo? parametersInfo)
+    {
+        if (parametersInfo == null) return;
+        var (parameters, isVoid, isVarArg) = parametersInfo;
+        if (isVoid) return;
+        if (isVarArg)
+            throw new NotImplementedException($"VarArg functions not supported, yet: {method.Name}.");
+
+        // TODO[#87]: Process empty (non-void) parameter list.
+
+        foreach (var parameter in parameters)
+        {
+            var (type, name) = parameter;
+            var parameterDefinition = new ParameterDefinition(type.Resolve(typeSystem))
+            {
+                Name = name
+            };
+            method.Parameters.Add(parameterDefinition);
+        }
+    }
+}

--- a/Cesium.CodeGen/Ir/BlockItems/DeclarationBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/DeclarationBlockItem.cs
@@ -33,9 +33,9 @@ internal class DeclarationBlockItem : IBlockItem
         foreach (var (declaration, initializer) in _declarations)
         {
             var method = scope.Method;
-            var (type, isConst, identifier, parametersInfo, cliImportMemberName) = declaration;
+            var (type, identifier, parametersInfo, cliImportMemberName) = declaration;
 
-            // TODO[#91]: A place to register {isConst}.
+            // TODO[#91]: A place to register whether {type} is const or not.
 
             if (identifier == null)
                 throw new NotSupportedException("An anonymous local declaration isn't supported.");

--- a/Cesium.CodeGen/Ir/DeclarationInfo.cs
+++ b/Cesium.CodeGen/Ir/DeclarationInfo.cs
@@ -4,17 +4,16 @@ using Cesium.CodeGen.Ir.Types;
 namespace Cesium.CodeGen.Ir;
 
 internal record DeclarationInfo(
-    IType Type,
-    bool IsConst,
+    IType ReturnType,
     string? Identifier,
     ParametersInfo? Parameters,
     string? CliImportMemberName)
 {
     public static DeclarationInfo Of(IList<IDeclarationSpecifier> specifiers, Declarator? declarator)
     {
-        (IType type, var isConst, var cliImportMemberName) = GetPrimitiveInfo(specifiers);
+        var (type, cliImportMemberName) = GetPrimitiveInfo(specifiers);
         if (declarator == null)
-            return new DeclarationInfo(type, isConst, null, null, null);
+            return new DeclarationInfo(type, null, null, null);
 
         var (pointer, directDeclarator) = declarator;
         if (pointer != null)
@@ -77,10 +76,10 @@ internal record DeclarationInfo(
             currentDirectDeclarator = currentDirectDeclarator.Base;
         }
 
-        return new DeclarationInfo(type, isConst, identifier, parameters, cliImportMemberName);
+        return new DeclarationInfo(type, identifier, parameters, cliImportMemberName);
     }
 
-    private static (PrimitiveType, bool isConst, string? cliImportMemberName) GetPrimitiveInfo(
+    private static (IType, string? cliImportMemberName) GetPrimitiveInfo(
         IList<IDeclarationSpecifier> specifiers)
     {
         PrimitiveType? type = null;
@@ -137,6 +136,6 @@ internal record DeclarationInfo(
             throw new NotSupportedException(
                 $"Declaration specifiers missing type specifier: {string.Join(", ", specifiers)}");
 
-        return (type, isConst, cliImportMemberName);
+        return (isConst ? new ConstType(type) : type, cliImportMemberName);
     }
 }

--- a/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
@@ -3,7 +3,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Constants;
 
-public class CharConstant : IConstant
+internal class CharConstant : IConstant
 {
     private readonly byte _value;
 

--- a/Cesium.CodeGen/Ir/Expressions/Constants/IConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/IConstant.cs
@@ -2,7 +2,7 @@ using Cesium.CodeGen.Contexts;
 
 namespace Cesium.CodeGen.Ir.Expressions.Constants;
 
-public interface IConstant
+internal interface IConstant
 {
     void EmitTo(FunctionScope scope);
 }

--- a/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
@@ -6,7 +6,7 @@ using Yoakke.Lexer;
 
 namespace Cesium.CodeGen.Ir.Expressions.Constants;
 
-public class StringConstant : IConstant
+internal class StringConstant : IConstant
 {
     private readonly string _value;
     public StringConstant(IToken<CTokenType> token)

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -36,8 +36,9 @@ internal class FunctionCallExpression : IExpression
             argument.EmitTo(scope);
 
         var functionName = _function.Identifier;
-        var callee = scope.Functions[functionName];
+        var callee = scope.Functions.GetValueOrDefault(functionName)
+                     ?? throw new NotSupportedException($"Function \"{functionName}\" was not found.");
 
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Call, callee));
+        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Call, callee.MethodReference));
     }
 }

--- a/Cesium.CodeGen/Ir/Expressions/IdentifierConstantExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IdentifierConstantExpression.cs
@@ -22,7 +22,7 @@ internal class IdentifierConstantExpression : IExpression, ILValueExpression
     public ILValue Resolve(FunctionScope scope)
     {
         scope.Variables.TryGetValue(Identifier, out var var);
-        scope.Parameters.TryGetValue(Identifier, out var par);
+        var par = scope.GetParameter(Identifier);
 
         switch (var, par)
         {

--- a/Cesium.CodeGen/Ir/ParametersInfo.cs
+++ b/Cesium.CodeGen/Ir/ParametersInfo.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Cesium.Ast;
 using Cesium.CodeGen.Ir.Types;
 
@@ -6,9 +5,6 @@ namespace Cesium.CodeGen.Ir;
 
 internal record ParametersInfo(IList<ParameterInfo> Parameters, bool IsVoid, bool IsVarArg)
 {
-    private static readonly ParameterDeclaration VoidParameterDeclaration = new(
-        ImmutableArray.Create<IDeclarationSpecifier>(new TypeSpecifier("void")));
-
     public static ParametersInfo Of(ParameterTypeList parameters)
     {
         var (parameterList, hasEllipsis) = parameters;
@@ -49,10 +45,7 @@ internal record ParameterInfo(IType Type, string? Name)
             throw new NotImplementedException(
                 $"Parameter with abstract declarator is not supported, yet: {declaration}.");
 
-        var (type, isConst, identifier, parameters, cliImportMemberName) = DeclarationInfo.Of(specifiers, declarator);
-        if (isConst)
-            throw new NotImplementedException(
-                $"Const parameter isn't supported, yet: {identifier}.");
+        var (type, identifier, parameters, cliImportMemberName) = DeclarationInfo.Of(specifiers, declarator);
 
         if (parameters != null)
             throw new NotImplementedException($"Parameters with parameters are not supported, yet: {parameters}.");

--- a/Cesium.CodeGen/Ir/TopLevel/SymbolDeclaration.cs
+++ b/Cesium.CodeGen/Ir/TopLevel/SymbolDeclaration.cs
@@ -1,5 +1,7 @@
 using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Contexts.Meta;
 using Cesium.CodeGen.Extensions;
+using Cesium.CodeGen.Ir.Types;
 
 namespace Cesium.CodeGen.Ir.TopLevel;
 
@@ -16,25 +18,31 @@ internal class SymbolDeclaration : ITopLevelNode
     {
         foreach (var (declaration, initializer) in _declarations)
         {
-            var (type, isConst, identifier, parametersInfo, cliImportMemberName) = declaration;
+            var (type, identifier, parametersInfo, cliImportMemberName) = declaration;
             if (identifier == null)
                 throw new NotSupportedException($"Unnamed global symbol of type {type} is not supported.");
 
-            // TODO[#75]: Generate a global variable of type {type, isConst}.
+            if (parametersInfo != null)
+            {
+                if (initializer != null)
+                    throw new NotSupportedException(
+                        $"Initializer expression for a function declaration isn't supported: {initializer}.");
+
+                EmitFunctionDeclaration(context, identifier, parametersInfo, type);
+                return;
+            }
+
             if (cliImportMemberName != null)
             {
                 if (initializer != null)
                     throw new NotSupportedException(
                         $"Initializer expression for a CLI import isn't supported: {initializer}.");
 
-                var method = context.MethodLookup(cliImportMemberName);
-                if (method == null) throw new NotSupportedException($"Cannot find CLI-imported member {cliImportMemberName}.");
-
-                // TODO[#93]: Verify method signature: {parametersIInfo, type, isConst}.
-                context.Functions.Add(identifier, method);
+                EmitCliImportDeclaration(context, identifier, parametersInfo, type, cliImportMemberName);
                 return;
             }
 
+            // TODO[#75]: Generate a global variable of type {type, isConst}.
             if (initializer != null)
             {
                 throw new NotImplementedException(
@@ -44,5 +52,37 @@ internal class SymbolDeclaration : ITopLevelNode
 
             throw new NotImplementedException($"Declaration not supported, yet: {declaration}.");
         }
+    }
+
+    private void EmitFunctionDeclaration(
+        TranslationUnitContext context,
+        string identifier,
+        ParametersInfo parametersInfo,
+        IType returnType)
+    {
+        var typeSystem = context.TypeSystem;
+        var method = context.ModuleType.DefineMethod(
+            typeSystem,
+            identifier,
+            returnType.Resolve(typeSystem),
+            parametersInfo);
+
+        context.Functions.Add(
+            identifier,
+            new FunctionInfo(parametersInfo, returnType, method));
+    }
+
+    private void EmitCliImportDeclaration(
+        TranslationUnitContext context,
+        string name,
+        ParametersInfo? parametersInfo,
+        IType returnType,
+        string memberName)
+    {
+        var method = context.MethodLookup(memberName);
+        if (method == null) throw new NotSupportedException($"Cannot find CLI-imported member {memberName}.");
+
+        // TODO[#93]: Verify method signature: {parametersIInfo, type}.
+        context.Functions.Add(name, new FunctionInfo(parametersInfo, returnType, method));
     }
 }

--- a/Cesium.CodeGen/Ir/Types/ConstType.cs
+++ b/Cesium.CodeGen/Ir/Types/ConstType.cs
@@ -1,0 +1,8 @@
+using Mono.Cecil;
+
+namespace Cesium.CodeGen.Ir.Types;
+
+internal record ConstType(IType Base) : IType
+{
+    public TypeReference Resolve(TypeSystem typeSystem) => Base.Resolve(typeSystem);
+}


### PR DESCRIPTION
This is a part of #69.

This only adds support for the internal linkage (i.e. inside of a translation unit, not between different ones).