### PR TITLE
Document publish process for Cesium

### DIFF
--- a/Cesium.Compiler/Cesium.Compiler.csproj
+++ b/Cesium.Compiler/Cesium.Compiler.csproj
@@ -5,10 +5,8 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <PublishAot Condition="$(TargetFramework) == 'net7.0'">true</PublishAot>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <Version>0.0.0</Version>
+        <PublishSingleFile>true</PublishSingleFile>
+        <PublishTrimmed>true</PublishTrimmed>
     </PropertyGroup>
 
     <ItemGroup>
@@ -22,6 +20,7 @@
             <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
             <OutputItemType>Content</OutputItemType>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
             <Targets>Build</Targets>
         </ProjectReference>
         <ProjectReference Include="..\Cesium.Parser\Cesium.Parser.csproj" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,5 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
+        <VersionPrefix>0.0.1</VersionPrefix>
     </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ pwsh -c ./Cesium.IntegrationTests/Run-Tests.ps1 -TestCaseName quoted_include_fal
 
 where `quoted_include_fallback.c` is path within `Cesium.IntegrationTests` folder.
 
+Publishing
+----------
+
+For producing standalone compiler executable run
+
+```shell
+dotnet publish Cesium.Compiler/Cesium.Compiler.csproj -r win-x64 --self-contained
+```
+
+Then navigate to `Cesium.Compiler\bin\Debug\net6.0\win-x64\publish\` and that's your Cesium.
+
 Code Quality (Experimental)
 ------------
 


### PR DESCRIPTION
This produces executable which can be packed into SDK + tools Nugets.

I move version management to shared `Directory.Build.props` so versioning would apply to all projects.
Also I use `VersionPrefix` so it would be easier for us to add custom suffix in automated fashion. For example add `--version-suffix ci-123` will produce `0.0.1-ci-123` version.

Bump version to 0.0.1, for SDK+tools I would like to have at least some version.