### PR TITLE
Parse INT_MIN value properly

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
@@ -83,6 +83,12 @@ int main()
 }");
 
     [Fact]
+    public Task ConstIntMinLiteralTest() => DoTest(@"int main()
+{
+    return -2147483648;
+}");
+
+    [Fact]
     public Task ConstCharLiteralDeduplication() => DoTest(@"int main()
 {
     const char *test1 = ""hellow"";

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AmbiguousCallTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.AmbiguousCallTest.verified.txt
@@ -8,11 +8,10 @@ System.Void <Module>::exit(System.Int32 x)
 System.Int32 <Module>::main()
   Locals:
     System.Int32 V_0
-  IL_0000: ldc.i4.s 42
-  IL_0002: neg
-  IL_0003: call System.Int32 <Module>::abs(System.Int32)
-  IL_0008: stloc.0
-  IL_0009: ldloc.0
-  IL_000a: call System.Void <Module>::exit(System.Int32)
-  IL_000f: ldc.i4.0
-  IL_0010: ret
+  IL_0000: ldc.i4.s -42
+  IL_0002: call System.Int32 <Module>::abs(System.Int32)
+  IL_0007: stloc.0
+  IL_0008: ldloc.0
+  IL_0009: call System.Void <Module>::exit(System.Int32)
+  IL_000e: ldc.i4.0
+  IL_000f: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.Arithmetic.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.Arithmetic.verified.txt
@@ -2,24 +2,23 @@
   Locals:
     System.Int32 V_0
     System.Int32 V_1
-  IL_0000: ldc.i4.s 42
-  IL_0002: neg
-  IL_0003: stloc.0
-  IL_0004: ldc.i4.s 18
-  IL_0006: stloc.1
-  IL_0007: ldloc.1
-  IL_0008: ldc.i4.1
-  IL_0009: add
-  IL_000a: stloc.1
-  IL_000b: ldloc.1
-  IL_000c: ldc.i4.1
-  IL_000d: add
-  IL_000e: stloc.1
-  IL_000f: ldloc.1
-  IL_0010: ldc.i4.2
-  IL_0011: mul
-  IL_0012: stloc.1
-  IL_0013: ldloc.1
-  IL_0014: ldc.i4.2
-  IL_0015: add
-  IL_0016: ret
+  IL_0000: ldc.i4.s -42
+  IL_0002: stloc.0
+  IL_0003: ldc.i4.s 18
+  IL_0005: stloc.1
+  IL_0006: ldloc.1
+  IL_0007: ldc.i4.1
+  IL_0008: add
+  IL_0009: stloc.1
+  IL_000a: ldloc.1
+  IL_000b: ldc.i4.1
+  IL_000c: add
+  IL_000d: stloc.1
+  IL_000e: ldloc.1
+  IL_000f: ldc.i4.2
+  IL_0010: mul
+  IL_0011: stloc.1
+  IL_0012: ldloc.1
+  IL_0013: ldc.i4.2
+  IL_0014: add
+  IL_0015: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.NegationExpressTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.NegationExpressTest.verified.txt
@@ -1,4 +1,3 @@
 ﻿System.Int32 <Module>::main()
-  IL_0000: ldc.i4.s 42
-  IL_0002: neg
-  IL_0003: ret
+  IL_0000: ldc.i4.s -42
+  IL_0002: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstIntMinLiteralTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ConstIntMinLiteralTest.verified.txt
@@ -1,0 +1,6 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::main()
+      IL_0000: ldc.i4 -2147483648
+      IL_0005: ret

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.AbsCallTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.AbsCallTest.verified.txt
@@ -59,14 +59,10 @@
                     },
                     "Arguments": [
                       {
-                        "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
-                        "Operator": "-",
-                        "Target": {
-                          "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
-                          "Constant": {
-                            "Kind": "IntLiteral",
-                            "Text": "42"
-                          }
+                        "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                        "Constant": {
+                          "Kind": "IntLiteral",
+                          "Text": "-42"
                         }
                       }
                     ]

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.NegationTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.NegationTest.verified.txt
@@ -49,14 +49,10 @@
                 "Initializer": {
                   "$type": "Cesium.Ast.AssignmentInitializer, Cesium.Ast",
                   "Expression": {
-                    "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
-                    "Operator": "-",
-                    "Target": {
-                      "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
-                      "Constant": {
-                        "Kind": "IntLiteral",
-                        "Text": "42"
-                      }
+                    "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                    "Constant": {
+                      "Kind": "IntLiteral",
+                      "Text": "-42"
                     }
                   }
                 }


### PR DESCRIPTION
Parse INT_MIN value properly
Right now I belive bug is in the tokenizer which parse `-34` as `-` (unary negation) and `34` (constant). That triggers bug in the lowering when we try to parse `-2147483648` and parse `2147483648` as integer, which is impossible.