### PR TITLE
Using optimized CIL instructions (ldc_i4_0 instead of ldc_i4, etc).

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
@@ -77,9 +77,9 @@ int main()
         "int main(int argc, char *argv[], ...){}",
         "Variable arguments for the main function aren't supported.");
 
-    [Fact] public Task ParameterGet() => DoTest("int foo(int x){ return x + 1; }");
-    [Fact]
-    public Task CharConstTest() => DoTest("int main() { char x = '\\t'; return 42; }");
+    [Fact] public Task Parameter1Get() => DoTest("int foo(int x){ return x + 1; }");
+    [Fact] public Task Parameter5Get() => DoTest("int foo(int a, int b, int c, int d, int e){ return e + 1; }");
+    [Fact] public Task CharConstTest() => DoTest("int main() { char x = '\\t'; return 42; }");
 
     [Fact] public Task MultiDeclaration() => DoTest("int main() { int x = 0, y = 2 + 2; }");
 

--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
@@ -58,6 +58,18 @@ int main()
 }");
 
     [Fact]
+    public Task ConstIntSmallLiteralTest() => DoTest(@"int main()
+{
+    return 42;
+}");
+
+    [Fact]
+    public Task ConstIntLargeLiteralTest() => DoTest(@"int main()
+{
+    return 1337;
+}");
+
+    [Fact]
     public Task ConstCharLiteralDeduplication() => DoTest(@"int main()
 {
     const char *test1 = ""hellow"";

--- a/Cesium.CodeGen.Tests/verified/CodeGenBreakStatementTests.BreakInFor.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenBreakStatementTests.BreakInFor.verified.txt
@@ -1,6 +1,6 @@
 ﻿System.Int32 <Module>::main()
   IL_0000: br IL_000a
-  IL_0005: br IL_0014
-  IL_000a: ldc.i4 1
-  IL_000f: brtrue IL_0005
-  IL_0014: nop
+  IL_0005: br IL_0010
+  IL_000a: ldc.i4.1
+  IL_000b: brtrue IL_0005
+  IL_0010: nop

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.ForTest_NoInit.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.ForTest_NoInit.verified.txt
@@ -1,18 +1,18 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: ldc.i4 0
-  IL_0005: stloc V_0
-  IL_0009: br IL_002a
-  IL_000e: ldloc V_0
-  IL_0012: ldc.i4 1
-  IL_0017: add
-  IL_0018: stloc V_0
-  IL_001c: ldloc V_0
-  IL_0020: ldc.i4 1
-  IL_0025: add
-  IL_0026: stloc V_0
-  IL_002a: ldloc V_0
-  IL_002e: ldc.i4 10
-  IL_0033: clt
-  IL_0035: brtrue IL_000e
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.s V_0
+  IL_0003: br IL_0012
+  IL_0008: ldloc.0
+  IL_0009: ldc.i4.1
+  IL_000a: add
+  IL_000b: stloc.s V_0
+  IL_000d: ldloc.0
+  IL_000e: ldc.i4.1
+  IL_000f: add
+  IL_0010: stloc.s V_0
+  IL_0012: ldloc.0
+  IL_0013: ldc.i4.s 10
+  IL_0015: clt
+  IL_0017: brtrue IL_0008

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_Empty.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_Empty.verified.txt
@@ -1,10 +1,10 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: br IL_0013
-  IL_0005: ldloc V_0
-  IL_0009: ldc.i4 1
-  IL_000e: add
-  IL_000f: stloc V_0
-  IL_0013: ldc.i4 1
-  IL_0018: brtrue IL_0005
+  IL_0000: br IL_000a
+  IL_0005: ldloc.0
+  IL_0006: ldc.i4.1
+  IL_0007: add
+  IL_0008: stloc.s V_0
+  IL_000a: ldc.i4.1
+  IL_000b: brtrue IL_0005

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoTest.verified.txt
@@ -1,16 +1,16 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: ldc.i4 0
-  IL_0005: stloc V_0
-  IL_0009: br IL_002a
-  IL_000e: ldloc V_0
-  IL_0012: ldc.i4 1
-  IL_0017: add
-  IL_0018: stloc V_0
-  IL_001c: ldloc V_0
-  IL_0020: ldc.i4 1
-  IL_0025: add
-  IL_0026: stloc V_0
-  IL_002a: ldc.i4 1
-  IL_002f: brtrue IL_000e
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.s V_0
+  IL_0003: br IL_0012
+  IL_0008: ldloc.0
+  IL_0009: ldc.i4.1
+  IL_000a: add
+  IL_000b: stloc.s V_0
+  IL_000d: ldloc.0
+  IL_000e: ldc.i4.1
+  IL_000f: add
+  IL_0010: stloc.s V_0
+  IL_0012: ldc.i4.1
+  IL_0013: brtrue IL_0008

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoUpdate.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoUpdate.verified.txt
@@ -1,14 +1,14 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: ldc.i4 0
-  IL_0005: stloc V_0
-  IL_0009: br IL_001c
-  IL_000e: ldloc V_0
-  IL_0012: ldc.i4 1
-  IL_0017: add
-  IL_0018: stloc V_0
-  IL_001c: ldloc V_0
-  IL_0020: ldc.i4 10
-  IL_0025: clt
-  IL_0027: brtrue IL_000e
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.s V_0
+  IL_0003: br IL_000d
+  IL_0008: ldloc.0
+  IL_0009: ldc.i4.1
+  IL_000a: add
+  IL_000b: stloc.s V_0
+  IL_000d: ldloc.0
+  IL_000e: ldc.i4.s 10
+  IL_0010: clt
+  IL_0012: brtrue IL_0008

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.SimpleFor.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.SimpleFor.verified.txt
@@ -1,18 +1,18 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: ldc.i4 0
-  IL_0005: stloc V_0
-  IL_0009: br IL_002a
-  IL_000e: ldloc V_0
-  IL_0012: ldc.i4 1
-  IL_0017: add
-  IL_0018: stloc V_0
-  IL_001c: ldloc V_0
-  IL_0020: ldc.i4 1
-  IL_0025: add
-  IL_0026: stloc V_0
-  IL_002a: ldloc V_0
-  IL_002e: ldc.i4 10
-  IL_0033: clt
-  IL_0035: brtrue IL_000e
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.s V_0
+  IL_0003: br IL_0012
+  IL_0008: ldloc.0
+  IL_0009: ldc.i4.1
+  IL_000a: add
+  IL_000b: stloc.s V_0
+  IL_000d: ldloc.0
+  IL_000e: ldc.i4.1
+  IL_000f: add
+  IL_0010: stloc.s V_0
+  IL_0012: ldloc.0
+  IL_0013: ldc.i4.s 10
+  IL_0015: clt
+  IL_0017: brtrue IL_0008

--- a/Cesium.CodeGen.Tests/verified/CodeGenIfTests.IfElseTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenIfTests.IfElseTest.verified.txt
@@ -1,10 +1,10 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 1
-  IL_0005: brfalse IL_0015
-  IL_000a: ldc.i4 0
+  IL_0000: ldc.i4.1
+  IL_0001: brfalse IL_000d
+  IL_0006: ldc.i4.0
+  IL_0007: ret
+  IL_0008: br IL_0010
+  IL_000d: nop
+  IL_000e: ldc.i4.1
   IL_000f: ret
-  IL_0010: br IL_001c
-  IL_0015: nop
-  IL_0016: ldc.i4 1
-  IL_001b: ret
-  IL_001c: nop
+  IL_0010: nop

--- a/Cesium.CodeGen.Tests/verified/CodeGenIfTests.IfImplicitElseTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenIfTests.IfImplicitElseTest.verified.txt
@@ -1,8 +1,8 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 1
-  IL_0005: brfalse IL_0010
-  IL_000a: ldc.i4 0
-  IL_000f: ret
-  IL_0010: nop
-  IL_0011: ldc.i4 1
-  IL_0016: ret
+  IL_0000: ldc.i4.1
+  IL_0001: brfalse IL_0008
+  IL_0006: ldc.i4.0
+  IL_0007: ret
+  IL_0008: nop
+  IL_0009: ldc.i4.1
+  IL_000a: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenIfTests.SimpleIfTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenIfTests.SimpleIfTest.verified.txt
@@ -1,6 +1,6 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 1
-  IL_0005: brfalse IL_0010
-  IL_000a: ldc.i4 0
-  IL_000f: ret
-  IL_0010: nop
+  IL_0000: ldc.i4.1
+  IL_0001: brfalse IL_0008
+  IL_0006: ldc.i4.0
+  IL_0007: ret
+  IL_0008: nop

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AddressOfTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AddressOfTest.verified.txt
@@ -2,6 +2,6 @@
   Locals:
     System.Int32 V_0
     System.Int32* V_1
-  IL_0000: ldloca V_0
-  IL_0004: conv.u
-  IL_0005: stloc V_1
+  IL_0000: ldloca.s V_0
+  IL_0002: conv.u
+  IL_0003: stloc.s V_1

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AmbiguousCallTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AmbiguousCallTest.verified.txt
@@ -1,6 +1,6 @@
 ﻿System.Int32 <Module>::abs(System.Int32 x)
-  IL_0000: ldarg x
-  IL_0004: ret
+  IL_0000: ldarg.0
+  IL_0001: ret
 
 System.Void <Module>::exit(System.Int32 x)
   IL_0000: ret
@@ -8,9 +8,9 @@ System.Void <Module>::exit(System.Int32 x)
 System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: ldc.i4 42
-  IL_0005: neg
-  IL_0006: call System.Int32 <Module>::abs(System.Int32)
-  IL_000b: stloc V_0
-  IL_000f: ldloc V_0
-  IL_0013: call System.Void <Module>::exit(System.Int32)
+  IL_0000: ldc.i4.s 42
+  IL_0002: neg
+  IL_0003: call System.Int32 <Module>::abs(System.Int32)
+  IL_0008: stloc.s V_0
+  IL_000a: ldloc.0
+  IL_000b: call System.Void <Module>::exit(System.Int32)

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.Arithmetic.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.Arithmetic.verified.txt
@@ -2,24 +2,24 @@
   Locals:
     System.Int32 V_0
     System.Int32 V_1
-  IL_0000: ldc.i4 42
-  IL_0005: neg
-  IL_0006: stloc V_0
-  IL_000a: ldc.i4 18
-  IL_000f: stloc V_1
-  IL_0013: ldloc V_1
-  IL_0017: ldc.i4 1
-  IL_001c: add
-  IL_001d: stloc V_1
-  IL_0021: ldloc V_1
-  IL_0025: ldc.i4 1
-  IL_002a: add
-  IL_002b: stloc V_1
-  IL_002f: ldloc V_1
-  IL_0033: ldc.i4 2
-  IL_0038: mul
-  IL_0039: stloc V_1
-  IL_003d: ldloc V_1
-  IL_0041: ldc.i4 2
-  IL_0046: add
-  IL_0047: ret
+  IL_0000: ldc.i4.s 42
+  IL_0002: neg
+  IL_0003: stloc.s V_0
+  IL_0005: ldc.i4.s 18
+  IL_0007: stloc.s V_1
+  IL_0009: ldloc.1
+  IL_000a: ldc.i4.1
+  IL_000b: add
+  IL_000c: stloc.s V_1
+  IL_000e: ldloc.1
+  IL_000f: ldc.i4.1
+  IL_0010: add
+  IL_0011: stloc.s V_1
+  IL_0013: ldloc.1
+  IL_0014: ldc.i4.2
+  IL_0015: mul
+  IL_0016: stloc.s V_1
+  IL_0018: ldloc.1
+  IL_0019: ldc.i4.2
+  IL_001a: add
+  IL_001b: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ArithmeticMainTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ArithmeticMainTest.verified.txt
@@ -1,7 +1,7 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 2
-  IL_0005: ldc.i4 2
-  IL_000a: ldc.i4 2
-  IL_000f: mul
-  IL_0010: add
-  IL_0011: ret
+  IL_0000: ldc.i4.2
+  IL_0001: ldc.i4.2
+  IL_0002: ldc.i4.2
+  IL_0003: mul
+  IL_0004: add
+  IL_0005: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ArrayAddressOf.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ArrayAddressOf.verified.txt
@@ -5,14 +5,14 @@
   IL_0000: ldc.i4 40
   IL_0005: conv.u
   IL_0006: localloc
-  IL_0008: stloc V_0
-  IL_000c: ldloc V_0
-  IL_0010: ldc.i4 2
-  IL_0015: conv.i
-  IL_0016: ldc.i4 4
-  IL_001b: mul
-  IL_001c: add
-  IL_001d: conv.u
-  IL_001e: stloc V_1
-  IL_0022: ldc.i4 0
-  IL_0027: ret
+  IL_0008: stloc.s V_0
+  IL_000a: ldloc.0
+  IL_000b: ldc.i4.2
+  IL_000c: conv.i
+  IL_000d: ldc.i4 4
+  IL_0012: mul
+  IL_0013: add
+  IL_0014: conv.u
+  IL_0015: stloc.s V_1
+  IL_0017: ldc.i4.0
+  IL_0018: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ArrayAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ArrayAssignment.verified.txt
@@ -4,20 +4,20 @@
   IL_0000: ldc.i4 40
   IL_0005: conv.u
   IL_0006: localloc
-  IL_0008: stloc V_0
-  IL_000c: ldloc V_0
-  IL_0010: ldc.i4 1
-  IL_0015: conv.i
-  IL_0016: ldc.i4 4
-  IL_001b: mul
-  IL_001c: add
-  IL_001d: ldc.i4 2
-  IL_0022: stind.i4
-  IL_0023: ldloc V_0
-  IL_0027: ldc.i4 1
-  IL_002c: conv.i
-  IL_002d: ldc.i4 4
-  IL_0032: mul
-  IL_0033: add
-  IL_0034: ldind.i4
-  IL_0035: ret
+  IL_0008: stloc.s V_0
+  IL_000a: ldloc.0
+  IL_000b: ldc.i4.1
+  IL_000c: conv.i
+  IL_000d: ldc.i4 4
+  IL_0012: mul
+  IL_0013: add
+  IL_0014: ldc.i4.2
+  IL_0015: stind.i4
+  IL_0016: ldloc.0
+  IL_0017: ldc.i4.1
+  IL_0018: conv.i
+  IL_0019: ldc.i4 4
+  IL_001e: mul
+  IL_001f: add
+  IL_0020: ldind.i4
+  IL_0021: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AssigmentLoweringTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AssigmentLoweringTest.verified.txt
@@ -1,13 +1,13 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: ldc.i4 0
-  IL_0005: stloc V_0
-  IL_0009: ldloc V_0
-  IL_000d: ldc.i4 1
-  IL_0012: add
-  IL_0013: stloc V_0
-  IL_0017: ldloc V_0
-  IL_001b: ldc.i4 1
-  IL_0020: add
-  IL_0021: ret
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.s V_0
+  IL_0003: ldloc.0
+  IL_0004: ldc.i4.1
+  IL_0005: add
+  IL_0006: stloc.s V_0
+  IL_0008: ldloc.0
+  IL_0009: ldc.i4.1
+  IL_000a: add
+  IL_000b: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.BitArithmetic.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.BitArithmetic.verified.txt
@@ -1,14 +1,14 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 1
-  IL_0005: not
-  IL_0006: ldc.i4 2
-  IL_000b: shl
-  IL_000c: ldc.i4 3
-  IL_0011: shr
-  IL_0012: ldc.i4 4
-  IL_0017: ldc.i4 5
-  IL_001c: and
-  IL_001d: ldc.i4 6
-  IL_0022: xor
-  IL_0023: or
-  IL_0024: ret
+  IL_0000: ldc.i4.1
+  IL_0001: not
+  IL_0002: ldc.i4.2
+  IL_0003: shl
+  IL_0004: ldc.i4.3
+  IL_0005: shr
+  IL_0006: ldc.i4.4
+  IL_0007: ldc.i4.5
+  IL_0008: and
+  IL_0009: ldc.i4.6
+  IL_000a: xor
+  IL_000b: or
+  IL_000c: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.BitOrAssignmentLoweringTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.BitOrAssignmentLoweringTest.verified.txt
@@ -1,11 +1,11 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: ldc.i4 0
-  IL_0005: stloc V_0
-  IL_0009: ldloc V_0
-  IL_000d: ldc.i4 1
-  IL_0012: or
-  IL_0013: stloc V_0
-  IL_0017: ldloc V_0
-  IL_001b: ret
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.s V_0
+  IL_0003: ldloc.0
+  IL_0004: ldc.i4.1
+  IL_0005: or
+  IL_0006: stloc.s V_0
+  IL_0008: ldloc.0
+  IL_0009: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.CharConstTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.CharConstTest.verified.txt
@@ -1,8 +1,8 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Byte V_0
-  IL_0000: ldc.i4 9
-  IL_0005: conv.u1
-  IL_0006: stloc V_0
-  IL_000a: ldc.i4 42
-  IL_000f: ret
+  IL_0000: ldc.i4.s 9
+  IL_0002: conv.u1
+  IL_0003: stloc.s V_0
+  IL_0005: ldc.i4.s 42
+  IL_0007: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.EqualToOperator.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.EqualToOperator.verified.txt
@@ -1,5 +1,5 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 1
-  IL_0005: ldc.i4 2
-  IL_000a: ceq
-  IL_000c: ret
+  IL_0000: ldc.i4.1
+  IL_0001: ldc.i4.2
+  IL_0002: ceq
+  IL_0004: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FunctionCallTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FunctionCallTest.verified.txt
@@ -1,6 +1,6 @@
 ﻿System.Int32 <Module>::foo()
-  IL_0000: ldc.i4 42
-  IL_0005: ret
+  IL_0000: ldc.i4.s 42
+  IL_0002: ret
 
 System.Int32 <Module>::main()
   IL_0000: call System.Int32 <Module>::foo()

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FunctionPtrTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FunctionPtrTest.verified.txt
@@ -1,5 +1,5 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     method System.Void *() V_0
-  IL_0000: ldc.i4 0
-  IL_0005: ret
+  IL_0000: ldc.i4.0
+  IL_0001: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FunctionPtrWithParamsTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FunctionPtrWithParamsTest.verified.txt
@@ -1,5 +1,5 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     method System.Int32 *(System.Int32) V_0
-  IL_0000: ldc.i4 0
-  IL_0005: ret
+  IL_0000: ldc.i4.0
+  IL_0001: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.LogicalAndOperator.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.LogicalAndOperator.verified.txt
@@ -1,11 +1,11 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 1
-  IL_0005: ldc.i4.0
-  IL_0006: beq IL_0018
-  IL_000b: ldc.i4 2
+  IL_0000: ldc.i4.1
+  IL_0001: ldc.i4.0
+  IL_0002: beq IL_0010
+  IL_0007: ldc.i4.2
+  IL_0008: ldc.i4.0
+  IL_0009: ceq
+  IL_000b: br IL_0011
   IL_0010: ldc.i4.0
-  IL_0011: ceq
-  IL_0013: br IL_0019
-  IL_0018: ldc.i4.0
-  IL_0019: nop
-  IL_001a: ret
+  IL_0011: nop
+  IL_0012: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.LogicalOrOperator.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.LogicalOrOperator.verified.txt
@@ -1,15 +1,15 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 1
-  IL_0005: ldc.i4.0
-  IL_0006: ceq
-  IL_0008: ldc.i4.1
-  IL_0009: beq IL_001e
-  IL_000e: ldc.i4 2
-  IL_0013: ldc.i4.0
-  IL_0014: ceq
+  IL_0000: ldc.i4.1
+  IL_0001: ldc.i4.0
+  IL_0002: ceq
+  IL_0004: ldc.i4.1
+  IL_0005: beq IL_0016
+  IL_000a: ldc.i4.2
+  IL_000b: ldc.i4.0
+  IL_000c: ceq
+  IL_000e: ldc.i4.1
+  IL_000f: ceq
+  IL_0011: br IL_0017
   IL_0016: ldc.i4.1
-  IL_0017: ceq
-  IL_0019: br IL_001f
-  IL_001e: ldc.i4.1
-  IL_001f: nop
-  IL_0020: ret
+  IL_0017: nop
+  IL_0018: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.MultiDeclaration.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.MultiDeclaration.verified.txt
@@ -2,9 +2,9 @@
   Locals:
     System.Int32 V_0
     System.Int32 V_1
-  IL_0000: ldc.i4 0
-  IL_0005: stloc V_0
-  IL_0009: ldc.i4 2
-  IL_000e: ldc.i4 2
-  IL_0013: add
-  IL_0014: stloc V_1
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.s V_0
+  IL_0003: ldc.i4.2
+  IL_0004: ldc.i4.2
+  IL_0005: add
+  IL_0006: stloc.s V_1

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.NegationExpressTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.NegationExpressTest.verified.txt
@@ -1,4 +1,4 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 42
-  IL_0005: neg
-  IL_0006: ret
+  IL_0000: ldc.i4.s 42
+  IL_0002: neg
+  IL_0003: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.NotEqualToOperator.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.NotEqualToOperator.verified.txt
@@ -1,7 +1,7 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 1
-  IL_0005: ldc.i4 2
-  IL_000a: ceq
-  IL_000c: ldc.i4 0
-  IL_0011: ceq
-  IL_0013: ret
+  IL_0000: ldc.i4.1
+  IL_0001: ldc.i4.2
+  IL_0002: ceq
+  IL_0004: ldc.i4.0
+  IL_0005: ceq
+  IL_0007: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.Parameter1Get.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.Parameter1Get.verified.txt
@@ -1,0 +1,5 @@
+﻿System.Int32 <Module>::foo(System.Int32 x)
+  IL_0000: ldarg.0
+  IL_0001: ldc.i4.1
+  IL_0002: add
+  IL_0003: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.Parameter5Get.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.Parameter5Get.verified.txt
@@ -1,0 +1,5 @@
+﻿System.Int32 <Module>::foo(System.Int32 a, System.Int32 b, System.Int32 c, System.Int32 d, System.Int32 e)
+  IL_0000: ldarg.s e
+  IL_0002: ldc.i4.1
+  IL_0003: add
+  IL_0004: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ParameterGet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ParameterGet.verified.txt
@@ -1,5 +1,0 @@
-﻿System.Int32 <Module>::foo(System.Int32 x)
-  IL_0000: ldarg x
-  IL_0004: ldc.i4 1
-  IL_0009: add
-  IL_000a: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.PostfixIncrementTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.PostfixIncrementTest.verified.txt
@@ -1,13 +1,13 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: ldc.i4 0
-  IL_0005: stloc V_0
-  IL_0009: ldloc V_0
-  IL_000d: ldc.i4 1
-  IL_0012: add
-  IL_0013: stloc V_0
-  IL_0017: ldloc V_0
-  IL_001b: ldc.i4 1
-  IL_0020: add
-  IL_0021: ret
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.s V_0
+  IL_0003: ldloc.0
+  IL_0004: ldc.i4.1
+  IL_0005: add
+  IL_0006: stloc.s V_0
+  IL_0008: ldloc.0
+  IL_0009: ldc.i4.1
+  IL_000a: add
+  IL_000b: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.PrimitiveTypes.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.PrimitiveTypes.verified.txt
@@ -29,5 +29,5 @@
     System.Int64 V_26
     System.Int64 V_27
     System.Double V_28
-  IL_0000: ldc.i4 0
-  IL_0005: ret
+  IL_0000: ldc.i4.0
+  IL_0001: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.RelationalOperatorsWithLowering.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.RelationalOperatorsWithLowering.verified.txt
@@ -1,11 +1,11 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 1
-  IL_0005: ldc.i4 2
-  IL_000a: clt
-  IL_000c: ldc.i4 0
-  IL_0011: ceq
-  IL_0013: ldc.i4 4
-  IL_0018: cgt
-  IL_001a: ldc.i4 0
-  IL_001f: ceq
-  IL_0021: ret
+  IL_0000: ldc.i4.1
+  IL_0001: ldc.i4.2
+  IL_0002: clt
+  IL_0004: ldc.i4.0
+  IL_0005: ceq
+  IL_0007: ldc.i4.4
+  IL_0008: cgt
+  IL_000a: ldc.i4.0
+  IL_000b: ceq
+  IL_000d: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.SimpleRelationalOperators.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.SimpleRelationalOperators.verified.txt
@@ -1,7 +1,7 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4 1
-  IL_0005: ldc.i4 2
-  IL_000a: cgt
-  IL_000c: ldc.i4 4
-  IL_0011: clt
-  IL_0013: ret
+  IL_0000: ldc.i4.1
+  IL_0001: ldc.i4.2
+  IL_0002: cgt
+  IL_0004: ldc.i4.4
+  IL_0005: clt
+  IL_0007: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.SimpleVariableTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.SimpleVariableTest.verified.txt
@@ -1,13 +1,13 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: ldc.i4 0
-  IL_0005: stloc V_0
-  IL_0009: ldloc V_0
-  IL_000d: ldc.i4 1
-  IL_0012: add
-  IL_0013: stloc V_0
-  IL_0017: ldloc V_0
-  IL_001b: ldc.i4 1
-  IL_0020: add
-  IL_0021: ret
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.s V_0
+  IL_0003: ldloc.0
+  IL_0004: ldc.i4.1
+  IL_0005: add
+  IL_0006: stloc.s V_0
+  IL_0008: ldloc.0
+  IL_0009: ldc.i4.1
+  IL_000a: add
+  IL_000b: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.UninitializedVariable.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.UninitializedVariable.verified.txt
@@ -1,5 +1,5 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: ldc.i4 0
-  IL_0005: ret
+  IL_0000: ldc.i4.0
+  IL_0001: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ArrayDeclaration.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ArrayDeclaration.verified.txt
@@ -8,6 +8,6 @@
       IL_0000: ldc.i4 4
       IL_0005: conv.u
       IL_0006: localloc
-      IL_0008: stloc V_1
-      IL_000c: ldc.i4 0
-      IL_0011: ret
+      IL_0008: stloc.s V_1
+      IL_000a: ldc.i4.0
+      IL_000b: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.BasicTypeDef.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.BasicTypeDef.verified.txt
@@ -4,5 +4,5 @@
     System.Int32 <Module>::main()
       Locals:
         System.Int32 V_0
-      IL_0000: ldc.i4 0
-      IL_0005: ret
+      IL_0000: ldc.i4.0
+      IL_0001: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstCharLiteralDeduplication.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstCharLiteralDeduplication.verified.txt
@@ -7,11 +7,11 @@
         System.Byte* V_1
         System.Byte* V_2
       IL_0000: ldsflda <ConstantPool>/<ConstantPoolItemType7> <ConstantPool>::ConstStringBuffer0
-      IL_0005: stloc V_0
-      IL_0009: ldsflda <ConstantPool>/<ConstantPoolItemType8> <ConstantPool>::ConstStringBuffer1
-      IL_000e: stloc V_1
-      IL_0012: ldsflda <ConstantPool>/<ConstantPoolItemType7> <ConstantPool>::ConstStringBuffer0
-      IL_0017: stloc V_2
+      IL_0005: stloc.s V_0
+      IL_0007: ldsflda <ConstantPool>/<ConstantPoolItemType8> <ConstantPool>::ConstStringBuffer1
+      IL_000c: stloc.s V_1
+      IL_000e: ldsflda <ConstantPool>/<ConstantPoolItemType7> <ConstantPool>::ConstStringBuffer0
+      IL_0013: stloc.s V_2
 
   Type: <ConstantPool>
   Types:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstCharLiteralTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstCharLiteralTest.verified.txt
@@ -5,7 +5,7 @@
       Locals:
         System.Byte* V_0
       IL_0000: ldsflda <ConstantPool>/<ConstantPoolItemType7> <ConstantPool>::ConstStringBuffer0
-      IL_0005: stloc V_0
+      IL_0005: stloc.s V_0
 
   Type: <ConstantPool>
   Types:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstIntLargeLiteralTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstIntLargeLiteralTest.verified.txt
@@ -1,0 +1,6 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::main()
+      IL_0000: ldc.i4 1337
+      IL_0005: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstIntSmallLiteralTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstIntSmallLiteralTest.verified.txt
@@ -1,0 +1,6 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::main()
+      IL_0000: ldc.i4.s 42
+      IL_0002: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.FunctionForwardDeclaration.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.FunctionForwardDeclaration.verified.txt
@@ -2,8 +2,8 @@
   Type: <Module>
   Methods:
     System.Int32 <Module>::bar()
-      IL_0000: ldc.i4 0
-      IL_0005: ret
+      IL_0000: ldc.i4.0
+      IL_0001: ret
 
     System.Int32 <Module>::foo()
       IL_0000: call System.Int32 <Module>::bar()

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.GlobalClassFQNTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.GlobalClassFQNTest.verified.txt
@@ -4,8 +4,8 @@
   Type: MyNameSpace.TestClass
   Methods:
     System.Int32 MyNameSpace.TestClass::foo()
-      IL_0000: ldc.i4 42
-      IL_0005: ret
+      IL_0000: ldc.i4.s 42
+      IL_0002: ret
 
     System.Int32 MyNameSpace.TestClass::main()
       IL_0000: call System.Int32 MyNameSpace.TestClass::foo()

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.GlobalClassTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.GlobalClassTest.verified.txt
@@ -4,8 +4,8 @@
   Type: TestClass
   Methods:
     System.Int32 TestClass::foo()
-      IL_0000: ldc.i4 42
-      IL_0005: ret
+      IL_0000: ldc.i4.s 42
+      IL_0002: ret
 
     System.Int32 TestClass::main()
       IL_0000: call System.Int32 TestClass::foo()

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.NamespaceTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.NamespaceTest.verified.txt
@@ -4,8 +4,8 @@
   Type: TestClass
   Methods:
     System.Int32 TestClass::foo()
-      IL_0000: ldc.i4 42
-      IL_0005: ret
+      IL_0000: ldc.i4.s 42
+      IL_0002: ret
 
     System.Int32 TestClass::main()
       IL_0000: call System.Int32 TestClass::foo()

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessGet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessGet.verified.txt
@@ -4,10 +4,10 @@
     System.Int32 <Module>::main()
       Locals:
         foo V_0
-      IL_0000: ldloca V_0
-      IL_0004: conv.u
-      IL_0005: ldfld System.Int32 foo::x
-      IL_000a: ret
+      IL_0000: ldloca.s V_0
+      IL_0002: conv.u
+      IL_0003: ldfld System.Int32 foo::x
+      IL_0008: ret
 
   Type: foo
   Fields:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessSet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessSet.verified.txt
@@ -4,12 +4,12 @@
     System.Int32 <Module>::main()
       Locals:
         foo V_0
-      IL_0000: ldloca V_0
-      IL_0004: conv.u
-      IL_0005: ldc.i4 42
-      IL_000a: stfld System.Int32 foo::x
-      IL_000f: ldc.i4 0
-      IL_0014: ret
+      IL_0000: ldloca.s V_0
+      IL_0002: conv.u
+      IL_0003: ldc.i4.s 42
+      IL_0005: stfld System.Int32 foo::x
+      IL_000a: ldc.i4.0
+      IL_000b: ret
 
   Type: foo
   Fields:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithPointerMemberAccessGet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithPointerMemberAccessGet.verified.txt
@@ -4,9 +4,9 @@
     System.Int32 <Module>::main()
       Locals:
         foo* V_0
-      IL_0000: ldloc V_0
-      IL_0004: ldfld System.Int32 foo::x
-      IL_0009: ret
+      IL_0000: ldloc.0
+      IL_0001: ldfld System.Int32 foo::x
+      IL_0006: ret
 
   Type: foo
   Fields:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithPointerMemberAccessSet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithPointerMemberAccessSet.verified.txt
@@ -4,11 +4,11 @@
     System.Int32 <Module>::main()
       Locals:
         foo* V_0
-      IL_0000: ldloc V_0
-      IL_0004: ldc.i4 42
-      IL_0009: stfld System.Int32 foo::x
-      IL_000e: ldc.i4 0
-      IL_0013: ret
+      IL_0000: ldloc.0
+      IL_0001: ldc.i4.s 42
+      IL_0003: stfld System.Int32 foo::x
+      IL_0008: ldc.i4.0
+      IL_0009: ret
 
   Type: foo
   Fields:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.TypeDefStructUsage.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.TypeDefStructUsage.verified.txt
@@ -4,8 +4,8 @@
     System.Int32 <Module>::main()
       Locals:
         foo V_0
-      IL_0000: ldc.i4 0
-      IL_0005: ret
+      IL_0000: ldc.i4.0
+      IL_0001: ret
 
   Type: foo
   Fields:

--- a/Cesium.CodeGen.Tests/verified/MultiFileCompilationTest.ExternalLinkage.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/MultiFileCompilationTest.ExternalLinkage.verified.txt
@@ -2,8 +2,8 @@
   Type: <Module>
   Methods:
     System.Int32 <Module>::foo()
-      IL_0000: ldc.i4 0
-      IL_0005: ret
+      IL_0000: ldc.i4.0
+      IL_0001: ret
 
     System.Int32 <Module>::main()
       IL_0000: call System.Int32 <Module>::foo()

--- a/Cesium.CodeGen.Tests/verified/MultiFileCompilationTest.MultiFileProgram.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/MultiFileCompilationTest.MultiFileProgram.verified.txt
@@ -2,8 +2,8 @@
   Type: <Module>
   Methods:
     System.Int32 <Module>::foo()
-      IL_0000: ldc.i4 0
-      IL_0005: ret
+      IL_0000: ldc.i4.0
+      IL_0001: ret
 
     System.Int32 <Module>::main()
       IL_0000: ldc.i4.0

--- a/Cesium.CodeGen/Extensions/CodeGenEx.cs
+++ b/Cesium.CodeGen/Extensions/CodeGenEx.cs
@@ -7,6 +7,13 @@ internal static class CodeGenEx
 {
     public static void StLoc(this IDeclarationScope scope, VariableDefinition variable)
     {
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Stloc, variable));
+        scope.Method.Body.Instructions.Add(
+            Instruction.Create(
+                variable.Index <= sbyte.MaxValue
+                    ? OpCodes.Stloc_S
+                    : OpCodes.Stloc,
+                variable
+            )
+        );
     }
 }

--- a/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
@@ -16,7 +16,7 @@ internal class CharConstant : IConstant
     public void EmitTo(IDeclarationScope scope)
     {
         var instructions = scope.Method.Body.Instructions;
-        instructions.Add(Instruction.Create(OpCodes.Ldc_I4, (int)_value));
+        instructions.Add(Instruction.Create(OpCodes.Ldc_I4_S, (sbyte) _value));
         instructions.Add(Instruction.Create(OpCodes.Conv_U1));
     }
 

--- a/Cesium.CodeGen/Ir/Expressions/Constants/IntegerConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/IntegerConstant.cs
@@ -16,8 +16,21 @@ internal class IntegerConstant : IConstant
 
     public void EmitTo(IDeclarationScope scope)
     {
-        // TODO[#92]: Optimizations like Ldc_I4_0 for selected constants
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldc_I4, _value));
+        scope.Method.Body.Instructions.Add(_value switch
+        {
+            0 => Instruction.Create(OpCodes.Ldc_I4_0),
+            1 => Instruction.Create(OpCodes.Ldc_I4_1),
+            2 => Instruction.Create(OpCodes.Ldc_I4_2),
+            3 => Instruction.Create(OpCodes.Ldc_I4_3),
+            4 => Instruction.Create(OpCodes.Ldc_I4_4),
+            5 => Instruction.Create(OpCodes.Ldc_I4_5),
+            6 => Instruction.Create(OpCodes.Ldc_I4_6),
+            7 => Instruction.Create(OpCodes.Ldc_I4_7),
+            8 => Instruction.Create(OpCodes.Ldc_I4_8),
+            -1 => Instruction.Create(OpCodes.Ldc_I4_M1),
+            >= sbyte.MinValue and <= sbyte.MaxValue => Instruction.Create(OpCodes.Ldc_I4_S, (sbyte) _value),
+            _ => Instruction.Create(OpCodes.Ldc_I4, _value)
+        });
     }
 
     public TypeReference GetConstantType(IDeclarationScope scope) => scope.TypeSystem.Int32;

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueLocalVariable.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueLocalVariable.cs
@@ -16,13 +16,27 @@ internal class LValueLocalVariable : ILValue
 
     public void EmitGetValue(IDeclarationScope scope)
     {
-        // TODO[#92]: Special instructions to emit Ldloc_0 etc.
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldloc, _definition));
+        scope.Method.Body.Instructions.Add(_definition.Index switch
+        {
+            0 => Instruction.Create(OpCodes.Ldloc_0),
+            1 => Instruction.Create(OpCodes.Ldloc_1),
+            2 => Instruction.Create(OpCodes.Ldloc_2),
+            3 => Instruction.Create(OpCodes.Ldloc_3),
+            <= sbyte.MaxValue => Instruction.Create(OpCodes.Ldloc_S, _definition),
+            _ => Instruction.Create(OpCodes.Ldloc, _definition)
+        });
     }
 
     public void EmitGetAddress(IDeclarationScope scope)
     {
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldloca, _definition));
+        scope.Method.Body.Instructions.Add(
+            Instruction.Create(
+                _definition.Index <= sbyte.MaxValue
+                    ? OpCodes.Ldloca_S
+                    : OpCodes.Ldloca,
+                _definition
+            )
+        );
     }
 
     public void EmitSetValue(IDeclarationScope scope, IExpression value)

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueParameter.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueParameter.cs
@@ -14,8 +14,15 @@ internal class LValueParameter : ILValue
 
     public void EmitGetValue(IDeclarationScope scope)
     {
-        // TODO[#92]: Special instructions to emit Ldarg_0 etc.
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldarg, _definition));
+        scope.Method.Body.Instructions.Add(_definition.Index switch
+        {
+            0 => Instruction.Create(OpCodes.Ldarg_0),
+            1 => Instruction.Create(OpCodes.Ldarg_1),
+            2 => Instruction.Create(OpCodes.Ldarg_2),
+            3 => Instruction.Create(OpCodes.Ldarg_3),
+            <= byte.MaxValue => Instruction.Create(OpCodes.Ldarg_S, _definition),
+            _ => Instruction.Create(OpCodes.Ldarg, _definition)
+        });
     }
 
     public void EmitGetAddress(IDeclarationScope scope)
@@ -27,8 +34,11 @@ internal class LValueParameter : ILValue
     {
         value.EmitTo(scope);
 
-        // TODO[#92]: Special instructions to emit Starg_0 etc.
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Starg, _definition));
+        scope.Method.Body.Instructions.Add(_definition.Index switch
+        {
+            <= byte.MaxValue => Instruction.Create(OpCodes.Starg_S, _definition),
+            _ => Instruction.Create(OpCodes.Starg, _definition)
+        });
     }
 
     public TypeReference GetValueType() => _definition.ParameterType;


### PR DESCRIPTION
Fixes #92.