### PR TITLE
Track type information for IR expressions

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
@@ -68,6 +68,14 @@ int main(void) { foo *x; return x->x; }");
 int main(void) { foo *x; x->x = 42; return 0; }");
 
     [Fact]
+    public Task StructAddressWithPointerMemberAccessGet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo x; return (&x)->x; }");
+
+    [Fact]
+    public Task StructAddressWithPointerMemberAccessSet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo x; (&x)->x = 42; return 0; }");
+
+    [Fact]
     public Task ArrayDeclaration() => DoTest(@"int main()
 {
     int i;

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessGet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessGet.verified.txt
@@ -1,0 +1,15 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::main()
+      Locals:
+        foo V_0
+      IL_0000: ldloca V_0
+      IL_0004: conv.u
+      IL_0005: ldfld System.Int32 foo::x
+      IL_000a: ret
+
+  Type: foo
+  Fields:
+    System.Int32 foo::x
+       Init with: []

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessSet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessSet.verified.txt
@@ -1,0 +1,17 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::main()
+      Locals:
+        foo V_0
+      IL_0000: ldloca V_0
+      IL_0004: conv.u
+      IL_0005: ldc.i4 42
+      IL_000a: stfld System.Int32 foo::x
+      IL_000f: ldc.i4 0
+      IL_0014: ret
+
+  Type: foo
+  Fields:
+    System.Int32 foo::x
+       Init with: []

--- a/Cesium.CodeGen/Ir/Expressions/AssignmentExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/AssignmentExpression.cs
@@ -1,4 +1,5 @@
 using Cesium.CodeGen.Contexts;
+using Mono.Cecil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
@@ -30,9 +31,6 @@ internal class AssignmentExpression : BinaryOperatorExpression
         _ => throw new NotImplementedException($"Assignment operator not supported, yet: {Operator}.")
     };
 
-    private AssignmentExpression LowerSmthAndAssign(BinaryOperator @operator)
-        => new(Left, BinaryOperator.Assign, new BinaryOperatorExpression(Left, @operator, Right.Lower()));
-
     public override void EmitTo(IDeclarationScope scope)
     {
         if (Operator != BinaryOperator.Assign)
@@ -40,4 +38,11 @@ internal class AssignmentExpression : BinaryOperatorExpression
 
         _target.Resolve(scope).EmitSetValue(scope, Right);
     }
+
+    // `x = v` expression returns type of x (and v)
+    // e.g `int x; int y; x = (y = 10);`
+    public override TypeReference GetExpressionType(IDeclarationScope scope) => _target.Resolve(scope).GetValueType();
+
+    private AssignmentExpression LowerSmthAndAssign(BinaryOperator @operator)
+        => new(Left, BinaryOperator.Assign, new BinaryOperatorExpression(Left, @operator, Right.Lower()));
 }

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperatorExpression.cs
@@ -66,7 +66,7 @@ internal class BinaryOperatorExpression : IExpression
         };
     }
 
-    // TODO[139]: Implement conversions and types tracking for arithmetic operations
+    // TODO[136]: Implement conversions and types tracking for arithmetic operations
     public virtual TypeReference GetExpressionType(IDeclarationScope scope) => throw new NotImplementedException();
 
     private static BinaryOperator GetOperatorKind(string @operator) => @operator switch

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperatorExpression.cs
@@ -1,6 +1,7 @@
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Extensions;
 using Cesium.CodeGen.Ir.Expressions.Constants;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
@@ -64,6 +65,9 @@ internal class BinaryOperatorExpression : IExpression
             _ => throw new NotSupportedException($"Unsupported binary operator: {Operator}.")
         };
     }
