### PR TITLE
Feature/102.array indexing

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
@@ -187,4 +187,11 @@ int main() { return foo(); }", "Function foo not defined.");
 
     [Fact]
     public Task LogicalOrOperator() => DoTest(@"int main() { return 1 || 2; }");
+
+    [Fact]
+    public Task ArrayAssignment() => DoTest(@"int main() {
+    int a[10];
+    a[1] = 2;
+    return a[1];
+ }");
 }

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ArrayAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ArrayAssignment.verified.txt
@@ -1,0 +1,23 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32* V_0
+  IL_0000: ldc.i4 40
+  IL_0005: conv.u
+  IL_0006: localloc
+  IL_0008: stloc V_0
+  IL_000c: ldloc V_0
+  IL_0010: ldc.i4 1
+  IL_0015: conv.i
+  IL_0016: ldc.i4 4
+  IL_001b: mul
+  IL_001c: add
+  IL_001d: ldc.i4 2
+  IL_0022: stind.i4
+  IL_0023: ldloc V_0
+  IL_0027: ldc.i4 1
+  IL_002c: conv.i
+  IL_002d: ldc.i4 4
+  IL_0032: mul
+  IL_0033: add
+  IL_0034: ldind.i4
+  IL_0035: ret

--- a/Cesium.CodeGen/Extensions/ExpressionEx.cs
+++ b/Cesium.CodeGen/Extensions/ExpressionEx.cs
@@ -21,6 +21,8 @@ internal static class ExpressionEx
         Ast.LogicalBinaryOperatorExpression e => new LogicalBinaryOperatorExpression(e),
         Ast.BinaryOperatorExpression e => new BinaryOperatorExpression(e),
 
+        Ast.SubscriptingExpression e => new SubscriptingExpression(e),
+
         _ => throw new NotImplementedException($"Expression not supported, yet: {ex}."),
     };
 }

--- a/Cesium.CodeGen/Ir/Expressions/AssignmentExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/AssignmentExpression.cs
@@ -38,8 +38,6 @@ internal class AssignmentExpression : BinaryOperatorExpression
         if (Operator != BinaryOperator.Assign)
             throw new NotSupportedException($"Operator {Operator} should've been lowered before emitting.");
 
-        Right.EmitTo(scope);
-
-        _target.Resolve(scope).EmitSetValue(scope);
+        _target.Resolve(scope).EmitSetValue(scope, Right);
     }
 }

--- a/Cesium.CodeGen/Ir/Expressions/LValues/ILValue.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/ILValue.cs
@@ -1,9 +1,11 @@
 using Cesium.CodeGen.Contexts;
+using Mono.Cecil;
 
 namespace Cesium.CodeGen.Ir.Expressions.LValues;
 
 internal interface ILValue
 {
     void EmitGetValue(IDeclarationScope scope);
-    void EmitSetValue(IDeclarationScope scope);
+    void EmitSetValue(IDeclarationScope scope, IExpression value);
+    TypeReference GetValueType();
 }

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueArrayElement.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueArrayElement.cs
@@ -1,0 +1,52 @@
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Ir.Types;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Cesium.CodeGen.Ir.Expressions.LValues;
+
+internal class LValueArrayElement : ILValue
+{
+    private readonly ILValue _array;
+    private readonly IExpression _index;
+
+    public LValueArrayElement(ILValue array, IExpression index)
+    {
+        _array = array;
+        _index = index;
+    }
+
+    public void EmitGetValue(IDeclarationScope scope)
+    {
+        EmitPointerMoveToElement(scope);
+
+        var (loadOp, _) = PrimitiveTypeInfo.Opcodes[GetElementType().Name];
+        scope.Method.Body.GetILProcessor().Emit(loadOp);
+    }
+
+    public void EmitSetValue(IDeclarationScope scope, IExpression value)
+    {
+        EmitPointerMoveToElement(scope);
+        value.EmitTo(scope);
+        var (_, storeOp) = PrimitiveTypeInfo.Opcodes[GetElementType().Name];
+        scope.Method.Body.GetILProcessor().Emit(storeOp);
+    }
+
+    public TypeReference GetValueType()
+        => _array.GetValueType();
+
+    private TypeReference GetElementType()
+        => GetValueType().GetElementType();
+
+    private void EmitPointerMoveToElement(IDeclarationScope scope)
+    {
+        _array.EmitGetValue(scope);
+        _index.EmitTo(scope);
+        var method = scope.Method.Body.GetILProcessor();
+        method.Emit(OpCodes.Conv_I);
+        var elementSize = PrimitiveTypeInfo.Size[GetElementType().Name];
+        method.Emit(OpCodes.Ldc_I4, elementSize);
+        method.Emit(OpCodes.Mul);
+        method.Emit(OpCodes.Add);
+    }
+}

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueLocalVariable.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueLocalVariable.cs
@@ -1,5 +1,6 @@
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Extensions;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.LValues;
@@ -7,6 +8,7 @@ namespace Cesium.CodeGen.Ir.Expressions.LValues;
 internal class LValueLocalVariable : ILValue
 {
     private readonly VariableDefinition _definition;
+
     public LValueLocalVariable(VariableDefinition definition)
     {
         _definition = definition;
@@ -18,5 +20,12 @@ internal class LValueLocalVariable : ILValue
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldloc, _definition));
     }
 
