### PR TITLE
Publishing of the compiler using MSBuild

### DIFF
--- a/Cesium.IntegrationTests/Cesium.IntegrationTests.proj
+++ b/Cesium.IntegrationTests/Cesium.IntegrationTests.proj
@@ -5,6 +5,17 @@
         <Content Include="Run-Tests.ps1" />
     </ItemGroup>
 
+    <!-- This allow run restore on project when use MSBuild task without warning -->
+    <Target Name="_IsProjectRestoreSupported"
+          Returns="@(_ValidProjectsForRestore)">
+
+        <ItemGroup>
+            <_ValidProjectsForRestore Include="$(MSBuildProjectFullPath)" />
+        </ItemGroup>
+    </Target>
+    <Target Name="Restore" />
     <Target Name="Build" />
     <Target Name="VSTest" />
+
+    <Import Project="../Directory.Build.targets" />
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,16 @@
+<Project>
+    <Target Name="PublishApp" Condition="'$(MSBuildThisFileDirectory)Cesium.Compiler\Cesium.Compiler.csproj' == '$(MSBuildProjectFullPath)'">
+        <PropertyGroup>
+            <_ResultDir>$(MSBuildThisFileDirectory)artifacts\bin\Compiler\</_ResultDir>
+            <TargetRuntimeIdentifier>win-x64</TargetRuntimeIdentifier>
+            <TargetPlatformTarget>x64</TargetPlatformTarget>
+        </PropertyGroup>
+
+        <MSBuild Projects="$(MSBuildThisFileDirectory)Cesium.Compiler\Cesium.Compiler.csproj" Targets="Restore"
+                 Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRuntimeIdentifier);PlatformTarget=$(TargetPlatformTarget)" />
+        <MSBuild Projects="$(MSBuildThisFileDirectory)Cesium.Compiler\Cesium.Compiler.csproj" Targets="Publish"
+                 Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRuntimeIdentifier);PlatformTarget=$(TargetPlatformTarget);PublishDir=$(_ResultDir)" />
+        <MSBuild Projects="$(MSBuildThisFileDirectory)Cesium.Runtime\Cesium.Runtime.csproj" Targets="Build"
+                 Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRuntimeIdentifier);PlatformTarget=$(TargetPlatformTarget);OutputPath=$(_ResultDir)" />
+    </Target>
+</Project>


### PR DESCRIPTION
This is same as #253 (and require changes in proj file from it) but for publishing
we using more modest `dotnet build . /t:PublishApp -c Release`
If expanding targets, we can ZIP, create SDK Nugets and perform other tasks