+
+    // TODO[139]: Implement conversions and types tracking for arithmetic operations
+    public virtual TypeReference GetExpressionType(IDeclarationScope scope) => throw new NotImplementedException();
 
     private static BinaryOperator GetOperatorKind(string @operator) => @operator switch
     {

--- a/Cesium.CodeGen/Ir/Expressions/ConstantExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/ConstantExpression.cs
@@ -1,5 +1,6 @@
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Ir.Expressions.Constants;
+using Mono.Cecil;
 using Yoakke.SynKit.C.Syntax;
 
 namespace Cesium.CodeGen.Ir.Expressions;
@@ -20,6 +21,8 @@ internal class ConstantExpression : IExpression
     public IExpression Lower() => this;
 
     public void EmitTo(IDeclarationScope scope) => _constant.EmitTo(scope);
+
+    public TypeReference GetExpressionType(IDeclarationScope scope) => _constant.GetConstantType(scope);
 
     public override string ToString() => $"{nameof(ConstantExpression)}: {_constant}";
 

--- a/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
@@ -1,4 +1,5 @@
 using Cesium.CodeGen.Contexts;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Constants;
@@ -18,6 +19,8 @@ internal class CharConstant : IConstant
         instructions.Add(Instruction.Create(OpCodes.Ldc_I4, (int)_value));
         instructions.Add(Instruction.Create(OpCodes.Conv_U1));
     }
+
+    public TypeReference GetConstantType(IDeclarationScope scope) => scope.TypeSystem.Char;
 
     public override string ToString() => $"char: {_value}";
 

--- a/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
@@ -20,7 +20,7 @@ internal class CharConstant : IConstant
         instructions.Add(Instruction.Create(OpCodes.Conv_U1));
     }
 
-    public TypeReference GetConstantType(IDeclarationScope scope) => scope.TypeSystem.Char;
+    public TypeReference GetConstantType(IDeclarationScope scope) => scope.TypeSystem.Byte;
 
     public override string ToString() => $"char: {_value}";
 

--- a/Cesium.CodeGen/Ir/Expressions/Constants/IConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/IConstant.cs
@@ -1,8 +1,11 @@
 using Cesium.CodeGen.Contexts;
+using Mono.Cecil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Constants;
 
 internal interface IConstant
 {
     void EmitTo(IDeclarationScope scope);
+
+    TypeReference GetConstantType(IDeclarationScope scope);
 }

--- a/Cesium.CodeGen/Ir/Expressions/Constants/IntegerConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/IntegerConstant.cs
@@ -1,4 +1,5 @@
 using Cesium.CodeGen.Contexts;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Constants;
@@ -18,6 +19,8 @@ internal class IntegerConstant : IConstant
         // TODO[#92]: Optimizations like Ldc_I4_0 for selected constants
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldc_I4, _value));
     }
+
+    public TypeReference GetConstantType(IDeclarationScope scope) => scope.TypeSystem.Int32;
 
     public override string ToString() => $"integer: {_value}";
 }

--- a/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
@@ -24,5 +24,5 @@ internal class StringConstant : IConstant
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldsflda, fieldReference));
     }
 
-    public TypeReference GetConstantType(IDeclarationScope scope) => scope.TypeSystem.Char.MakePointerType(); // char*
+    public TypeReference GetConstantType(IDeclarationScope scope) => scope.TypeSystem.Byte.MakePointerType(); // char*
 }

--- a/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
@@ -1,5 +1,6 @@
 using Cesium.CodeGen.Contexts;
 using Cesium.Parser;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Yoakke.SynKit.C.Syntax;
 using Yoakke.SynKit.Lexer;
@@ -21,4 +22,7 @@ internal class StringConstant : IConstant
         var fieldReference = scope.AssemblyContext.GetConstantPoolReference(_value);
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldsflda, fieldReference));
     }
+
+    // TODO: String? Not a char* or something?
+    public TypeReference GetConstantType(IDeclarationScope scope) => scope.TypeSystem.String;
 }

--- a/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
@@ -2,6 +2,7 @@ using Cesium.CodeGen.Contexts;
 using Cesium.Parser;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 using Yoakke.SynKit.C.Syntax;
 using Yoakke.SynKit.Lexer;
 
@@ -23,6 +24,5 @@ internal class StringConstant : IConstant
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldsflda, fieldReference));
     }
 
-    // TODO: String? Not a char* or something?
-    public TypeReference GetConstantType(IDeclarationScope scope) => scope.TypeSystem.String;
+    public TypeReference GetConstantType(IDeclarationScope scope) => scope.TypeSystem.Char.MakePointerType(); // char*
 }

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -1,5 +1,6 @@
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Extensions;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
@@ -40,5 +41,13 @@ internal class FunctionCallExpression : IExpression
                      ?? throw new NotSupportedException($"Function \"{functionName}\" was not found.");
 
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Call, callee.MethodReference));
+    }
+
+    public TypeReference GetExpressionType(IDeclarationScope scope)
+    {
+        var functionName = _function.Identifier;
+        var callee = scope.Functions.GetValueOrDefault(functionName)
+                     ?? throw new NotSupportedException($"Function \"{functionName}\" was not found.");
+        return callee.ReturnType.Resolve(scope.Context);
     }
 }