-    public void EmitSetValue(IDeclarationScope scope) => scope.StLoc(_definition);
+    public void EmitSetValue(IDeclarationScope scope, IExpression value)
+    {
+        value.EmitTo(scope);
+
+        scope.StLoc(_definition);
+    }
+
+    public TypeReference GetValueType() => _definition.VariableType;
 }

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueParameter.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueParameter.cs
@@ -18,9 +18,13 @@ internal class LValueParameter : ILValue
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldarg, _definition));
     }
 
-    public void EmitSetValue(IDeclarationScope scope)
+    public void EmitSetValue(IDeclarationScope scope, IExpression value)
     {
+        value.EmitTo(scope);
+
         // TODO[#92]: Special instructions to emit Starg_0 etc.
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Starg, _definition));
     }
+
+    public TypeReference GetValueType() => _definition.ParameterType;
 }

--- a/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
@@ -1,0 +1,37 @@
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Extensions;
+using Cesium.CodeGen.Ir.Expressions.LValues;
+
+namespace Cesium.CodeGen.Ir.Expressions;
+
+internal class SubscriptingExpression : IExpression, ILValueExpression
+{
+    private readonly IExpression _expression;
+    private readonly IExpression _index;
+
+    public SubscriptingExpression(Ast.SubscriptingExpression subscriptingExpression)
+    {
+        var (expression, index) = subscriptingExpression;
+        _expression = expression.ToIntermediate();
+        _index = index.ToIntermediate();
+    }
+
+    private SubscriptingExpression(IExpression expression, IExpression index)
+    {
+        _expression = expression;
+        _index = index;
+    }
+
+    public IExpression Lower()
+        => new SubscriptingExpression(_expression.Lower(), _index.Lower());
+
+    public void EmitTo(IDeclarationScope scope) => Resolve(scope).EmitGetValue(scope);
+
+    public ILValue Resolve(IDeclarationScope scope)
+    {
+        if (_expression is not IdentifierConstantExpression identifier)
+            throw new NotImplementedException("Subscription supported only for IdentifierConstantExpression");
+
+        return new LValueArrayElement(identifier.Resolve(scope), _index);
+    }
+}

--- a/Cesium.CodeGen/Ir/Types/PrimitiveType.cs
+++ b/Cesium.CodeGen/Ir/Types/PrimitiveType.cs
@@ -1,5 +1,6 @@
 using Cesium.CodeGen.Contexts;
 using Mono.Cecil;
+using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Types;
 
@@ -132,4 +133,39 @@ internal record PrimitiveType(PrimitiveTypeKind Kind) : IType
 
     public override string ToString()
         => $"PrimitiveType {{ Kind = {Kind} }}";
