### PR TITLE
Output all build files to single folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ obj/
 *.runtimeconfig.json
 *.received.txt
 *.user
+*.binlog
+artifacts/

--- a/Cesium.Compiler/Cesium.Compiler.csproj
+++ b/Cesium.Compiler/Cesium.Compiler.csproj
@@ -35,4 +35,9 @@
         <RdXmlFile Include="rd.xml" />
     </ItemGroup>
 
+    <Target Name="PublishZip" AfterTargets="Build">
+        <MakeDir Directories="$(ArtifactsShippingPackagesDir)" />
+        <ZipDirectory SourceDirectory="$(OutputPath)" DestinationFile="$(ArtifactsShippingPackagesDir)cesium-$(Version).zip" Overwrite="true" />
+    </Target>
+
 </Project>

--- a/Cesium.Runtime/Cesium.Runtime.csproj
+++ b/Cesium.Runtime/Cesium.Runtime.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <IsShippingPackage>true</IsShippingPackage>
+    <!-- Generate package during Build, rather than Pack, so that it can be used during Test. -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,4 +4,27 @@
         <WarningsAsErrors>nullable</WarningsAsErrors>
         <VersionPrefix>0.0.1</VersionPrefix>
     </PropertyGroup>
+
+    <PropertyGroup Label="Build">
+        <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+        <RepoRoot Condition="'$(RepoRoot)' == ''">$([MSBuild]::NormalizeDirectory('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Cesium.sln'))'))</RepoRoot>
+        <ArtifactsDir Condition="'$(ArtifactsDir)' == ''">$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts'))</ArtifactsDir>
+        <ArtifactsObjDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'obj'))</ArtifactsObjDir>
+        <ArtifactsBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'bin'))</ArtifactsBinDir>
+        <ArtifactsLogDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'log', '$(Configuration)'))</ArtifactsLogDir>
+        <ArtifactsTmpDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'tmp', '$(Configuration)'))</ArtifactsTmpDir>
+        <ArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'packages', '$(Configuration)'))</ArtifactsPackagesDir>
+        <ArtifactsShippingPackagesDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsPackagesDir)', 'Shipping'))</ArtifactsShippingPackagesDir>
+        <ArtifactsNonShippingPackagesDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsPackagesDir)', 'NonShipping'))</ArtifactsNonShippingPackagesDir>
+
+        <OutDirName Condition="'$(OutDirName)' == ''">$(MSBuildProjectName)</OutDirName>
+
+        <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)$(OutDirName)\'))</BaseOutputPath>
+        <OutputPath Condition="'$(PlatformName)' == 'AnyCPU'">$(BaseOutputPath)$(Configuration)\</OutputPath>
+        <OutputPath Condition="'$(PlatformName)' != 'AnyCPU'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
+
+        <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(ArtifactsObjDir)$(OutDirName)\'))</BaseIntermediateOutputPath>
+        <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU'">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+        <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
+    </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+    <PropertyGroup Label="Build">
+        <PackageOutputPath Condition="'$(IsShippingPackage)' == 'true'">$(ArtifactsShippingPackagesDir)</PackageOutputPath>
+        <PackageOutputPath Condition="'$(IsShippingPackage)' != 'true'">$(ArtifactsNonShippingPackagesDir)</PackageOutputPath>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
That gives nice property that someone can nuke all build artifacts just by deliting folder, but also allows easier testing Nuget packages, since all of them would be stored in same `artifacts\packages\$(Configuration)\Shipping` folder for example.

Also add ZIP distribution for the compiler. At this point this file can be safely published and distributed, and if someone have .NET 6 installed, can see the glory of current Cesium.