--- a/Cesium.CodeGen/Ir/Expressions/IExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IExpression.cs
@@ -1,4 +1,5 @@
 using Cesium.CodeGen.Contexts;
+using Mono.Cecil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
@@ -6,4 +7,5 @@ internal interface IExpression
 {
     IExpression Lower();
     void EmitTo(IDeclarationScope scope);
+    TypeReference GetExpressionType(IDeclarationScope scope);
 }

--- a/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
@@ -1,5 +1,6 @@
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Ir.Expressions.LValues;
+using Mono.Cecil;
 using Yoakke.SynKit.C.Syntax;
 
 namespace Cesium.CodeGen.Ir.Expressions;
@@ -24,6 +25,10 @@ internal class IdentifierExpression : IExpression, ILValueExpression
 
     public IExpression Lower() => this;
 
+    public void EmitTo(IDeclarationScope scope) => Resolve(scope).EmitGetValue(scope);
+
+    public TypeReference GetExpressionType(IDeclarationScope scope) => Resolve(scope).GetValueType();
+
     public ILValue Resolve(IDeclarationScope scope)
     {
         scope.Variables.TryGetValue(Identifier, out var var);
@@ -42,6 +47,4 @@ internal class IdentifierExpression : IExpression, ILValueExpression
                     $"Variable {Identifier} is both available as a local and as a function parameter.");
         }
     }
-
-    public void EmitTo(IDeclarationScope scope) => Resolve(scope).EmitGetValue(scope);
 }

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueField.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueField.cs
@@ -6,30 +6,30 @@ namespace Cesium.CodeGen.Ir.Expressions.LValues;
 
 internal class LValueField : ILValue
 {
-    private readonly ILValue _lvalue;
+    private readonly IExpression _expression;
     private readonly FieldReference _field;
 
-    public LValueField(ILValue lvalue, FieldReference field)
+    public LValueField(IExpression expression, FieldReference field)
     {
-        _lvalue = lvalue;
+        _expression = expression;
         _field = field;
     }
 
     public void EmitGetValue(IDeclarationScope scope)
     {
-        _lvalue.EmitGetValue(scope);
+        _expression.EmitTo(scope);
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldfld, _field));
     }
 
     public void EmitGetAddress(IDeclarationScope scope)
     {
-        _lvalue.EmitGetValue(scope);
+        _expression.EmitTo(scope);
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldflda, _field));
     }
 
     public void EmitSetValue(IDeclarationScope scope, IExpression value)
     {
-        _lvalue.EmitGetValue(scope);
+        _expression.EmitTo(scope);
         value.EmitTo(scope);
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Stfld, _field));
     }

--- a/Cesium.CodeGen/Ir/Expressions/LogicalBinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LogicalBinaryOperatorExpression.cs
@@ -1,4 +1,5 @@
 using Cesium.CodeGen.Contexts;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
@@ -30,6 +31,8 @@ internal class LogicalBinaryOperatorExpression : BinaryOperatorExpression
                 throw new NotSupportedException($"Operator {Operator} is not binary logical operator");
         }
     }
+
+    public override TypeReference GetExpressionType(IDeclarationScope scope) => scope.TypeSystem.Boolean;
 
     private void EmitLogicalAnd(IDeclarationScope scope)
     {

--- a/Cesium.CodeGen/Ir/Expressions/PrefixIncrementExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/PrefixIncrementExpression.cs
@@ -1,6 +1,7 @@
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Extensions;
 using Cesium.CodeGen.Ir.Expressions.Constants;
+using Mono.Cecil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
@@ -28,4 +29,6 @@ internal class PrefixIncrementExpression : IExpression
     }
 
     public void EmitTo(IDeclarationScope scope) => throw new NotSupportedException("Should be lowered");
+
+    public TypeReference GetExpressionType(IDeclarationScope scope) => _target.GetExpressionType(scope);
 }

--- a/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
@@ -1,6 +1,7 @@
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Extensions;
 using Cesium.CodeGen.Ir.Expressions.LValues;
