### PR TITLE
Pointer member access and address-of operator

### DIFF
--- a/Cesium.Ast/Expressions.cs
+++ b/Cesium.Ast/Expressions.cs
@@ -13,6 +13,7 @@ public record ConstantExpression(IToken<CTokenType> Constant) : Expression;
 // 6.5.2 Postfix operators
 public record SubscriptingExpression(Expression Base, Expression Index) : Expression;
 public record FunctionCallExpression(Expression Function, ImmutableArray<Expression>? Arguments) : Expression;
+public record PointerMemberAccessExpression(Expression Function, IdentifierExpression Identifier) : Expression;
 
 // 6.5.3 Unary operators
 public record PrefixIncrementExpression(Expression Target) : Expression;

--- a/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
@@ -63,6 +63,9 @@ int main()
     [Fact]
     public Task NegationExpressTest() => DoTest("int main() { return -42; }");
 
+    [Fact]
+    public Task AddressOfTest() => DoTest("int main() { int x; int *y = &x; }");
+
     [Fact] public Task ParameterlessMain() => DoTest("int main(){}");
     [Fact] public Task VoidParameterMain() => DoTest("int main(void){}");
     [Fact] public Task PointerReceivingFunction() => DoTest("void foo(int *ptr){}");

--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
@@ -60,6 +60,14 @@ void foo(void)
 int main(void) { foo x; return 0; }");
 
     [Fact]
