### PR TITLE
(#198) PointerMemberAccessExpression: get rid of redundant catch

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
@@ -184,4 +184,11 @@ typedef int (*foo_t)(int);
 int main(void) {
     foo_t x = &foo;
 }");
+
+    [Fact]
+    public void NonExistingStructMember() => DoesNotCompile(@"typedef struct { int x; } foo;
+int main(void) {
+    foo x;
+    return x.nonExisting;
+}", "\"foo\" has no member named \"nonExisting\"");
 }

--- a/Cesium.CodeGen/Ir/Expressions/PointerMemberAccessExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/PointerMemberAccessExpression.cs
@@ -38,16 +38,9 @@ internal class PointerMemberAccessExpression : IExpression, IValueExpression
         var valueType = _target.GetExpressionType(scope);
         var valueTypeDef = valueType.Resolve();
 
-        try
-        {
-            var field = valueTypeDef.Fields.First(f => f?.Name == memberIdentifier.Identifier);
-            return new LValueField(_target, new FieldReference(field.Name, field.FieldType, field.DeclaringType));
-        }
-        catch (InvalidOperationException e)
-        {
-            throw new NotSupportedException(
-                $"\"{valueTypeDef.Name}\" has no member named \"{memberIdentifier.Identifier}\"",
-                e);
-        }
+        var field = valueTypeDef.Fields.FirstOrDefault(f => f?.Name == memberIdentifier.Identifier)
+                    ?? throw new NotSupportedException(
+                        $"\"{valueTypeDef.Name}\" has no member named \"{memberIdentifier.Identifier}\"");
+        return new LValueField(_target, new FieldReference(field.Name, field.FieldType, field.DeclaringType));
     }
 }


### PR DESCRIPTION
Closes #198.