### PR TITLE
Add more test cases for function signatures

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenMethodTests.PointerReceivingFunction.verified.txt
+++ b/Cesium.CodeGen.Tests/CodeGenMethodTests.PointerReceivingFunction.verified.txt
@@ -1,1 +1,2 @@
 ﻿System.Void <Module>::foo(System.Int32* ptr)
+  IL_0000: ret

--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.EmptyFunctionDeclaration.verified.txt
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.EmptyFunctionDeclaration.verified.txt
@@ -1,0 +1,5 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Void <Module>::foo()
+      IL_0000: ret

--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
@@ -45,4 +45,23 @@ int bar(void)
 {
     return 0;
 }");
+
+    [Fact]
+    public Task EmptyFunctionDeclaration() => DoTest(@"
+void foo(void)
+{
+}");
+
+    [Fact]
+    public Task FunctionForwardDeclaration2() => DoTest(@"int bar();
+
+int foo(void)
+{
+    return bar();
+}
+
+int bar(void)
+{
+    return 0;
+}");
 }

--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
@@ -51,17 +51,4 @@ int bar(void)
 void foo(void)
 {
 }");
-
-    [Fact]
-    public Task FunctionForwardDeclaration2() => DoTest(@"int bar();
-
-int foo(void)
-{
-    return bar();
-}
-
-int bar(void)
-{
-    return 0;
-}");
 }

--- a/Cesium.IntegrationTests/functions.c
+++ b/Cesium.IntegrationTests/functions.c
@@ -1,5 +1,5 @@
 //void forward_declaration_void_1();
-//void forward_declaration_void_2(void);
+void forward_declaration_void_2(void);
 
 void declaration_void(void)
 {
@@ -9,7 +9,7 @@ int foo()
 {
     declaration_void();
     //forward_declaration_void_1();
-    //forward_declaration_void_2();
+    forward_declaration_void_2();
     return 42;
 }
 

--- a/Cesium.IntegrationTests/functions.c
+++ b/Cesium.IntegrationTests/functions.c
@@ -1,6 +1,26 @@
-int foo(void)
+//void forward_declaration_void_1();
+//void forward_declaration_void_2(void);
+
+void declaration_void(void)
 {
+}
+
+int foo()
+{
+    declaration_void();
+    //forward_declaration_void_1();
+    //forward_declaration_void_2();
     return 42;
+}
+
+void forward_declaration_void_1()
+{
+    // Do nothing here.
+}
+
+void forward_declaration_void_2()
+{
+    // Do nothing here.
 }
 
 int main(void)

--- a/Cesium.IntegrationTests/functions.c
+++ b/Cesium.IntegrationTests/functions.c
@@ -1,4 +1,3 @@
-//void forward_declaration_void_1();
 void forward_declaration_void_2(void);
 
 void declaration_void(void)
@@ -8,7 +7,6 @@ void declaration_void(void)
 int foo()
 {
     declaration_void();
-    //forward_declaration_void_1();
     forward_declaration_void_2();
     return 42;
 }


### PR DESCRIPTION
Fix codegen for empty functions without any statement. Inside IL they are require to have at least one `ret`  instruction inside method body.