### PR TITLE
Warn when running approve-all.ps1 not in script mode

### DIFF
--- a/scripts/approve-all.ps1
+++ b/scripts/approve-all.ps1
@@ -5,8 +5,13 @@ param (
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Get-ChildItem -Recurse $SolutionRoot -Filter "*.received.txt" | ForEach-Object {
-    $receivedTestResult = $_.FullName
-    $approvedTestResult = $receivedTestResult.Replace('.received.txt', '.verified.txt')
-    Move-Item -Force -LiteralPath $receivedTestResult $approvedTestResult
+if (-Not $PSScriptRoot) {
+    Write-Error "\`$PSScriptRoot variable isn't set. Do you run this code as a script? Please, follow instructions at https://github.com/ForNeVeR/Cesium/blob/main/docs/tests.md"
+}
+else {
+    Get-ChildItem -Recurse $SolutionRoot -Filter "*.received.txt" | ForEach-Object {
+        $receivedTestResult = $_.FullName
+        $approvedTestResult = $receivedTestResult.Replace('.received.txt', '.verified.txt')
+        Move-Item -Force -LiteralPath $receivedTestResult $approvedTestResult
+    }
 }


### PR DESCRIPTION
I know for a fact that there is a person who tried to run `approve-all.ps1` script by copy-pasting it's code in PowerShell shell :grinning: The script by default relies on `$PSScriptRoot` variable, but PowerShell populates it only when running in script mode, i.e. 
`> powershell -c approve-all.ps1`. Otherwise, this variable is empty, and `$SolutionRoot` variable becomes `"/.."`.  As a result `Get-ChildItem` scans the whole disk recursively in search of  "*.received.txt" files which can be quite dangerous.

With this PR I try to detect cases when `$PSScriptRoot` has no meaningful value, warn user about it and essentially prevent execution of search.

As far as I know, aforementioned person had troubles with configuration of execution policy. Maybe it also makes sense to modify command in the [docs](https://github.com/ForNeVeR/Cesium/blob/main/docs/tests.md#unit-tests) by adding ExecutionPolicy parameter? Something like `$ pwsh -c ./scripts/approve-all.ps1 -ExecutionPolicy Bypass` should do the trick, I guess.