### PR TITLE
Local variable set optimization

### DIFF
--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.ForTest_NoInit.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.ForTest_NoInit.verified.txt
@@ -3,18 +3,18 @@
     System.Int32 V_0
   IL_0000: ldc.i4.0
   IL_0001: stloc.s V_0
-  IL_0003: br IL_0012
+  IL_0003: br IL_0010
   IL_0008: ldloc.0
   IL_0009: ldc.i4.1
   IL_000a: add
-  IL_000b: stloc.s V_0
-  IL_000d: ldloc.0
-  IL_000e: ldc.i4.1
-  IL_000f: add
-  IL_0010: stloc.s V_0
-  IL_0012: ldloc.0
-  IL_0013: ldc.i4.s 10
-  IL_0015: clt
-  IL_0017: brtrue IL_0008
-  IL_001c: ldc.i4.0
-  IL_001d: ret
+  IL_000b: stloc.0
+  IL_000c: ldloc.0
+  IL_000d: ldc.i4.1
+  IL_000e: add
+  IL_000f: stloc.0
+  IL_0010: ldloc.0
+  IL_0011: ldc.i4.s 10
+  IL_0013: clt
+  IL_0015: brtrue IL_0008
+  IL_001a: ldc.i4.0
+  IL_001b: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_Empty.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_Empty.verified.txt
@@ -1,12 +1,12 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: br IL_000a
+  IL_0000: br IL_0009
   IL_0005: ldloc.0
   IL_0006: ldc.i4.1
   IL_0007: add
-  IL_0008: stloc.s V_0
-  IL_000a: ldc.i4.1
-  IL_000b: brtrue IL_0005
-  IL_0010: ldc.i4.0
-  IL_0011: ret
+  IL_0008: stloc.0
+  IL_0009: ldc.i4.1
+  IL_000a: brtrue IL_0005
+  IL_000f: ldc.i4.0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoTest.verified.txt
@@ -2,17 +2,17 @@
   Locals:
     System.Int32 V_0
   IL_0000: ldc.i4.0
-  IL_0001: stloc.s V_0
-  IL_0003: br IL_0012
-  IL_0008: ldloc.0
-  IL_0009: ldc.i4.1
-  IL_000a: add
-  IL_000b: stloc.s V_0
-  IL_000d: ldloc.0
-  IL_000e: ldc.i4.1
-  IL_000f: add
-  IL_0010: stloc.s V_0
-  IL_0012: ldc.i4.1
-  IL_0013: brtrue IL_0008
-  IL_0018: ldc.i4.0
-  IL_0019: ret
+  IL_0001: stloc.0
+  IL_0002: br IL_000f
+  IL_0007: ldloc.0
+  IL_0008: ldc.i4.1
+  IL_0009: add
+  IL_000a: stloc.0
+  IL_000b: ldloc.0
+  IL_000c: ldc.i4.1
+  IL_000d: add
+  IL_000e: stloc.0
+  IL_000f: ldc.i4.1
+  IL_0010: brtrue IL_0007
+  IL_0015: ldc.i4.0
+  IL_0016: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoUpdate.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoUpdate.verified.txt
@@ -2,15 +2,15 @@
   Locals:
     System.Int32 V_0
   IL_0000: ldc.i4.0
-  IL_0001: stloc.s V_0
-  IL_0003: br IL_000d
-  IL_0008: ldloc.0
-  IL_0009: ldc.i4.1
-  IL_000a: add
-  IL_000b: stloc.s V_0
-  IL_000d: ldloc.0
-  IL_000e: ldc.i4.s 10
-  IL_0010: clt
-  IL_0012: brtrue IL_0008
-  IL_0017: ldc.i4.0
-  IL_0018: ret
+  IL_0001: stloc.0
+  IL_0002: br IL_000b
+  IL_0007: ldloc.0
+  IL_0008: ldc.i4.1
+  IL_0009: add
+  IL_000a: stloc.0
+  IL_000b: ldloc.0
+  IL_000c: ldc.i4.s 10
+  IL_000e: clt
+  IL_0010: brtrue IL_0007
+  IL_0015: ldc.i4.0
+  IL_0016: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.SimpleFor.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.SimpleFor.verified.txt
@@ -2,19 +2,19 @@
   Locals:
     System.Int32 V_0
   IL_0000: ldc.i4.0
-  IL_0001: stloc.s V_0
-  IL_0003: br IL_0012
-  IL_0008: ldloc.0
-  IL_0009: ldc.i4.1
-  IL_000a: add
-  IL_000b: stloc.s V_0
-  IL_000d: ldloc.0
-  IL_000e: ldc.i4.1
-  IL_000f: add
-  IL_0010: stloc.s V_0
-  IL_0012: ldloc.0
-  IL_0013: ldc.i4.s 10
-  IL_0015: clt
-  IL_0017: brtrue IL_0008
-  IL_001c: ldc.i4.0
-  IL_001d: ret
+  IL_0001: stloc.0
+  IL_0002: br IL_000f
+  IL_0007: ldloc.0
+  IL_0008: ldc.i4.1
+  IL_0009: add
+  IL_000a: stloc.0
+  IL_000b: ldloc.0
+  IL_000c: ldc.i4.1
+  IL_000d: add
+  IL_000e: stloc.0
+  IL_000f: ldloc.0
+  IL_0010: ldc.i4.s 10
+  IL_0012: clt
+  IL_0014: brtrue IL_0007
+  IL_0019: ldc.i4.0
+  IL_001a: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenIfTests.IfElseTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenIfTests.IfElseTest.verified.txt
@@ -4,13 +4,13 @@
   IL_0000: ldc.i4.0
   IL_0001: stloc.s V_0
   IL_0003: ldc.i4.1