+    public Task StructUsageWithPointerMemberAccessGet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo *x; return x->x; }");
+
+    [Fact]
+    public Task StructUsageWithPointerMemberAccessSet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo *x; x->x = 42; return 0; }");
+
+    [Fact]
     public Task ArrayDeclaration() => DoTest(@"int main()
 {
     int i;

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AddressOfTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AddressOfTest.verified.txt
@@ -1,0 +1,7 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32 V_0
+    System.Int32* V_1
+  IL_0000: ldloca V_0
+  IL_0004: conv.u
+  IL_0005: stloc V_1

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithPointerMemberAccessGet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithPointerMemberAccessGet.verified.txt
@@ -1,0 +1,14 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::main()
+      Locals:
+        foo* V_0
+      IL_0000: ldloc V_0
+      IL_0004: ldfld System.Int32 foo::x
+      IL_0009: ret
+
+  Type: foo
+  Fields:
+    System.Int32 foo::x
+       Init with: []

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithPointerMemberAccessSet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithPointerMemberAccessSet.verified.txt
@@ -1,0 +1,16 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::main()
+      Locals:
+        foo* V_0
+      IL_0000: ldloc V_0
+      IL_0004: ldc.i4 42
+      IL_0009: stfld System.Int32 foo::x
+      IL_000e: ldc.i4 0
+      IL_0013: ret
+
+  Type: foo
+  Fields:
+    System.Int32 foo::x
+       Init with: []

--- a/Cesium.CodeGen/Extensions/ExpressionEx.cs
+++ b/Cesium.CodeGen/Extensions/ExpressionEx.cs
@@ -7,7 +7,8 @@ internal static class ExpressionEx
 {
     public static IExpression ToIntermediate(this Ast.Expression ex) => ex switch
     {
-        Ast.ConstantExpression { Constant.Kind: CTokenType.Identifier } e => new IdentifierConstantExpression(e),
+        Ast.IdentifierExpression e => new IdentifierExpression(e),
+        Ast.ConstantExpression { Constant.Kind: CTokenType.Identifier } e => new IdentifierExpression(e),
         Ast.ConstantExpression e => new ConstantExpression(e),
 
         Ast.FunctionCallExpression e => new FunctionCallExpression(e),
@@ -22,6 +23,7 @@ internal static class ExpressionEx
         Ast.BinaryOperatorExpression e => new BinaryOperatorExpression(e),
 
         Ast.SubscriptingExpression e => new SubscriptingExpression(e),
+        Ast.PointerMemberAccessExpression e => new PointerMemberAccessExpression(e),
 
         _ => throw new NotImplementedException($"Expression not supported, yet: {ex}."),
     };

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -6,10 +6,10 @@ namespace Cesium.CodeGen.Ir.Expressions;
 
 internal class FunctionCallExpression : IExpression
 {
-    private readonly IdentifierConstantExpression _function;
+    private readonly IdentifierExpression _function;
     private readonly IList<IExpression> _arguments;
 
-    private FunctionCallExpression(IdentifierConstantExpression function, IList<IExpression> arguments)
+    private FunctionCallExpression(IdentifierExpression function, IList<IExpression> arguments)
     {
         _function = function;
         _arguments = arguments;
@@ -19,7 +19,7 @@ internal class FunctionCallExpression : IExpression
     {
         var (function, arguments) = expression;
         var functionExpression = function.ToIntermediate();
-        _function = functionExpression as IdentifierConstantExpression
+        _function = functionExpression as IdentifierExpression
                     ?? throw new NotImplementedException(
                         $"Non-constant expressions as function name aren't supported, yet: {functionExpression}.");
         _arguments = (IList<IExpression>?)arguments?.Select(e => e.ToIntermediate()).ToList()
@@ -27,7 +27,7 @@ internal class FunctionCallExpression : IExpression
     }
 
     public IExpression Lower() => new FunctionCallExpression(
-        (IdentifierConstantExpression)_function.Lower(),
+        (IdentifierExpression)_function.Lower(),
         _arguments.Select(a => a.Lower()).ToList());
 
     public void EmitTo(IDeclarationScope scope)

--- a/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
@@ -4,17 +4,22 @@ using Yoakke.SynKit.C.Syntax;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class IdentifierConstantExpression : IExpression, ILValueExpression
+internal class IdentifierExpression : IExpression, ILValueExpression
 {
     public string Identifier { get; }
 
-    public IdentifierConstantExpression(Ast.ConstantExpression expression)
+    public IdentifierExpression(Ast.ConstantExpression expression)
     {
         var constant = expression.Constant;
         if (expression.Constant.Kind != CTokenType.Identifier)
             throw new NotSupportedException($"Constant kind not supported: {expression.Constant.Kind}.");
 
         Identifier = constant.Text;
+    }
+
+    public IdentifierExpression(Ast.IdentifierExpression expression)
+    {
+        Identifier = expression.Identifier;
     }
 
     public IExpression Lower() => this;

--- a/Cesium.CodeGen/Ir/Expressions/LValues/ILValue.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/ILValue.cs
@@ -6,6 +6,7 @@ namespace Cesium.CodeGen.Ir.Expressions.LValues;
 internal interface ILValue
 {
     void EmitGetValue(IDeclarationScope scope);
+    void EmitGetAddress(IDeclarationScope scope);
     void EmitSetValue(IDeclarationScope scope, IExpression value);
     TypeReference GetValueType();
 }

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueArrayElement.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueArrayElement.cs
@@ -26,7 +26,7 @@ internal class LValueArrayElement : ILValue
 
     public void EmitGetAddress(IDeclarationScope scope)
     {
-        // TODO Implement '&' operator for array elements
+        // TODO[#133]: Implement '&' operator for array elements
         throw new NotImplementedException("Unary operator '&' is not supported for array elements");
     }
 

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueArrayElement.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueArrayElement.cs
@@ -24,6 +24,12 @@ internal class LValueArrayElement : ILValue
         scope.Method.Body.GetILProcessor().Emit(loadOp);
     }
 
+    public void EmitGetAddress(IDeclarationScope scope)
+    {
+        // TODO Implement '&' operator for array elements
+        throw new NotImplementedException("Unary operator '&' is not supported for array elements");
+    }
+
     public void EmitSetValue(IDeclarationScope scope, IExpression value)
     {
         EmitPointerMoveToElement(scope);

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueField.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueField.cs
@@ -1,0 +1,38 @@
+using Cesium.CodeGen.Contexts;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Cesium.CodeGen.Ir.Expressions.LValues;
+
+internal class LValueField : ILValue
+{
+    private readonly ILValue _lvalue;
+    private readonly FieldReference _field;
+
+    public LValueField(ILValue lvalue, FieldReference field)
+    {
+        _lvalue = lvalue;
+        _field = field;
+    }
+
+    public void EmitGetValue(IDeclarationScope scope)
+    {
+        _lvalue.EmitGetValue(scope);
+        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldfld, _field));
+    }
+
+    public void EmitGetAddress(IDeclarationScope scope)
+    {
+        _lvalue.EmitGetValue(scope);
+        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldflda, _field));
+    }
+
+    public void EmitSetValue(IDeclarationScope scope, IExpression value)
+    {
+        _lvalue.EmitGetValue(scope);
+        value.EmitTo(scope);
+        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Stfld, _field));
+    }
+
+    public TypeReference GetValueType() => _field.FieldType;
+}

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueLocalVariable.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueLocalVariable.cs
@@ -20,6 +20,11 @@ internal class LValueLocalVariable : ILValue
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldloc, _definition));
     }
 
