### PR TITLE
Feature/return analysis

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
@@ -231,4 +231,16 @@ int main()
     foo unused;
     return 0;
 }");
+
+    [Fact]
+    public Task ImplicitReturnAllowedForMain() => DoTest(@"int main()
+{
+    int unused;
+}");
+
+    [Fact]
+    public void ImplicitReturnDisallowedNonMain() => DoesNotCompile(@"int foo()
+{
+    int unused;
+}", "Function foo has no return statement.");
 }

--- a/Cesium.CodeGen.Tests/verified/CodeGenBreakStatementTests.BreakInFor.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenBreakStatementTests.BreakInFor.verified.txt
@@ -4,3 +4,5 @@
   IL_000a: ldc.i4.1
   IL_000b: brtrue IL_0005
   IL_0010: nop
+  IL_0011: ldc.i4.0
+  IL_0012: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.ForTest_NoInit.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.ForTest_NoInit.verified.txt
@@ -16,3 +16,5 @@
   IL_0013: ldc.i4.s 10
   IL_0015: clt
   IL_0017: brtrue IL_0008
+  IL_001c: ldc.i4.0
+  IL_001d: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_Empty.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_Empty.verified.txt
@@ -8,3 +8,5 @@
   IL_0008: stloc.s V_0
   IL_000a: ldc.i4.1
   IL_000b: brtrue IL_0005
+  IL_0010: ldc.i4.0
+  IL_0011: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoTest.verified.txt
@@ -14,3 +14,5 @@
   IL_0010: stloc.s V_0
   IL_0012: ldc.i4.1
   IL_0013: brtrue IL_0008
+  IL_0018: ldc.i4.0
+  IL_0019: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoUpdate.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoUpdate.verified.txt
@@ -12,3 +12,5 @@
   IL_000e: ldc.i4.s 10
   IL_0010: clt
   IL_0012: brtrue IL_0008
+  IL_0017: ldc.i4.0
+  IL_0018: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.SimpleFor.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.SimpleFor.verified.txt
@@ -16,3 +16,5 @@
   IL_0013: ldc.i4.s 10
   IL_0015: clt
   IL_0017: brtrue IL_0008
+  IL_001c: ldc.i4.0
+  IL_001d: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenIfTests.SimpleIfTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenIfTests.SimpleIfTest.verified.txt
@@ -4,3 +4,5 @@
   IL_0006: ldc.i4.0
   IL_0007: ret
   IL_0008: nop
+  IL_0009: ldc.i4.0
+  IL_000a: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AddressOfTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AddressOfTest.verified.txt
@@ -5,3 +5,5 @@
   IL_0000: ldloca.s V_0
   IL_0002: conv.u
   IL_0003: stloc.s V_1
+  IL_0005: ldc.i4.0
+  IL_0006: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AmbiguousCallTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AmbiguousCallTest.verified.txt
@@ -14,3 +14,5 @@ System.Int32 <Module>::main()
   IL_0008: stloc.s V_0
   IL_000a: ldloc.0
   IL_000b: call System.Void <Module>::exit(System.Int32)
+  IL_0010: ldc.i4.0
+  IL_0011: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ImplicitReturnAllowedForMain.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ImplicitReturnAllowedForMain.verified.txt
@@ -1,0 +1,5 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32 V_0
+  IL_0000: ldc.i4.0
+  IL_0001: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.MultiDeclaration.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.MultiDeclaration.verified.txt
@@ -8,3 +8,5 @@
   IL_0004: ldc.i4.2
   IL_0005: add
   IL_0006: stloc.s V_1
+  IL_0008: ldc.i4.0
+  IL_0009: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstCharLiteralDeduplication.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstCharLiteralDeduplication.verified.txt
@@ -12,6 +12,8 @@
       IL_000c: stloc.s V_1
       IL_000e: ldsflda <ConstantPool>/<ConstantPoolItemType7> <ConstantPool>::ConstStringBuffer0
       IL_0013: stloc.s V_2
+      IL_0015: ldc.i4.0
+      IL_0016: ret
 
   Type: <ConstantPool>
   Types:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstCharLiteralTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstCharLiteralTest.verified.txt
@@ -6,6 +6,8 @@
         System.Byte* V_0
       IL_0000: ldsflda <ConstantPool>/<ConstantPoolItemType7> <ConstantPool>::ConstStringBuffer0
       IL_0005: stloc.s V_0
+      IL_0007: ldc.i4.0
+      IL_0008: ret
 
   Type: <ConstantPool>
   Types:

--- a/Cesium.CodeGen/Ir/BlockItems/CompoundStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/CompoundStatement.cs
@@ -17,7 +17,7 @@ internal class CompoundStatement : IBlockItem
     {
     }
 
-    public bool HasDefiniteReturn => _items.Count > 0; // TODO[#90]: Better definite return analysis.
+    bool IBlockItem.HasDefiniteReturn => _items.Any(x => x.HasDefiniteReturn);
 
     public IBlockItem Lower() => this; // since actual lowering of child items is done on emit, anyway
 

--- a/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
@@ -43,6 +43,8 @@ internal class ForStatement : IBlockItem
             _updateExpression?.Lower(),
             _body.Lower());
 
