### PR TITLE
Help enum values

### DIFF
--- a/Cesium.Compiler/Main.cs
+++ b/Cesium.Compiler/Main.cs
@@ -1,7 +1,8 @@
-﻿using System.Reflection;
+using System.Reflection;
 using Cesium.CodeGen;
 using Cesium.Compiler;
 using CommandLine;
+using CommandLine.Text;
 
 var parserResult = new Parser(x => x.HelpWriter = null).ParseArguments<Arguments>(args);
 
@@ -35,10 +36,10 @@ return await parserResult.MapResult(async args =>
 
 static void DisplayHelp<T>(ParserResult<T> result)
 {
-    var helpText = CommandLine.Text.HelpText.AutoBuild(result, h =>
+    var helpText = HelpText.AutoBuild(result, h =>
     {
         h.AddEnumValuesToHelpText = true;
-        return h;
+        return HelpText.DefaultParsingErrorsHandler(result, h);
     }, e => e);
     Console.WriteLine(helpText);
 }

--- a/Cesium.Compiler/Main.cs
+++ b/Cesium.Compiler/Main.cs
@@ -39,6 +39,6 @@ static void DisplayHelp<T>(ParserResult<T> result)
     {
         h.AddEnumValuesToHelpText = true;
         return h;
-    }, e => e, verbsIndex: true);
+    }, e => e);
     Console.WriteLine(helpText);
 }

--- a/Cesium.Compiler/Main.cs
+++ b/Cesium.Compiler/Main.cs
@@ -3,7 +3,9 @@ using Cesium.CodeGen;
 using Cesium.Compiler;
 using CommandLine;
 
-return await Parser.Default.ParseArguments<Arguments>(args).MapResult(async args =>
+var parserResult = new Parser(x => x.HelpWriter = null).ParseArguments<Arguments>(args);
+
+return await parserResult.MapResult(async args =>
     {
         if (!args.NoLogo)
         {
@@ -25,4 +27,18 @@ return await Parser.Default.ParseArguments<Arguments>(args).MapResult(async args
 
         return await Compilation.Compile(args.InputFilePaths, args.OutputFilePath, targetRuntime);
     },
-    _ => Task.FromResult(-1));
+    _ =>
+    {
+        DisplayHelp(parserResult);
+        return Task.FromResult(-1);
+    });
+
+static void DisplayHelp<T>(ParserResult<T> result)
+{
+    var helpText = CommandLine.Text.HelpText.AutoBuild(result, h =>
+    {
+        h.AddEnumValuesToHelpText = true;
+        return h;
+    }, e => e, verbsIndex: true);
+    Console.WriteLine(helpText);
+}


### PR DESCRIPTION
In current implementation available values for enum type arguments do not show in help

```
Cesium.Compiler 0.0.0
Copyright (C) 2022 Cesium.Compiler
    -o, --out       Required.
    --framework     (Default: Net)
    --nologo        Suppress compiler banner message
...
```

changed to

```
Cesium.Compiler 0.0.0
Copyright (C) 2022 Cesium.Compiler
    -o, --out       Required.
    --framework     (Default: Net)  Valid values: Net, NetFramework, NetStandard
    --nologo        Suppress compiler banner message
...