+    public void EmitGetAddress(IDeclarationScope scope)
+    {
+        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldloca, _definition));
+    }
+
     public void EmitSetValue(IDeclarationScope scope, IExpression value)
     {
         value.EmitTo(scope);

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueParameter.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueParameter.cs
@@ -18,6 +18,11 @@ internal class LValueParameter : ILValue
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldarg, _definition));
     }
 
+    public void EmitGetAddress(IDeclarationScope scope)
+    {
+        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldarga, _definition));
+    }
+
     public void EmitSetValue(IDeclarationScope scope, IExpression value)
     {
         value.EmitTo(scope);

--- a/Cesium.CodeGen/Ir/Expressions/PointerMemberAccessExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/PointerMemberAccessExpression.cs
@@ -1,0 +1,53 @@
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Extensions;
+using Cesium.CodeGen.Ir.Expressions.LValues;
+using Mono.Cecil;
+
+namespace Cesium.CodeGen.Ir.Expressions;
+
+internal class PointerMemberAccessExpression : IExpression, ILValueExpression
+{
+    private readonly IExpression _expression;
+    private readonly IExpression _memberIdentifier;
+
+    public PointerMemberAccessExpression(Ast.PointerMemberAccessExpression accessExpression)
+    {
+        var (expression, memberIdentifier) = accessExpression;
+        _expression = expression.ToIntermediate();
+        _memberIdentifier = memberIdentifier.ToIntermediate();
+    }
+
+    private PointerMemberAccessExpression(IExpression expression, IExpression memberIdentifier)
+    {
+        _expression = expression;
+        _memberIdentifier = memberIdentifier;
+    }
+
+    public IExpression Lower()
+        => new PointerMemberAccessExpression(_expression.Lower(), _memberIdentifier.Lower());
+
+    public void EmitTo(IDeclarationScope scope) => Resolve(scope).EmitGetValue(scope);
+
+    public ILValue Resolve(IDeclarationScope scope)
+    {
+        if (_expression is not ILValueExpression expression)
+            throw new NotSupportedException("Pointer member access supported only for lvalues");
+
+        if (_memberIdentifier is not IdentifierExpression memberIdentifier)
+            throw new NotSupportedException($"\"{_memberIdentifier}\" is not a valid identifier");
+
+        var lvalue = expression.Resolve(scope);
+        var valueType = lvalue.GetValueType();
+        var valueTypeDef = valueType.Resolve();
+
+        try
+        {
+            var field = valueTypeDef.Fields.First(f => f?.Name == memberIdentifier.Identifier);
+            return new LValueField(lvalue, new FieldReference(field.Name, field.FieldType, field.DeclaringType));
+        }
+        catch (InvalidOperationException _)
+        {
+            throw new NotSupportedException($"Unable to find field \"{memberIdentifier.Identifier}\" for type \"{valueTypeDef.Name}\"");
+        }
+    }
+}

--- a/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
@@ -29,7 +29,7 @@ internal class SubscriptingExpression : IExpression, ILValueExpression
 
     public ILValue Resolve(IDeclarationScope scope)
     {
-        if (_expression is not IdentifierConstantExpression identifier)
+        if (_expression is not IdentifierExpression identifier)
             throw new NotImplementedException("Subscription supported only for IdentifierConstantExpression");
 
         return new LValueArrayElement(identifier.Resolve(scope), _index);

--- a/Cesium.CodeGen/Ir/Expressions/UnaryOperator.cs
+++ b/Cesium.CodeGen/Ir/Expressions/UnaryOperator.cs
@@ -4,4 +4,5 @@ public enum UnaryOperator
 {
     Negation, // -
     BitwiseNot, // ~
+    AddressOf, // &
 }

--- a/Cesium.CodeGen/Ir/Expressions/UnaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/UnaryOperatorExpression.cs
@@ -41,7 +41,6 @@ internal class UnaryOperatorExpression : IExpression
         {
             UnaryOperator.Negation => Instruction.Create(OpCodes.Neg),
             UnaryOperator.BitwiseNot => Instruction.Create(OpCodes.Not),
-            UnaryOperator.AddressOf => Instruction.Create(OpCodes.Neg),
             _ => throw new NotSupportedException($"Unsupported unary operator: {_operator}.")
         };
 

--- a/Cesium.IntegrationTests/structs.c
+++ b/Cesium.IntegrationTests/structs.c
@@ -1,0 +1,15 @@
+typedef struct { int x; } foo;
+typedef struct { foo *x; } bar;
+
+int main(void) 
+{ 
+  foo x; 
+  bar y;
+
+  bar* z = &y;
+  z->x = &x;
+  z->x->x = 42;
+
+  foo* o = &x;
+  return o->x;
+}

--- a/Cesium.Parser.Tests/ParserTests/FullParserTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/FullParserTests.cs
@@ -91,6 +91,9 @@ int main()
     public Task NegationTest() => DoTest("void foo() { int x = -42; }");
 
     [Fact]
+    public Task AddressOfTest() => DoTest("void foo() { int x; int *y = &x; }");
+
+    [Fact]
     public Task IntParameter() => DoTest("void foo(int x){}");
 
     [Fact]
@@ -128,4 +131,12 @@ int main()
     [Fact]
     public Task TypeDefStructUsage() => DoTest(@"typedef struct { int x; } foo;
 int main(void) { foo x; return 0; }");
+
+    [Fact]
+    public Task StructUsageWithPointerMemberAccessGet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo *x; return x->x; }");
+
+    [Fact]
+    public Task StructUsageWithPointerMemberAccessSet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo *x; x->x = 42; return 0; }");
 }

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.AddressOfTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.AddressOfTest.verified.txt
@@ -1,0 +1,98 @@
+﻿{
+  "$type": "Cesium.Ast.TranslationUnit, Cesium.Ast",
+  "Declarations": [
+    {
+      "$type": "Cesium.Ast.FunctionDefinition, Cesium.Ast",
+      "Specifiers": [
+        {
+          "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+          "TypeName": "void"
+        }
+      ],
+      "Declarator": {
+        "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+        "Pointer": null,
+        "DirectDeclarator": {
+          "$type": "Cesium.Ast.IdentifierListDirectDeclarator, Cesium.Ast",
+          "Base": {
+            "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+            "Identifier": "foo",
+            "Base": null
+          },
+          "Identifiers": null
+        }
+      },
+      "Declarations": null,
+      "Statement": {
+        "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",
+        "Block": [
+          {
+            "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+            "Specifiers": [
+              {
+                "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                "TypeName": "int"
+              }
+            ],
+            "InitDeclarators": [
+              {
+                "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+                "Declarator": {
+                  "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                  "Pointer": null,
+                  "DirectDeclarator": {
+                    "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                    "Identifier": "x",
+                    "Base": null
+                  }
+                },
+                "Initializer": null
+              }
+            ]
+          },
+          {
+            "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+            "Specifiers": [
+              {
+                "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                "TypeName": "int"
+              }
+            ],
+            "InitDeclarators": [
+              {
+                "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+                "Declarator": {
+                  "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                  "Pointer": {
+                    "$type": "Cesium.Ast.Pointer, Cesium.Ast",
+                    "TypeQualifiers": null,
+                    "ChildPointer": null
+                  },
+                  "DirectDeclarator": {
+                    "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                    "Identifier": "y",
+                    "Base": null
+                  }
+                },
+                "Initializer": {
+                  "$type": "Cesium.Ast.AssignmentInitializer, Cesium.Ast",
+                  "Expression": {
+                    "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
+                    "Operator": "&",
+                    "Target": {
+                      "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                      "Constant": {
+                        "Kind": "Identifier",
+                        "Text": "x"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithPointerMemberAccessGet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithPointerMemberAccessGet.verified.txt
@@ -1,0 +1,151 @@
+﻿{
+  "$type": "Cesium.Ast.TranslationUnit, Cesium.Ast",
+  "Declarations": [
+    {
+      "$type": "Cesium.Ast.SymbolDeclaration, Cesium.Ast",
+      "Declaration": {
+        "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+        "Specifiers": [
+          {
+            "$type": "Cesium.Ast.StorageClassSpecifier, Cesium.Ast",
+            "Name": "typedef"
+          },
+          {
+            "$type": "Cesium.Ast.StructOrUnionSpecifier, Cesium.Ast",
+            "TypeKind": "Struct",
+            "Identifier": null,
+            "StructDeclarations": [
+              {
+                "$type": "Cesium.Ast.StructDeclaration, Cesium.Ast",
+                "SpecifiersQualifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "int"
+                  }
+                ],
+                "Declarators": [
+                  {
+                    "$type": "Cesium.Ast.StructDeclarator, Cesium.Ast",
+                    "Declarator": {
+                      "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                      "Pointer": null,
+                      "DirectDeclarator": {
+                        "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                        "Identifier": "x",
+                        "Base": null
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "InitDeclarators": [
+          {
+            "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+            "Declarator": {
+              "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+              "Pointer": null,
+              "DirectDeclarator": {
+                "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                "Identifier": "foo",
+                "Base": null
+              }
+            },
+            "Initializer": null
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Cesium.Ast.FunctionDefinition, Cesium.Ast",
+      "Specifiers": [
+        {
+          "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+          "TypeName": "int"
+        }
+      ],
+      "Declarator": {
+        "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+        "Pointer": null,
+        "DirectDeclarator": {
+          "$type": "Cesium.Ast.ParameterListDirectDeclarator, Cesium.Ast",
+          "Base": {
+            "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+            "Identifier": "main",
+            "Base": null
+          },
+          "Parameters": {
+            "$type": "Cesium.Ast.ParameterTypeList, Cesium.Ast",
+            "Parameters": [
+              {
+                "$type": "Cesium.Ast.ParameterDeclaration, Cesium.Ast",
+                "Specifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "void"
+                  }
+                ],
+                "Declarator": null,
+                "AbstractDeclarator": null
+              }
+            ],
+            "HasEllipsis": false
+          }
+        }
+      },
+      "Declarations": null,
+      "Statement": {
+        "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",
+        "Block": [
+          {
+            "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+            "Specifiers": [
+              {
+                "$type": "Cesium.Ast.NamedTypeSpecifier, Cesium.Ast",
+                "TypeDefName": "foo"
+              }
+            ],
+            "InitDeclarators": [
+              {
+                "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+                "Declarator": {
+                  "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                  "Pointer": {
+                    "$type": "Cesium.Ast.Pointer, Cesium.Ast",
+                    "TypeQualifiers": null,
+                    "ChildPointer": null
+                  },
+                  "DirectDeclarator": {
+                    "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                    "Identifier": "x",
+                    "Base": null
+                  }
+                },
+                "Initializer": null
+              }
+            ]
+          },
+          {
+            "$type": "Cesium.Ast.ReturnStatement, Cesium.Ast",
+            "Expression": {
+              "$type": "Cesium.Ast.PointerMemberAccessExpression, Cesium.Ast",
+              "Function": {
+                "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                "Constant": {
+                  "Kind": "Identifier",
+                  "Text": "x"
+                }
+              },
+              "Identifier": {
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "x"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithPointerMemberAccessSet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithPointerMemberAccessSet.verified.txt
@@ -1,0 +1,172 @@
+﻿{
+  "$type": "Cesium.Ast.TranslationUnit, Cesium.Ast",
+  "Declarations": [
+    {
+      "$type": "Cesium.Ast.SymbolDeclaration, Cesium.Ast",
+      "Declaration": {
+        "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+        "Specifiers": [
+          {
+            "$type": "Cesium.Ast.StorageClassSpecifier, Cesium.Ast",
+            "Name": "typedef"
+          },
+          {
+            "$type": "Cesium.Ast.StructOrUnionSpecifier, Cesium.Ast",
+            "TypeKind": "Struct",
+            "Identifier": null,
+            "StructDeclarations": [
+              {
+                "$type": "Cesium.Ast.StructDeclaration, Cesium.Ast",
+                "SpecifiersQualifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "int"
+                  }
+                ],
+                "Declarators": [
+                  {
+                    "$type": "Cesium.Ast.StructDeclarator, Cesium.Ast",
+                    "Declarator": {
+                      "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                      "Pointer": null,
+                      "DirectDeclarator": {
+                        "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                        "Identifier": "x",
+                        "Base": null
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "InitDeclarators": [
+          {
+            "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+            "Declarator": {
+              "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+              "Pointer": null,
+              "DirectDeclarator": {
+                "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                "Identifier": "foo",
+                "Base": null
+              }
+            },
+            "Initializer": null
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Cesium.Ast.FunctionDefinition, Cesium.Ast",
+      "Specifiers": [
+        {
+          "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+          "TypeName": "int"
+        }
+      ],
+      "Declarator": {
+        "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+        "Pointer": null,
+        "DirectDeclarator": {
+          "$type": "Cesium.Ast.ParameterListDirectDeclarator, Cesium.Ast",
+          "Base": {
+            "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+            "Identifier": "main",
+            "Base": null
+          },
+          "Parameters": {
+            "$type": "Cesium.Ast.ParameterTypeList, Cesium.Ast",
+            "Parameters": [
+              {
+                "$type": "Cesium.Ast.ParameterDeclaration, Cesium.Ast",
+                "Specifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "void"
+                  }
+                ],
+                "Declarator": null,
+                "AbstractDeclarator": null
+              }
+            ],
+            "HasEllipsis": false
+          }
+        }
+      },
+      "Declarations": null,
+      "Statement": {
+        "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",
+        "Block": [
+          {
+            "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+            "Specifiers": [
+              {
+                "$type": "Cesium.Ast.NamedTypeSpecifier, Cesium.Ast",
+                "TypeDefName": "foo"
+              }
+            ],
+            "InitDeclarators": [
+              {
+                "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+                "Declarator": {
+                  "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                  "Pointer": {
+                    "$type": "Cesium.Ast.Pointer, Cesium.Ast",
+                    "TypeQualifiers": null,
+                    "ChildPointer": null
+                  },
+                  "DirectDeclarator": {
+                    "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                    "Identifier": "x",
+                    "Base": null
+                  }
+                },
+                "Initializer": null
+              }
+            ]
+          },
+          {
+            "$type": "Cesium.Ast.ExpressionStatement, Cesium.Ast",
+            "Expression": {
+              "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
+              "Left": {
+                "$type": "Cesium.Ast.PointerMemberAccessExpression, Cesium.Ast",
+                "Function": {
+                  "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                  "Constant": {
+                    "Kind": "Identifier",
+                    "Text": "x"
+                  }
+                },
+                "Identifier": {
+                  "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                  "Identifier": "x"
+                }
+              },
+              "Operator": "=",
+              "Right": {
+                "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                "Constant": {
+                  "Kind": "IntLiteral",
+                  "Text": "42"
+                }
+              }
+            }
+          },
+          {
+            "$type": "Cesium.Ast.ReturnStatement, Cesium.Ast",
+            "Expression": {
+              "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+              "Constant": {
+                "Kind": "IntLiteral",
+                "Text": "0"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Cesium.Parser/CParser.cs
+++ b/Cesium.Parser/CParser.cs
@@ -86,6 +86,12 @@ public partial class CParser
         ArgumentExpressionList? arguments,
         IToken __) => new FunctionCallExpression(function, arguments);
 
+    [Rule("postfix_expression: postfix_expression '->' Identifier")]
+    private static Expression MakePointerMemberAccessExpression(
+        Expression function,
+        IToken _,
+        IToken identifier) => new PointerMemberAccessExpression(function, new IdentifierExpression(identifier.Text));
+
     // TODO:
     // postfix-expression:
     //     postfix-expression . identifier
@@ -125,8 +131,8 @@ public partial class CParser
     //    & * + - !
     [Rule("unary_operator: '-'")]
     [Rule("unary_operator: '~'")]
+    [Rule("unary_operator: '&'")]
     // TODO: [Rule("unary_operator: '!'")]
-    // TODO: [Rule("unary_operator: '&'")]
     // TODO: [Rule("unary_operator: '*'")]
     private static ICToken MakeUnaryOperator(ICToken @operator) => @operator;
 

--- a/Cesium.Parser/CParser.cs
+++ b/Cesium.Parser/CParser.cs
@@ -86,6 +86,10 @@ public partial class CParser
         ArgumentExpressionList? arguments,
         IToken __) => new FunctionCallExpression(function, arguments);
 
+    // TODO:
+    // postfix-expression:
+    //     postfix-expression . identifier
+
     [Rule("postfix_expression: postfix_expression '->' Identifier")]
     private static Expression MakePointerMemberAccessExpression(
         Expression function,
@@ -94,8 +98,6 @@ public partial class CParser
 
     // TODO:
     // postfix-expression:
-    //     postfix-expression . identifier
-    //     postfix-expression -> identifier
     //     postfix-expression ++
     //     postfix-expression -
     //     ( type-name ) { initializer-list }
@@ -131,8 +133,8 @@ public partial class CParser
     //    & * + - !
     [Rule("unary_operator: '-'")]
     [Rule("unary_operator: '~'")]
-    [Rule("unary_operator: '&'")]
     // TODO: [Rule("unary_operator: '!'")]
+    [Rule("unary_operator: '&'")]
     // TODO: [Rule("unary_operator: '*'")]
     private static ICToken MakeUnaryOperator(ICToken @operator) => @operator;
 

--- a/Cesium.Samples/structs.c
+++ b/Cesium.Samples/structs.c
@@ -1,0 +1,10 @@
+typedef struct { int x; } foo;
+
+int main(void) 
+{ 
+  foo y; 
+  foo *z; 
+  z = &y; 
+  z->x = 42; 
+  return z->x; 
+}


### PR DESCRIPTION
Short example:
```c
typedef struct { int x; } foo;

int main(void) 
{ 
  foo y; 
  foo *z; 
  z = &y; 
  z->x = 42; 
  return z->x; 
}
```

TODO:
- [x] Modify parser to support `->` operator
- [x] Modify parser to support `&` operator
- [x] Make codegen for getting addess of lvalues
- [x] Make codegen for pointer member access operator
- [x] Tests, tests, tests
- [x] Samples