+    bool IBlockItem.HasDefiniteReturn => _body.HasDefiniteReturn;
+
     public void EmitTo(IDeclarationScope scope)
     {
         var forScope = new ForScope(scope);

--- a/Cesium.CodeGen/Ir/BlockItems/IBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/IBlockItem.cs
@@ -4,6 +4,8 @@ namespace Cesium.CodeGen.Ir.BlockItems;
 
 internal interface IBlockItem
 {
+    bool HasDefiniteReturn => false;
+
     IBlockItem Lower();
     void EmitTo(IDeclarationScope scope);
 }

--- a/Cesium.CodeGen/Ir/BlockItems/IfElseStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/IfElseStatement.cs
@@ -26,6 +26,8 @@ internal class IfElseStatement : IBlockItem
         _falseBranch = falseBranch?.ToIntermediate();
     }
 
+    bool IBlockItem.HasDefiniteReturn => _trueBranch.HasDefiniteReturn && (_falseBranch == null || _falseBranch.HasDefiniteReturn);
+
     public IBlockItem Lower() => new IfElseStatement(_expression.Lower(), _trueBranch.Lower(), _falseBranch?.Lower());
 
     public void EmitTo(IDeclarationScope scope)

--- a/Cesium.CodeGen/Ir/BlockItems/IfElseStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/IfElseStatement.cs
@@ -26,7 +26,7 @@ internal class IfElseStatement : IBlockItem
         _falseBranch = falseBranch?.ToIntermediate();
     }
 
-    bool IBlockItem.HasDefiniteReturn => _trueBranch.HasDefiniteReturn && (_falseBranch == null || _falseBranch.HasDefiniteReturn);
+    bool IBlockItem.HasDefiniteReturn => _trueBranch.HasDefiniteReturn && _falseBranch?.HasDefiniteReturn == true;
 
     public IBlockItem Lower() => new IfElseStatement(_expression.Lower(), _trueBranch.Lower(), _falseBranch?.Lower());
 

--- a/Cesium.CodeGen/Ir/BlockItems/ReturnStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ReturnStatement.cs
@@ -19,6 +19,8 @@ internal class ReturnStatement : IBlockItem
         _expression = expression;
     }
 
+    bool IBlockItem.HasDefiniteReturn => true;
+
     public IBlockItem Lower() => new ReturnStatement(_expression.Lower());
 
     public void EmitTo(IDeclarationScope scope)

--- a/Cesium.CodeGen/Ir/TopLevel/FunctionDefinition.cs
+++ b/Cesium.CodeGen/Ir/TopLevel/FunctionDefinition.cs
@@ -256,7 +256,7 @@ internal class FunctionDefinition : ITopLevelNode
     private void EmitCode(TranslationUnitContext context, FunctionScope scope)
     {
         _statement.EmitTo(scope);
-        if (!_statement.HasDefiniteReturn)
+        if ((_statement as IBlockItem).HasDefiniteReturn == false)
         {
             if (IsMain)
             {
@@ -271,7 +271,7 @@ internal class FunctionDefinition : ITopLevelNode
             }
             else
             {
-                throw new InvalidOperationException($"{scope.Method.Name} do not have return statement. This is compiler bug.");
+                throw new NotSupportedException($"Function {scope.Method.Name} has no return statement.");
             }
         }
     }


### PR DESCRIPTION
Implements a better return analysis check. The rules are still quite simple:
* `return` statement: always returns (obviously)
* `if` statement: returns if both branches are present and both return
* block statement: returns if any of the children returns
* other statements: do not return

Closes #90, also fixes #142!

This PR depends on #147.