+using Mono.Cecil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
@@ -26,6 +27,8 @@ internal class SubscriptingExpression : IExpression, ILValueExpression
         => new SubscriptingExpression(_expression.Lower(), _index.Lower());
 
     public void EmitTo(IDeclarationScope scope) => Resolve(scope).EmitGetValue(scope);
+
+    public TypeReference GetExpressionType(IDeclarationScope scope) => Resolve(scope).GetValueType();
 
     public ILValue Resolve(IDeclarationScope scope)
     {

--- a/Cesium.CodeGen/Ir/Expressions/UnaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/UnaryOperatorExpression.cs
@@ -1,6 +1,8 @@
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Extensions;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
@@ -53,6 +55,12 @@ internal class UnaryOperatorExpression : IExpression
             scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Conv_U));
         }
     }
+
+    public TypeReference GetExpressionType(IDeclarationScope scope) => _operator switch
+    {
+        UnaryOperator.AddressOf => _target.GetExpressionType(scope).MakePointerType(), // address-of returns T*
+        _ => _target.GetExpressionType(scope), // other operators return T
+    };
 
     private static UnaryOperator GetOperatorKind(string @operator) => @operator switch
     {

--- a/Cesium.Parser.Tests/ParserTests/FullParserTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/FullParserTests.cs
@@ -139,4 +139,12 @@ int main(void) { foo *x; return x->x; }");
     [Fact]
     public Task StructUsageWithPointerMemberAccessSet() => DoTest(@"typedef struct { int x; } foo;
 int main(void) { foo *x; x->x = 42; return 0; }");
+
+    [Fact]
+    public Task StructAddressWithPointerMemberAccessGet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo x; return (&x)->x; }");
+
+    [Fact]
+    public Task StructAddressWithPointerMemberAccessSet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo x; (&x)->x = 42; return 0; }");
 }

--- a/Cesium.Parser.Tests/ParserTests/StatementParserTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/StatementParserTests.cs
@@ -38,11 +38,11 @@ public class StatementParserTests : ParserTestBase
     [Fact]
     public Task NestedIfs() => DoTest(@"
 if (1)
-    if (2) { 
+    if (2) {
         int x = 0;
     } else {
         int y = 1;
-    } 
+    }
 ");
 
     [Fact]
@@ -92,4 +92,7 @@ if (1)
     int a[1];
     a[0] = 0;
 }");
