### PR TITLE
Center type and method importation around Cecil

### DIFF
--- a/Cesium.CodeGen.Tests/Cesium.CodeGen.Tests.csproj
+++ b/Cesium.CodeGen.Tests/Cesium.CodeGen.Tests.csproj
@@ -24,6 +24,7 @@
     <ItemGroup>
       <ProjectReference Include="..\Cesium.CodeGen\Cesium.CodeGen.csproj" />
       <ProjectReference Include="..\Cesium.Parser\Cesium.Parser.csproj" />
+      <ProjectReference Include="..\Cesium.Runtime\Cesium.Runtime.csproj" />
       <ProjectReference Include="..\Cesium.Test.Framework\Cesium.Test.Framework.csproj" />
     </ItemGroup>
 

--- a/Cesium.CodeGen.Tests/CodeGenTestBase.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTestBase.cs
@@ -36,7 +36,9 @@ public abstract class CodeGenTestBase : VerifyTestBase
             new AssemblyNameDefinition("test", new Version()),
             ModuleKind.Console,
             targetRuntime,
-            new [] { typeof(Console).Assembly },
+            new [] { typeof(Console).Assembly.Location },
+            typeof(Math).Assembly.Location,
+            typeof(Cesium.Runtime.RuntimeHelpers).Assembly.Location,
             @namespace,
             globalTypeFqn);
 

--- a/Cesium.CodeGen/Cesium.CodeGen.csproj
+++ b/Cesium.CodeGen/Cesium.CodeGen.csproj
@@ -13,7 +13,6 @@
     <ItemGroup>
       <ProjectReference Include="..\Cesium.Ast\Cesium.Ast.csproj" />
       <ProjectReference Include="..\Cesium.Parser\Cesium.Parser.csproj" />
-      <ProjectReference Include="..\Cesium.Runtime\Cesium.Runtime.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Cesium.CodeGen/Extensions/TypeDefinitionEx.cs
+++ b/Cesium.CodeGen/Extensions/TypeDefinitionEx.cs
@@ -45,4 +45,21 @@ internal static class TypeDefinitionEx
             method.Parameters.Add(parameterDefinition);
         }
     }
+    public static TypeDefinition? GetType(this AssemblyDefinition assemblyDefinition, string typeName)
+    {
+        foreach (var module in assemblyDefinition.Modules)
+        {
+            var foundType = module.GetType(typeName);
+            if (foundType != null)
+            {
+                return foundType;
+            }
+        }
+
+        return null;
+    }
+    public static MethodDefinition FindMethod(this TypeDefinition typeDefinition, string methodName)
+    {
+        return typeDefinition.Methods.Single(method => method.Name == methodName);
+    }
 }

--- a/Cesium.CodeGen/Extensions/TypeSystemEx.cs
+++ b/Cesium.CodeGen/Extensions/TypeSystemEx.cs
@@ -1,8 +1,8 @@
+using System.Runtime.Versioning;
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Ir;
 using Cesium.CodeGen.Ir.Types;
 using Mono.Cecil;
-using System.Runtime.Versioning;
 
 namespace Cesium.CodeGen.Extensions;
 
@@ -21,7 +21,6 @@ internal static class TypeSystemEx
         var typeName = components[0];
         var methodName = components[1];
 
-        // TODO[#161]: Method search should be implemented in Cecil, to not load the assemblies into the current process.
         var candidates = FindMethods(context.AssemblyContext.ImportAssemblies, typeName, methodName).ToList();
         var similarMethods = new List<(MethodDefinition, string)>();
         foreach (var candidate in candidates)

--- a/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
@@ -32,9 +32,13 @@ internal class SubscriptingExpression : IExpression, ILValueExpression
 
     public ILValue Resolve(IDeclarationScope scope)
     {
-        if (_expression is not IdentifierExpression identifier)
-            throw new NotImplementedException("Subscription supported only for IdentifierConstantExpression");
-
-        return new LValueArrayElement(identifier.Resolve(scope), _index);
+        switch (_expression) {
+            case IdentifierExpression identifier:
+                return new LValueArrayElement(identifier.Resolve(scope), _index);
+            case PointerMemberAccessExpression pointerMemberAccess:
+                return new LValueArrayElement(pointerMemberAccess.Resolve(scope), _index);
+            default:
+                throw new NotImplementedException($"Subscription supported only for IdentifierConstantExpression, but {_expression.GetType().Name} seen.");
+        }
     }
 }

