### PR TITLE
(#138) Implement member access operator (`.`)

### DIFF
--- a/Cesium.Ast/Expressions.cs
+++ b/Cesium.Ast/Expressions.cs
@@ -13,6 +13,7 @@ public record ConstantExpression(IToken<CTokenType> Constant) : Expression;
 // 6.5.2 Postfix operators
 public record SubscriptingExpression(Expression Base, Expression Index) : Expression;
 public record FunctionCallExpression(Expression Function, ImmutableArray<Expression>? Arguments) : Expression;
+public record MemberAccessExpression(Expression Target, IdentifierExpression Identifier) : Expression;
 public record PointerMemberAccessExpression(Expression Function, IdentifierExpression Identifier) : Expression;
 
 // 6.5.3 Unary operators

--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
@@ -144,6 +144,14 @@ int main(void) { foo x; return (&x)->x; }");
 int main(void) { foo x; (&x)->x = 42; return 0; }");
 
     [Fact]
+    public Task StructUsageWithMemberAccessGet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo x; return x.x; }");
+
+    [Fact]
+    public Task StructUsageWithMemberAccessSet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo x; x.x = 42; return 0; }");
+
+    [Fact]
     public Task ArrayDeclaration() => DoTest(@"int main()
 {
     int i;

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithMemberAccessGet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithMemberAccessGet.verified.txt
@@ -1,0 +1,15 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::main()
+      Locals:
+        foo V_0
+      IL_0000: ldloca.s V_0
+      IL_0002: conv.u
+      IL_0003: ldfld System.Int32 foo::x
+      IL_0008: ret
+
+  Type: foo
+  Fields:
+    System.Int32 foo::x
+       Init with: []

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithMemberAccessSet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithMemberAccessSet.verified.txt
@@ -1,0 +1,17 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::main()
+      Locals:
+        foo V_0
+      IL_0000: ldloca.s V_0
+      IL_0002: conv.u
+      IL_0003: ldc.i4.s 42
+      IL_0005: stfld System.Int32 foo::x
+      IL_000a: ldc.i4.0
+      IL_000b: ret
+
+  Type: foo
+  Fields:
+    System.Int32 foo::x
+       Init with: []

--- a/Cesium.CodeGen/Extensions/ExpressionEx.cs
+++ b/Cesium.CodeGen/Extensions/ExpressionEx.cs
@@ -26,6 +26,7 @@ internal static class ExpressionEx
         Ast.ComparisonBinaryOperatorExpression e => new ComparisonBinaryOperatorExpression(e),
 
         Ast.SubscriptingExpression e => new SubscriptingExpression(e),
+        Ast.MemberAccessExpression e => new MemberAccessExpression(e),
         Ast.PointerMemberAccessExpression e => new PointerMemberAccessExpression(e),
 
         _ => throw new NotImplementedException($"Expression not supported, yet: {ex}."),

--- a/Cesium.CodeGen/Ir/Expressions/MemberAccessExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/MemberAccessExpression.cs
@@ -1,0 +1,36 @@
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Extensions;
+using Cesium.CodeGen.Ir.Expressions.LValues;
+using Mono.Cecil;
+
+namespace Cesium.CodeGen.Ir.Expressions;
+
+internal class MemberAccessExpression : IExpression, ILValueExpression
+{
+    private readonly IExpression _target;
+    private readonly IExpression _memberIdentifier;
+
+    public MemberAccessExpression(Ast.MemberAccessExpression accessExpression)
+    {
+        var (expression, memberIdentifier) = accessExpression;
+        _target = expression.ToIntermediate();
+        _memberIdentifier = memberIdentifier.ToIntermediate();
+    }
+
+    private MemberAccessExpression(IExpression target, IExpression memberIdentifier)
+    {
+        _target = target;
+        _memberIdentifier = memberIdentifier;
+    }
+
+    public IExpression Lower()
+        => new PointerMemberAccessExpression(
+            new UnaryOperatorExpression(UnaryOperator.AddressOf, _target.Lower()),
+            _memberIdentifier.Lower());
+
+    public void EmitTo(IDeclarationScope scope) => throw new NotSupportedException("Should be lowered");
+
+    public TypeReference GetExpressionType(IDeclarationScope scope) => throw new NotSupportedException("Should be lowered");
+
+    public ILValue Resolve(IDeclarationScope scope) => throw new NotSupportedException("Should be lowered");
+}

--- a/Cesium.CodeGen/Ir/Expressions/PointerMemberAccessExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/PointerMemberAccessExpression.cs
@@ -17,7 +17,7 @@ internal class PointerMemberAccessExpression : IExpression, ILValueExpression
         _memberIdentifier = memberIdentifier.ToIntermediate();
     }
 
-    private PointerMemberAccessExpression(IExpression expression, IExpression memberIdentifier)
+    internal PointerMemberAccessExpression(IExpression expression, IExpression memberIdentifier)
     {
         _expression = expression;
         _memberIdentifier = memberIdentifier;

--- a/Cesium.Parser.Tests/ParserTests/FullParserTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/FullParserTests.cs
@@ -154,4 +154,12 @@ int main(void) { foo x; return (&x)->x; }");
     [Fact]
     public Task StructAddressWithPointerMemberAccessSet() => DoTest(@"typedef struct { int x; } foo;
 int main(void) { foo x; (&x)->x = 42; return 0; }");
+
+    [Fact]
+    public Task StructUsageWithMemberAccessGet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo x; return x.x; }");
+
+    [Fact]
+    public Task StructUsageWithMemberAccessSet() => DoTest(@"typedef struct { int x; } foo;
+int main(void) { foo x; x.x = 42; return 0; }");
 }

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithMemberAccessGet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithMemberAccessGet.verified.txt
@@ -1,0 +1,147 @@
+﻿{
+  "$type": "Cesium.Ast.TranslationUnit, Cesium.Ast",
+  "Declarations": [
+    {
+      "$type": "Cesium.Ast.SymbolDeclaration, Cesium.Ast",
+      "Declaration": {
+        "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+        "Specifiers": [
+          {
+            "$type": "Cesium.Ast.StorageClassSpecifier, Cesium.Ast",
+            "Name": "typedef"
+          },
+          {
+            "$type": "Cesium.Ast.StructOrUnionSpecifier, Cesium.Ast",
+            "TypeKind": "Struct",
+            "Identifier": null,
+            "StructDeclarations": [
+              {
+                "$type": "Cesium.Ast.StructDeclaration, Cesium.Ast",
+                "SpecifiersQualifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "int"
+                  }
+                ],
+                "Declarators": [
+                  {
+                    "$type": "Cesium.Ast.StructDeclarator, Cesium.Ast",
+                    "Declarator": {
+                      "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                      "Pointer": null,
+                      "DirectDeclarator": {
+                        "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                        "Identifier": "x",
+                        "Base": null
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "InitDeclarators": [
+          {
+            "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+            "Declarator": {
+              "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+              "Pointer": null,
+              "DirectDeclarator": {
+                "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                "Identifier": "foo",
+                "Base": null
+              }
+            },
+            "Initializer": null
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Cesium.Ast.FunctionDefinition, Cesium.Ast",
+      "Specifiers": [
+        {
+          "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+          "TypeName": "int"
+        }
+      ],
+      "Declarator": {
+        "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+        "Pointer": null,
+        "DirectDeclarator": {
+          "$type": "Cesium.Ast.ParameterListDirectDeclarator, Cesium.Ast",
+          "Base": {
+            "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+            "Identifier": "main",
+            "Base": null
+          },
+          "Parameters": {
+            "$type": "Cesium.Ast.ParameterTypeList, Cesium.Ast",
+            "Parameters": [
+              {
+                "$type": "Cesium.Ast.ParameterDeclaration, Cesium.Ast",
+                "Specifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "void"
+                  }
+                ],
+                "Declarator": null,
+                "AbstractDeclarator": null
+              }
+            ],
+            "HasEllipsis": false
+          }
+        }
+      },
+      "Declarations": null,
+      "Statement": {
+        "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",
+        "Block": [
+          {
+            "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+            "Specifiers": [
+              {
+                "$type": "Cesium.Ast.NamedTypeSpecifier, Cesium.Ast",
+                "TypeDefName": "foo"
+              }
+            ],
+            "InitDeclarators": [
+              {
+                "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+                "Declarator": {
+                  "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                  "Pointer": null,
+                  "DirectDeclarator": {
+                    "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                    "Identifier": "x",
+                    "Base": null
+                  }
+                },
+                "Initializer": null
+              }
+            ]
+          },
+          {
+            "$type": "Cesium.Ast.ReturnStatement, Cesium.Ast",
+            "Expression": {
+              "$type": "Cesium.Ast.MemberAccessExpression, Cesium.Ast",
+              "Target": {
+                "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                "Constant": {
+                  "Kind": "Identifier",
+                  "Text": "x"
+                }
+              },
+              "Identifier": {
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "x"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithMemberAccessSet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithMemberAccessSet.verified.txt
@@ -1,0 +1,168 @@
+﻿{
+  "$type": "Cesium.Ast.TranslationUnit, Cesium.Ast",
+  "Declarations": [
+    {
+      "$type": "Cesium.Ast.SymbolDeclaration, Cesium.Ast",
+      "Declaration": {
+        "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+        "Specifiers": [
+          {
+            "$type": "Cesium.Ast.StorageClassSpecifier, Cesium.Ast",
+            "Name": "typedef"
+          },
+          {
+            "$type": "Cesium.Ast.StructOrUnionSpecifier, Cesium.Ast",
+            "TypeKind": "Struct",
+            "Identifier": null,
+            "StructDeclarations": [
+              {
+                "$type": "Cesium.Ast.StructDeclaration, Cesium.Ast",
+                "SpecifiersQualifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "int"
+                  }
+                ],
+                "Declarators": [
+                  {
+                    "$type": "Cesium.Ast.StructDeclarator, Cesium.Ast",
+                    "Declarator": {
+                      "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                      "Pointer": null,
+                      "DirectDeclarator": {
+                        "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                        "Identifier": "x",
+                        "Base": null
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "InitDeclarators": [
+          {
+            "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+            "Declarator": {
+              "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+              "Pointer": null,
+              "DirectDeclarator": {
+                "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                "Identifier": "foo",
+                "Base": null
+              }
+            },
+            "Initializer": null
+          }
+        ]
+      }
+    },
+    {
+      "$type": "Cesium.Ast.FunctionDefinition, Cesium.Ast",
+      "Specifiers": [
+        {
+          "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+          "TypeName": "int"
+        }
+      ],
+      "Declarator": {
+        "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+        "Pointer": null,
+        "DirectDeclarator": {
+          "$type": "Cesium.Ast.ParameterListDirectDeclarator, Cesium.Ast",
+          "Base": {
+            "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+            "Identifier": "main",
+            "Base": null
+          },
+          "Parameters": {
+            "$type": "Cesium.Ast.ParameterTypeList, Cesium.Ast",
+            "Parameters": [
+              {
+                "$type": "Cesium.Ast.ParameterDeclaration, Cesium.Ast",
+                "Specifiers": [
+                  {
+                    "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                    "TypeName": "void"
+                  }
+                ],
+                "Declarator": null,
+                "AbstractDeclarator": null
+              }
+            ],
+            "HasEllipsis": false
+          }
+        }
+      },
+      "Declarations": null,
+      "Statement": {
+        "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",
+        "Block": [
+          {
+            "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+            "Specifiers": [
+              {
+                "$type": "Cesium.Ast.NamedTypeSpecifier, Cesium.Ast",
+                "TypeDefName": "foo"
+              }
+            ],
+            "InitDeclarators": [
+              {
+                "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+                "Declarator": {
+                  "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                  "Pointer": null,
+                  "DirectDeclarator": {
+                    "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                    "Identifier": "x",
+                    "Base": null
+                  }
+                },
+                "Initializer": null
+              }
+            ]
+          },
+          {
+            "$type": "Cesium.Ast.ExpressionStatement, Cesium.Ast",
+            "Expression": {
+              "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
+              "Left": {
+                "$type": "Cesium.Ast.MemberAccessExpression, Cesium.Ast",
+                "Target": {
+                  "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                  "Constant": {
+                    "Kind": "Identifier",
+                    "Text": "x"
+                  }
+                },
+                "Identifier": {
+                  "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                  "Identifier": "x"
+                }
+              },
+              "Operator": "=",
+              "Right": {
+                "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                "Constant": {
+                  "Kind": "IntLiteral",
+                  "Text": "42"
+                }
+              }
+            }
+          },
+          {
+            "$type": "Cesium.Ast.ReturnStatement, Cesium.Ast",
+            "Expression": {
+              "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+              "Constant": {
+                "Kind": "IntLiteral",
+                "Text": "0"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Cesium.Parser/CParser.cs
+++ b/Cesium.Parser/CParser.cs
@@ -88,9 +88,11 @@ public partial class CParser
         ArgumentExpressionList? arguments,
         IToken __) => new FunctionCallExpression(function, arguments);
 
-    // TODO:
-    // postfix-expression:
-    //     postfix-expression . identifier
+    [Rule("postfix_expression: postfix_expression '.' Identifier")]
+    private static Expression MakeMemberAccessExpression(
+        Expression target,
+        IToken _,
+        IToken identifier) => new MemberAccessExpression(target, new IdentifierExpression(identifier.Text));
 
     [Rule("postfix_expression: postfix_expression '->' Identifier")]
     private static Expression MakePointerMemberAccessExpression(


### PR DESCRIPTION
Member access operator is basically combination of `&` and `->`, so I use lowering to already existing expressions.

Closes #138