+}
+
+internal static class PrimitiveTypeInfo
+{
+    internal static readonly Dictionary<string, int> Size = new()
+    {
+        { "Byte", 1 },
+        { "SByte", 1 },
+        { "Boolean", 1 },
+        { "Int16", 2 },
+        { "UInt16", 2 },
+        { "Char", 2 },
+        { "Int32", 4 },
+        { "UInt32", 4 },
+        { "Single", 4 },
+        { "Int64", 8 },
+        { "UInt64", 8 },
+        { "Double", 8 },
+    };
+
+    internal static readonly Dictionary<string, (OpCode load, OpCode store)> Opcodes = new()
+    {
+        { "Byte", (OpCodes.Ldind_I1, OpCodes.Stind_I1) },
+        { "SByte", (OpCodes.Ldind_I1, OpCodes.Stind_I1) },
+        { "Boolean", (OpCodes.Ldind_I1, OpCodes.Stind_I1) },
+        { "Int16", (OpCodes.Ldind_I2, OpCodes.Stind_I2) },
+        { "UInt16", (OpCodes.Ldind_I2, OpCodes.Stind_I2) },
+        { "Char", (OpCodes.Ldind_I4, OpCodes.Stind_I4) },
+        { "Int32", (OpCodes.Ldind_I4, OpCodes.Stind_I4) },
+        { "UInt32", (OpCodes.Ldind_I4, OpCodes.Stind_I4) },
+        { "Single", (OpCodes.Ldind_R4, OpCodes.Stind_R4) },
+        { "Int64", (OpCodes.Ldind_I8, OpCodes.Stind_I8) },
+        { "UInt64", (OpCodes.Ldind_I8, OpCodes.Stind_I8) },
+        { "Double", (OpCodes.Ldind_R8, OpCodes.Stind_R8) },
+    };
 }

--- a/Cesium.IntegrationTests/array.c
+++ b/Cesium.IntegrationTests/array.c
@@ -1,0 +1,6 @@
+int main(int argc, char *argv[])
+{
+    int a[10];
+    a[1] = 42;
+    return a[1];
+}

--- a/Cesium.Parser.Tests/ParserTests/StatementParserTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/StatementParserTests.cs
@@ -86,4 +86,10 @@ if (1)
     i = i - 1;
     i = i + 2;
 }");
+
+    [Fact]
+    public Task ArrayAssigment() => DoTest(@"{
+    int a[1];
+    a[0] = 0;
+}");
 }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ArrayAssigment.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ArrayAssigment.verified.txt
@@ -1,0 +1,71 @@
+﻿{
+  "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",
+  "Block": [
+    {
+      "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+      "Specifiers": [
+        {
+          "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+          "TypeName": "int"
+        }
+      ],
+      "InitDeclarators": [
+        {
+          "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+          "Declarator": {
+            "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+            "Pointer": null,
+            "DirectDeclarator": {
+              "$type": "Cesium.Ast.ArrayDirectDeclarator, Cesium.Ast",
+              "Base": {
+                "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                "Identifier": "a",
+                "Base": null
+              },
+              "TypeQualifiers": null,
+              "Size": {
+                "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                "Constant": {
+                  "Kind": "IntLiteral",
+                  "Text": "1"
+                }
+              }
+            }
+          },
+          "Initializer": null
+        }
+      ]
+    },
+    {
+      "$type": "Cesium.Ast.ExpressionStatement, Cesium.Ast",
+      "Expression": {
+        "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
+        "Left": {
+          "$type": "Cesium.Ast.SubscriptingExpression, Cesium.Ast",
+          "Base": {
+            "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+            "Constant": {
+              "Kind": "Identifier",
+              "Text": "a"
+            }
+          },
+          "Index": {
+            "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+            "Constant": {
+              "Kind": "IntLiteral",
+              "Text": "0"
+            }
+          }
+        },
+        "Operator": "=",
+        "Right": {
+          "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+          "Constant": {
+            "Kind": "IntLiteral",
+            "Text": "0"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #102 
Restrictions: 
- only primitive type arrays
- no type conversion — you can't set byte to int[]