--- a/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
@@ -32,13 +32,9 @@ internal class SubscriptingExpression : IExpression, ILValueExpression
 
     public ILValue Resolve(IDeclarationScope scope)
     {
-        switch (_expression) {
-            case IdentifierExpression identifier:
-                return new LValueArrayElement(identifier.Resolve(scope), _index);
-            case PointerMemberAccessExpression pointerMemberAccess:
-                return new LValueArrayElement(pointerMemberAccess.Resolve(scope), _index);
-            default:
-                throw new NotImplementedException($"Subscription supported only for IdentifierConstantExpression, but {_expression.GetType().Name} seen.");
-        }
+        if (_expression is not IdentifierExpression identifier)
+            throw new NotImplementedException("Subscription supported only for IdentifierConstantExpression");
+
+        return new LValueArrayElement(identifier.Resolve(scope), _index);
     }
 }

--- a/Cesium.CodeGen/Ir/TopLevel/FunctionDefinition.cs
+++ b/Cesium.CodeGen/Ir/TopLevel/FunctionDefinition.cs
@@ -4,7 +4,6 @@ using Cesium.CodeGen.Extensions;
 using Cesium.CodeGen.Ir.BlockItems;
 using Cesium.CodeGen.Ir.Declarations;
 using Cesium.CodeGen.Ir.Types;
-using Cesium.Runtime;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
@@ -149,10 +148,9 @@ internal class FunctionDefinition : ITopLevelNode
 
         var bytePtrType = context.TypeSystem.Byte.MakePointerType();
         var bytePtrArrayType = bytePtrType.MakeArrayType();
-        var argsToArgv = module.ImportReference(typeof(RuntimeHelpers).GetMethod("ArgsToArgv"));
-        var freeArgv = module.ImportReference(typeof(RuntimeHelpers).GetMethod("FreeArgv"));
-        var arrayCopyTo = module.ImportReference(typeof(byte*[])
-            .GetMethod("CopyTo", new[] { typeof(Array), typeof(int) }));
+        var argsToArgv = context.GetRuntimeHelperMethod("ArgsToArgv");
+        var freeArgv = context.GetRuntimeHelperMethod("FreeArgv");
+        var arrayCopyTo = context.GetArrayCopyToMethod();
 
         var argC = new VariableDefinition(context.TypeSystem.Int32); // 0
         syntheticEntrypoint.Body.Variables.Add(argC);

--- a/Cesium.CodeGen/Ir/Types/InPlaceArrayType.cs
+++ b/Cesium.CodeGen/Ir/Types/InPlaceArrayType.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Extensions;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
@@ -35,7 +36,7 @@ internal record InPlaceArrayType(IType Base, int Size) : IType
             {
                 ConstructorArguments =
                 {
-                    new CustomAttributeArgument(context.Module.ImportReference(typeof(Type)), itemType),
+                    new CustomAttributeArgument(context.Module.ImportReference(context.AssemblyContext.MscorlibAssembly.GetType("System.Type")), itemType),
                     new CustomAttributeArgument(context.TypeSystem.Int32, SizeInBytes)
                 }
             };

--- a/Cesium.CodeGen/Ir/Types/StructType.cs
+++ b/Cesium.CodeGen/Ir/Types/StructType.cs
@@ -1,4 +1,5 @@
 using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Extensions;
 using Cesium.CodeGen.Ir.Declarations;
 using Mono.Cecil;
 
@@ -18,7 +19,7 @@ internal class StructType : IGeneratedType
             "",
             name,
             TypeAttributes.Sealed,
-            context.Module.ImportReference(typeof(ValueType)));
+            context.Module.ImportReference(context.AssemblyContext.MscorlibAssembly.GetType("System.ValueType")));
         context.Module.Types.Add(structType);
 
         foreach (var member in _members)

--- a/Cesium.Compiler/Compilation.cs
+++ b/Cesium.Compiler/Compilation.cs
@@ -50,15 +50,15 @@ internal static class Compilation
         var assemblyName = Path.GetFileNameWithoutExtension(outputFilePath);
         var defaultImportAssemblies = new []
         {
-            typeof(Math).Assembly, // System.Runtime.dll
-            typeof(Console).Assembly, // System.Console.dll
-            typeof(Runtime.StdLibFunctions).Assembly
+            typeof(Console).Assembly.Location, // System.Console.dll
         };
         return AssemblyContext.Create(
             new AssemblyNameDefinition(assemblyName, new Version()),
             parsedModuleKind,
             targetRuntime,
             defaultImportAssemblies,
+            typeof(Math).Assembly.Location, // System.Runtime.dll
+            typeof(Runtime.StdLibFunctions).Assembly.Location, // Cesium runtime assembly
             @namespace,
             globalClassFQN);
     }


### PR DESCRIPTION
Reduce usage of `typeof` and Reflection across codebase
I did not change all usages, since some of them require factoring code differently, and it produce much more noise, and would be hard to review

**Notes from F.:**

Closes #161.