### PR TITLE
Add support for #else directive

### DIFF
--- a/Cesium.Parser.Tests/PreprocessorTests/PreprocessorTests.cs
+++ b/Cesium.Parser.Tests/PreprocessorTests/PreprocessorTests.cs
@@ -77,6 +77,27 @@ int foo() { return 0; }
 ");
 
     [Fact]
+    public Task IfElseLiteral() => DoTest(
+@"#define foo main
+#ifndef foo
+int myfoo() { return 0; }
+#else
+int foo() { return 0; }
+#endif
+");
+
+    [Fact]
+    public Task NestedIfDefined() => DoTest(
+@"#define foo main
+#ifdef foo
+int foo() { return 0; }
+#ifdef xfoo
+int foo() { return 0; }
+#endif
+#endif
+");
+
+    [Fact]
     public Task IfNotDefinedLiteral() => DoTest(
 @"#define foo main
 #ifndef foo

--- a/Cesium.Parser.Tests/PreprocessorTests/verified/PreprocessorTests.IfElseLiteral.verified.txt
+++ b/Cesium.Parser.Tests/PreprocessorTests/verified/PreprocessorTests.IfElseLiteral.verified.txt
@@ -1,0 +1,3 @@
+﻿
+int main() { return 0; }
+

--- a/Cesium.Parser.Tests/PreprocessorTests/verified/PreprocessorTests.NestedIfDefined.verified.txt
+++ b/Cesium.Parser.Tests/PreprocessorTests/verified/PreprocessorTests.NestedIfDefined.verified.txt
@@ -1,0 +1,4 @@
+﻿
+int main() { return 0; }
+
+

--- a/Cesium.Preprocessor/CPreprocessor.cs
+++ b/Cesium.Preprocessor/CPreprocessor.cs
@@ -226,6 +226,11 @@ public record CPreprocessor(ILexer<IToken<CPreprocessorTokenType>> Lexer, IInclu
                 IncludeTokens = true;
                 return Array.Empty<IToken<CPreprocessorTokenType>>();
             }
+            case "else":
+            {
+                IncludeTokens = !IncludeTokens;
+                return Array.Empty<IToken<CPreprocessorTokenType>>();
+            }
             default:
                 throw new WipException(
                     77,


### PR DESCRIPTION
Extend limits with signed/unsigned char options. By default MSVC/GCC/LLVM use signed char and you can enable unisnged char if you like using switch.

We can expose `-funsigned-char` switch using command line option afterwards.

Closes #250