-  IL_0004: brfalse IL_0011
+  IL_0004: brfalse IL_0010
   IL_0009: ldc.i4.1
-  IL_000a: stloc.s V_0
-  IL_000c: br IL_0015
-  IL_0011: nop
-  IL_0012: ldc.i4.2
-  IL_0013: stloc.s V_0
-  IL_0015: nop
-  IL_0016: ldc.i4.0
-  IL_0017: ret
+  IL_000a: stloc.0
+  IL_000b: br IL_0013
+  IL_0010: nop
+  IL_0011: ldc.i4.2
+  IL_0012: stloc.0
+  IL_0013: nop
+  IL_0014: ldc.i4.0
+  IL_0015: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.Arithmetic.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.Arithmetic.verified.txt
@@ -10,16 +10,16 @@
   IL_0009: ldloc.1
   IL_000a: ldc.i4.1
   IL_000b: add
-  IL_000c: stloc.s V_1
-  IL_000e: ldloc.1
-  IL_000f: ldc.i4.1
-  IL_0010: add
-  IL_0011: stloc.s V_1
-  IL_0013: ldloc.1
-  IL_0014: ldc.i4.2
-  IL_0015: mul
-  IL_0016: stloc.s V_1
-  IL_0018: ldloc.1
-  IL_0019: ldc.i4.2
-  IL_001a: add
-  IL_001b: ret
+  IL_000c: stloc.1
+  IL_000d: ldloc.1
+  IL_000e: ldc.i4.1
+  IL_000f: add
+  IL_0010: stloc.1
+  IL_0011: ldloc.1
+  IL_0012: ldc.i4.2
+  IL_0013: mul
+  IL_0014: stloc.1
+  IL_0015: ldloc.1
+  IL_0016: ldc.i4.2
+  IL_0017: add
+  IL_0018: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AssigmentLoweringTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AssigmentLoweringTest.verified.txt
@@ -6,8 +6,8 @@
   IL_0003: ldloc.0
   IL_0004: ldc.i4.1
   IL_0005: add
-  IL_0006: stloc.s V_0
-  IL_0008: ldloc.0
-  IL_0009: ldc.i4.1
-  IL_000a: add
-  IL_000b: ret
+  IL_0006: stloc.0
+  IL_0007: ldloc.0
+  IL_0008: ldc.i4.1
+  IL_0009: add
+  IL_000a: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.BitOrAssignmentLoweringTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.BitOrAssignmentLoweringTest.verified.txt
@@ -6,6 +6,6 @@
   IL_0003: ldloc.0
   IL_0004: ldc.i4.1
   IL_0005: or
-  IL_0006: stloc.s V_0
-  IL_0008: ldloc.0
-  IL_0009: ret
+  IL_0006: stloc.0
+  IL_0007: ldloc.0
+  IL_0008: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.PostfixIncrementTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.PostfixIncrementTest.verified.txt
@@ -6,8 +6,8 @@
   IL_0003: ldloc.0
   IL_0004: ldc.i4.1
   IL_0005: add
-  IL_0006: stloc.s V_0
-  IL_0008: ldloc.0
-  IL_0009: ldc.i4.1
-  IL_000a: add
-  IL_000b: ret
+  IL_0006: stloc.0
+  IL_0007: ldloc.0
+  IL_0008: ldc.i4.1
+  IL_0009: add
+  IL_000a: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.SimpleVariableTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.SimpleVariableTest.verified.txt
@@ -6,8 +6,8 @@
   IL_0003: ldloc.0
   IL_0004: ldc.i4.1
   IL_0005: add
-  IL_0006: stloc.s V_0
-  IL_0008: ldloc.0
-  IL_0009: ldc.i4.1
-  IL_000a: add
-  IL_000b: ret
+  IL_0006: stloc.0
+  IL_0007: ldloc.0
+  IL_0008: ldc.i4.1
+  IL_0009: add
+  IL_000a: ret

--- a/Cesium.CodeGen/Ir/Expressions/LValues/LValueLocalVariable.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LValues/LValueLocalVariable.cs
@@ -42,8 +42,15 @@ internal class LValueLocalVariable : ILValue
     public void EmitSetValue(IDeclarationScope scope, IExpression value)
     {
         value.EmitTo(scope);
-
-        scope.StLoc(_definition);
+        scope.Method.Body.Instructions.Add(_definition.Index switch
+        {
+            0 => Instruction.Create(OpCodes.Stloc_0),
+            1 => Instruction.Create(OpCodes.Stloc_1),
+            2 => Instruction.Create(OpCodes.Stloc_2),
+            3 => Instruction.Create(OpCodes.Stloc_3),
+            <= sbyte.MaxValue => Instruction.Create(OpCodes.Stloc_S, _definition),
+            _ => Instruction.Create(OpCodes.Stloc, _definition)
+        });
     }
 
     public TypeReference GetValueType() => _definition.VariableType;


### PR DESCRIPTION
Before:
``` csharp
value.EmitTo(scope);
scope.StLoc(_definition);
```

After:

``` csharp
value.EmitTo(scope);
scope.Method.Body.Instructions.Add(_definition.Index switch
{
    0 => Instruction.Create(OpCodes.Stloc_0),
    1 => Instruction.Create(OpCodes.Stloc_1),
    2 => Instruction.Create(OpCodes.Stloc_2),
    3 => Instruction.Create(OpCodes.Stloc_3),
    <= sbyte.MaxValue => Instruction.Create(OpCodes.Stloc_S, _definition),
    _ => Instruction.Create(OpCodes.Stloc, _definition)
});
```