+
+    [Fact]
+    public Task AddressOfInParens() => DoTest("(&x)->x = 42;");
 }

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessGet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessGet.verified.txt
@@ -1,0 +1,151 @@
+﻿{
+  "$type": "Cesium.Ast.TranslationUnit, Cesium.Ast",
+  "Declarations": [
+    {
+      "$type": "Cesium.Ast.SymbolDeclaration, Cesium.Ast",
+      "Declaration": {
+        "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+        "Specifiers": [
+          {
+            "$type": "Cesium.Ast.StorageClassSpecifier, Cesium.Ast",
+            "Name": "typedef"
+          },
+          {
+            "$type": "Cesium.Ast.StructOrUnionSpecifier, Cesium.Ast",
+            "TypeKind": "Struct",
+            "Identifier": null,
+            "StructDeclarations": [
+              {
+                "$type": "Cesium.Ast.StructDeclaration, Cesium.Ast",
+                "SpecifiersQualifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "int"
+                  }
+                ],
+                "Declarators": [
+                  {
+                    "$type": "Cesium.Ast.StructDeclarator, Cesium.Ast",
+                    "Declarator": {
+                      "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                      "Pointer": null,
+                      "DirectDeclarator": {
+                        "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                        "Identifier": "x",
+                        "Base": null
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "InitDeclarators": [
+          {
+            "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+            "Declarator": {
+              "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+              "Pointer": null,
+              "DirectDeclarator": {
+                "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                "Identifier": "foo",
+                "Base": null
+              }
+            },
+            "Initializer": null
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Cesium.Ast.FunctionDefinition, Cesium.Ast",
+      "Specifiers": [
+        {
+          "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+          "TypeName": "int"
+        }
+      ],
+      "Declarator": {
+        "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+        "Pointer": null,
+        "DirectDeclarator": {
+          "$type": "Cesium.Ast.ParameterListDirectDeclarator, Cesium.Ast",
+          "Base": {
+            "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+            "Identifier": "main",
+            "Base": null
+          },
+          "Parameters": {
+            "$type": "Cesium.Ast.ParameterTypeList, Cesium.Ast",
+            "Parameters": [
+              {
+                "$type": "Cesium.Ast.ParameterDeclaration, Cesium.Ast",
+                "Specifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "void"
+                  }
+                ],
+                "Declarator": null,
+                "AbstractDeclarator": null
+              }
+            ],
+            "HasEllipsis": false
+          }
+        }
+      },
+      "Declarations": null,
+      "Statement": {
+        "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",
+        "Block": [
+          {
+            "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+            "Specifiers": [
+              {
+                "$type": "Cesium.Ast.NamedTypeSpecifier, Cesium.Ast",
+                "TypeDefName": "foo"
+              }
+            ],
+            "InitDeclarators": [
+              {
+                "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+                "Declarator": {
+                  "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                  "Pointer": null,
+                  "DirectDeclarator": {
+                    "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                    "Identifier": "x",
+                    "Base": null
+                  }
+                },
+                "Initializer": null
+              }
+            ]
+          },
+          {
+            "$type": "Cesium.Ast.ReturnStatement, Cesium.Ast",
+            "Expression": {
+              "$type": "Cesium.Ast.PointerMemberAccessExpression, Cesium.Ast",
+              "Function": {
+                "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
+                "Operator": "&",
+                "Target": {
+                  "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                  "Constant": {
+                    "Kind": "Identifier",
+                    "Text": "x"
+                  }
+                }
+              },
+              "Identifier": {
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "x"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessSet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessSet.verified.txt
@@ -1,0 +1,172 @@
+﻿{
+  "$type": "Cesium.Ast.TranslationUnit, Cesium.Ast",
+  "Declarations": [
+    {
+      "$type": "Cesium.Ast.SymbolDeclaration, Cesium.Ast",
+      "Declaration": {
+        "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+        "Specifiers": [
+          {
+            "$type": "Cesium.Ast.StorageClassSpecifier, Cesium.Ast",
+            "Name": "typedef"
+          },
+          {
+            "$type": "Cesium.Ast.StructOrUnionSpecifier, Cesium.Ast",
+            "TypeKind": "Struct",
+            "Identifier": null,
+            "StructDeclarations": [
+              {
+                "$type": "Cesium.Ast.StructDeclaration, Cesium.Ast",
+                "SpecifiersQualifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "int"
+                  }
+                ],
+                "Declarators": [
+                  {
+                    "$type": "Cesium.Ast.StructDeclarator, Cesium.Ast",
+                    "Declarator": {
+                      "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                      "Pointer": null,
+                      "DirectDeclarator": {
+                        "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                        "Identifier": "x",
+                        "Base": null
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "InitDeclarators": [
+          {
+            "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+            "Declarator": {
+              "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+              "Pointer": null,
+              "DirectDeclarator": {
+                "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                "Identifier": "foo",
+                "Base": null
+              }
+            },
+            "Initializer": null
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Cesium.Ast.FunctionDefinition, Cesium.Ast",
+      "Specifiers": [
+        {
+          "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+          "TypeName": "int"
+        }
+      ],
+      "Declarator": {
+        "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+        "Pointer": null,
+        "DirectDeclarator": {
+          "$type": "Cesium.Ast.ParameterListDirectDeclarator, Cesium.Ast",
+          "Base": {
+            "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+            "Identifier": "main",
+            "Base": null
+          },
+          "Parameters": {
+            "$type": "Cesium.Ast.ParameterTypeList, Cesium.Ast",
+            "Parameters": [
+              {
+                "$type": "Cesium.Ast.ParameterDeclaration, Cesium.Ast",
+                "Specifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "void"
+                  }
+                ],
+                "Declarator": null,
+                "AbstractDeclarator": null
+              }
+            ],
+            "HasEllipsis": false
+          }
+        }
+      },
+      "Declarations": null,
+      "Statement": {
+        "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",
+        "Block": [
+          {
+            "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+            "Specifiers": [
+              {
+                "$type": "Cesium.Ast.NamedTypeSpecifier, Cesium.Ast",
+                "TypeDefName": "foo"
+              }
+            ],
+            "InitDeclarators": [
+              {
+                "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+                "Declarator": {
+                  "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                  "Pointer": null,
+                  "DirectDeclarator": {
+                    "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                    "Identifier": "x",
+                    "Base": null
+                  }
+                },
+                "Initializer": null
+              }
+            ]
+          },
+          {
+            "$type": "Cesium.Ast.ExpressionStatement, Cesium.Ast",
+            "Expression": {
+              "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
+              "Left": {
+                "$type": "Cesium.Ast.PointerMemberAccessExpression, Cesium.Ast",
+                "Function": {
+                  "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
+                  "Operator": "&",
+                  "Target": {
+                    "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                    "Constant": {
+                      "Kind": "Identifier",
+                      "Text": "x"
+                    }
+                  }
+                },
+                "Identifier": {
+                  "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                  "Identifier": "x"
+                }
+              },
+              "Operator": "=",
+              "Right": {
+                "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                "Constant": {
+                  "Kind": "IntLiteral",
+                  "Text": "42"
+                }
+              }
+            }
+          },
+          {
+            "$type": "Cesium.Ast.ReturnStatement, Cesium.Ast",
+            "Expression": {
+              "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+              "Constant": {
+                "Kind": "IntLiteral",
+                "Text": "0"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.AddressOfInParens.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.AddressOfInParens.verified.txt
@@ -1,0 +1,32 @@
+﻿{
+  "$type": "Cesium.Ast.ExpressionStatement, Cesium.Ast",
+  "Expression": {
+    "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
+    "Left": {
+      "$type": "Cesium.Ast.PointerMemberAccessExpression, Cesium.Ast",
+      "Function": {
+        "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
+        "Operator": "&",
+        "Target": {
+          "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+          "Constant": {
+            "Kind": "Identifier",
+            "Text": "x"
+          }
+        }
+      },
+      "Identifier": {
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "x"
+      }
+    },
+    "Operator": "=",
+    "Right": {
+      "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+      "Constant": {
+        "Kind": "IntLiteral",
+        "Text": "42"
+      }
+    }
+  }
+}

--- a/Cesium.Parser/CParser.cs
+++ b/Cesium.Parser/CParser.cs
@@ -73,7 +73,6 @@ public partial class CParser
 
     // TODO:
     // primary-expression:
-    //     ( expression )
     //     generic-selection
 
     // 6.5.2 Postfix operators

--- a/Cesium.Parser/CParser.cs
+++ b/Cesium.Parser/CParser.cs
@@ -68,6 +68,9 @@ public partial class CParser
     private static Expression MakeStringLiteralExpression(ICToken stringLiteral) =>
         new ConstantExpression(stringLiteral);
 
+    [Rule("primary_expression: '(' expression ')'")]
+    private static Expression MakeParens(IToken _, Expression expression, IToken __) => expression;
+
     // TODO:
     // primary-expression:
     //     ( expression )

--- a/Cesium.Samples/structs.c
+++ b/Cesium.Samples/structs.c
@@ -3,8 +3,6 @@ typedef struct { int x; } foo;
 int main(void) 
 { 
   foo y; 
-  foo *z; 
-  z = &y; 
-  z->x = 42; 
-  return z->x; 
+  (&y)->x = 42; 
+  return (&y)->x; 
 }


### PR DESCRIPTION
For now pointer member access operator (#129) works only for lvalues, but not rvalues. E.g. this sample doesn't compile:
```c
foo x;
(&x)->x = 42; // error
```
In #129 to find members by identifier we relied on `GetValueType: unit -> TypeReference` method implemented for all lvalues. I propose to extend this approach and track type information for all IR expressions:
```c
foo x;
// `x` is lvalue expression of type `foo`
// `(&x)` is rvalue expression of type `foo*`
// `(&x)->x` is lvalue expression of type `int`
(&x)->x = 42; // works!
(42)->x = 42; // error: "Int32" has no member named "x"
```

- [x] Fix parser for expressions in parentheses
- [x] Implement `GetConstantType` for constants
- [x] Implement `GetExpessionType` for address-of operator (`&`) expression
- [x] Implement `GetExpressionType` for other unary expressions
- ~Implement `GetExpessionType` for binary operator expressions~ See #136 
- [x] Implement `GetExpressionType` for other expressions
- [x] Fix pointer member access operator
- [x] Tests, tests, tests!
- [x] Add sample