### PR TITLE
Add typecast expression

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
@@ -80,6 +80,8 @@ int main()
     [Fact] public Task Parameter5Get() => DoTest("int foo(int a, int b, int c, int d, int e){ return e + 1; }");
     [Fact] public Task CharConstTest() => DoTest("int main() { char x = '\\t'; return 42; }");
     [Fact] public Task DoubleConstTest() => DoTest("int main() { double x = 1.5; return 42; }");
+    [Fact] public Task FloatConstTest() => DoTest("int main() { float x = 1.5f; return 42; }");
+    [Fact] public Task FloatConstTest2() => DoTest("int main() { float x = 1.5; return 42; }");
 
     [Fact] public Task MultiDeclaration() => DoTest("int main() { int x = 0, y = 2 + 2; }");
 

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FloatConstTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FloatConstTest.verified.txt
@@ -1,0 +1,17 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Single V_0
+  IL_0000: ldc.r4 1.5
+  IL_0005: stloc.0
+  IL_0006: ldc.i4.s 42
+  IL_0008: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FloatConstTest2.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FloatConstTest2.verified.txt
@@ -1,0 +1,18 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Single V_0
+  IL_0000: ldc.r8 1.5
+  IL_0009: conv.r4
+  IL_000a: stloc.0
+  IL_000b: ldc.i4.s 42
+  IL_000d: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.PrimitiveTypes.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.PrimitiveTypes.verified.txt
@@ -42,53 +42,55 @@
   IL_000b: ldc.i4.0
   IL_000c: stloc.s V_5
   IL_000e: ldc.i4.0
-  IL_000f: stloc.s V_6
-  IL_0011: ldc.i4.0
-  IL_0012: stloc.s V_7
-  IL_0014: ldc.i4.0
-  IL_0015: stloc.s V_8
-  IL_0017: ldc.i4.0
-  IL_0018: stloc.s V_9
-  IL_001a: ldc.i4.0
-  IL_001b: stloc.s V_10
-  IL_001d: ldc.i4.0
-  IL_001e: stloc.s V_11
-  IL_0020: ldc.i4.0
-  IL_0021: stloc.s V_12
-  IL_0023: ldc.i4.0
-  IL_0024: stloc.s V_13
-  IL_0026: ldc.i4.0
-  IL_0027: stloc.s V_14
-  IL_0029: ldc.i4.0
-  IL_002a: stloc.s V_15
-  IL_002c: ldc.i4.0
-  IL_002d: stloc.s V_16
-  IL_002f: ldc.i4.0
-  IL_0030: stloc.s V_17
-  IL_0032: ldc.i4.0
-  IL_0033: stloc.s V_18
-  IL_0035: ldc.i4.0
-  IL_0036: stloc.s V_19
-  IL_0038: ldc.i4.0
-  IL_0039: stloc.s V_20
-  IL_003b: ldc.i4.0
-  IL_003c: stloc.s V_21
-  IL_003e: ldc.i4.0
-  IL_003f: stloc.s V_22
-  IL_0041: ldc.i4.0
-  IL_0042: stloc.s V_23
-  IL_0044: ldc.i4.0
-  IL_0045: stloc.s V_24
-  IL_0047: ldc.i4.0
-  IL_0048: stloc.s V_25
-  IL_004a: ldc.i4.0
-  IL_004b: stloc.s V_26
-  IL_004d: ldc.i4.0
-  IL_004e: stloc.s V_27
-  IL_0050: ldc.i4.0
-  IL_0051: stloc.s V_28
-  IL_0053: ldc.i4.0
-  IL_0054: ret
+  IL_000f: conv.r4
+  IL_0010: stloc.s V_6
+  IL_0012: ldc.i4.0
+  IL_0013: conv.r8
+  IL_0014: stloc.s V_7
+  IL_0016: ldc.i4.0
+  IL_0017: stloc.s V_8
+  IL_0019: ldc.i4.0
+  IL_001a: stloc.s V_9
+  IL_001c: ldc.i4.0
+  IL_001d: stloc.s V_10
+  IL_001f: ldc.i4.0
+  IL_0020: stloc.s V_11
+  IL_0022: ldc.i4.0
+  IL_0023: stloc.s V_12
+  IL_0025: ldc.i4.0
+  IL_0026: stloc.s V_13
+  IL_0028: ldc.i4.0
+  IL_0029: stloc.s V_14
+  IL_002b: ldc.i4.0
+  IL_002c: stloc.s V_15
+  IL_002e: ldc.i4.0
+  IL_002f: stloc.s V_16
+  IL_0031: ldc.i4.0
+  IL_0032: stloc.s V_17
+  IL_0034: ldc.i4.0
+  IL_0035: stloc.s V_18
+  IL_0037: ldc.i4.0
+  IL_0038: stloc.s V_19
+  IL_003a: ldc.i4.0
+  IL_003b: stloc.s V_20
+  IL_003d: ldc.i4.0
+  IL_003e: stloc.s V_21
+  IL_0040: ldc.i4.0
+  IL_0041: stloc.s V_22
+  IL_0043: ldc.i4.0
+  IL_0044: stloc.s V_23
+  IL_0046: ldc.i4.0
+  IL_0047: stloc.s V_24
+  IL_0049: ldc.i4.0
+  IL_004a: stloc.s V_25
+  IL_004c: ldc.i4.0
+  IL_004d: stloc.s V_26
+  IL_004f: ldc.i4.0
+  IL_0050: stloc.s V_27
+  IL_0052: ldc.i4.0
+  IL_0053: stloc.s V_28
+  IL_0055: ldc.i4.0
+  IL_0056: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen/Ir/BlockItems/DeclarationBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/DeclarationBlockItem.cs
@@ -84,20 +84,20 @@ internal class DeclarationBlockItem : IBlockItem
                     arrayType.EmitInitializer(scope);
                     break;
                 default:
-                    var initialierExpression = initializer;
-                    if (initialierExpression != null)
+                    var initializerExpression = initializer;
+                    if (initializerExpression != null)
                     {
                         // This should be part of lowering process
                         // But because lowering process does not have access to type-system, I place this bandaid.
-                        // also I do think that during lowering process initalizer expression should be extracted into separate
+                        // also I do think that during lowering process initializer expression should be extracted into separate
                         // AssignmentExpression, so we do not duplicate this conversion logic everywhere.
-                        if (scope.CTypeSystem.IsConversionAvailable(initialierExpression.GetExpressionType(scope), type))
+                        if (scope.CTypeSystem.IsConversionAvailable(initializerExpression.GetExpressionType(scope), type))
                         {
-                            initialierExpression = new TypeCastExpression(type, initialierExpression);
+                            initializerExpression = new TypeCastExpression(type, initializerExpression);
                         }
                     }
 
-                    initialierExpression?.EmitTo(scope);
+                    initializerExpression?.EmitTo(scope);
                     break;
             }
 

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BinaryOperatorExpression.cs
@@ -31,17 +31,12 @@ internal abstract class BinaryOperatorExpression : IExpression
     public abstract IType GetExpressionType(IDeclarationScope scope);
     public abstract void EmitTo(IDeclarationScope scope);
 
-    protected void EmitConversion(IDeclarationScope scope, IType exprType, IType desiredType)
+    internal static void EmitConversion(IDeclarationScope scope, IType exprType, IType desiredType)
     {
-        if (exprType.IsEqualTo(desiredType)
-            || (scope.CTypeSystem.IsBool(exprType) && scope.CTypeSystem.IsInteger(desiredType))
-            || (scope.CTypeSystem.IsBool(desiredType) && scope.CTypeSystem.IsInteger(exprType)))
+        if (!scope.CTypeSystem.IsConversionRequired(exprType, desiredType))
             return;
 
         var ts = scope.CTypeSystem;
-        if(!ts.IsNumeric(exprType))
-            throw new CompilationException($"Conversion from {exprType} to {desiredType} is not supported.");
-
         if(desiredType.Equals(ts.SignedChar))
             Add(OpCodes.Conv_I1);
         else if(desiredType.Equals(ts.Short))
@@ -63,7 +58,7 @@ internal abstract class BinaryOperatorExpression : IExpression
         else if (desiredType.Equals(ts.Double))
             Add(OpCodes.Conv_R8);
         else
-            throw new CompilationException($"Conversion from {exprType} to {desiredType} is not supported.");
+            throw new AssertException($"Conversion from {exprType} to {desiredType} is not supported.");
 
         void Add(OpCode op) => scope.Method.Body.Instructions.Add(Instruction.Create(op));
     }

--- a/Cesium.CodeGen/Ir/Expressions/ConstantExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/ConstantExpression.cs
@@ -2,6 +2,7 @@ using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Ir.Expressions.Constants;
 using Cesium.CodeGen.Ir.Types;
 using Cesium.Core;
+using System.Globalization;
 using Yoakke.SynKit.C.Syntax;
 
 namespace Cesium.CodeGen.Ir.Expressions;
@@ -35,8 +36,28 @@ internal class ConstantExpression : IExpression
             CTokenType.IntLiteral => new IntegerConstant(constant.Text),
             CTokenType.CharLiteral => new CharConstant(constant.Text),
             CTokenType.StringLiteral => new StringConstant(constant),
-            CTokenType.FloatLiteral => new FloatingPointConstant(constant.Text),
+            CTokenType.FloatLiteral => ParseFloatingPoint(constant.Text),
             _ => throw new WipException(228, $"Constant of kind {constant.Kind} is not supported.")
         };
+    }
+
+    private static IConstant ParseFloatingPoint(string value)
+    {
+        if (value.EndsWith('f'))
+        {
+            if (!float.TryParse(value.AsSpan().Slice(0, value.Length - 1), NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out var floatValue))
+            {
+                throw new CompilationException($"Value {value} is too large to fit into float");
+            }
+
+            return new FloatingPointConstant(floatValue, true);
+        }
+        else
+        {
+            if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out var doubleValue))
+                throw new CompilationException($"Cannot parse a double literal: {value}.");
+
+            return new FloatingPointConstant(doubleValue, false);
+        }
     }
 }

--- a/Cesium.CodeGen/Ir/Expressions/Constants/FloatingPointConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/FloatingPointConstant.cs
@@ -1,7 +1,5 @@
-using System.Globalization;
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Ir.Types;
-using Cesium.Core;
 using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Constants;
@@ -9,20 +7,27 @@ namespace Cesium.CodeGen.Ir.Expressions.Constants;
 internal class FloatingPointConstant : IConstant
 {
     private readonly double _value;
+    private readonly bool _isFloat;
 
-    public FloatingPointConstant(string value)
+    public FloatingPointConstant(double value, bool isFloat)
     {
-        if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out _value))
-            throw new CompilationException($"Cannot parse a double literal: {value}.");
+        _value = value;
+        _isFloat = isFloat;
     }
 
     public void EmitTo(IDeclarationScope scope)
     {
-        // TODO[#248]: This should support `float` as well.
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldc_R8, _value));
+        if (_isFloat)
+        {
+            scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldc_R4, (float)_value));
+        }
+        else
+        {
+            scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldc_R8, _value));
+        }
     }
 
-    public IType GetConstantType(IDeclarationScope scope) => scope.CTypeSystem.Double;
+    public IType GetConstantType(IDeclarationScope scope) => _isFloat ? scope.CTypeSystem.Float : scope.CTypeSystem.Double;
 
-    public override string ToString() => $"double: {_value}";
+    public override string ToString() => $"{(_isFloat ? "float" : "double")}: {_value}";
 }

--- a/Cesium.CodeGen/Ir/Expressions/TypeCastExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/TypeCastExpression.cs
@@ -1,0 +1,27 @@
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Ir.Expressions.BinaryOperators;
+using Cesium.CodeGen.Ir.Types;
+
+namespace Cesium.CodeGen.Ir.Expressions;
+
+internal sealed class TypeCastExpression : IExpression
+{
+    private IType _targetType;
+    private IExpression _expression;
+
+    public TypeCastExpression(IType targetType, IExpression expression)
+    {
+        _targetType = targetType;
+        _expression = expression;
+    }
+
+    public void EmitTo(IDeclarationScope scope)
+    {
+        _expression.EmitTo(scope);
+        BinaryOperatorExpression.EmitConversion(scope, _expression.GetExpressionType(scope), _targetType);
+    }
+
+    public IType GetExpressionType(IDeclarationScope scope) => _targetType;
+
+    public IExpression Lower() => this;
+}

--- a/Cesium.CodeGen/Ir/Types/CTypeSystem.cs
+++ b/Cesium.CodeGen/Ir/Types/CTypeSystem.cs
@@ -1,4 +1,7 @@
+using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Extensions;
+using Cesium.Core;
+using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Types;
 
@@ -16,4 +19,72 @@ internal class CTypeSystem
     public IType CharPtr { get; } = new PrimitiveType(PrimitiveTypeKind.Char).MakePointerType();
     public IType Float { get; } = new PrimitiveType(PrimitiveTypeKind.Float);
     public IType Double { get; } = new PrimitiveType(PrimitiveTypeKind.Double);
+
+    public bool IsConversionAvailable(IType type, IType targetType)
+    {
+        if (type.IsEqualTo(targetType)
+            || (this.IsBool(type) && this.IsInteger(targetType))
+            || (this.IsBool(targetType) && this.IsInteger(type)))
+            return true;
+
+        if (!this.IsNumeric(type))
+            return false;
+
+        if (targetType.Equals(SignedChar))
+            return true;
+        else if (targetType.Equals(Short))
+            return true;
+        else if (targetType.Equals(Int))
+            return true;
+        else if (targetType.Equals(Long))
+            return true;
+        else if (targetType.Equals(Char))
+            return true;
+        else if (targetType.Equals(UnsignedShort))
+            return true;
+        else if (targetType.Equals(UnsignedInt))
+            return true;
+        else if (targetType.Equals(UnsignedLong))
+            return true;
+        else if (targetType.Equals(Float))
+            return true;
+        else if (targetType.Equals(Double))
+            return true;
+        else
+            return false;
+    }
+
+    internal bool IsConversionRequired(IType type, IType targetType)
+    {
+        if (type.IsEqualTo(targetType)
+            || (this.IsBool(type) && this.IsInteger(targetType))
+            || (this.IsBool(targetType) && this.IsInteger(type)))
+            return false;
+
+        if (!this.IsNumeric(type))
+            throw new CompilationException($"Conversion from {type} to {targetType} is not supported.");
+
+        if (targetType.Equals(SignedChar))
+            return true;
+        else if (targetType.Equals(Short))
+            return true;
+        else if (targetType.Equals(Int))
+            return true;
+        else if (targetType.Equals(Long))
+            return true;
+        else if (targetType.Equals(Char))
+            return true;
+        else if (targetType.Equals(UnsignedShort))
+            return true;
+        else if (targetType.Equals(UnsignedInt))
+            return true;
+        else if (targetType.Equals(UnsignedLong))
+            return true;
+        else if (targetType.Equals(Float))
+            return true;
+        else if (targetType.Equals(Double))
+            return true;
+        else
+            throw new CompilationException($"Conversion from {type} to {targetType} is not supported.");
+    }
 }

--- a/Cesium.IntegrationTests/float.c
+++ b/Cesium.IntegrationTests/float.c
@@ -1,0 +1,10 @@
+
+int main(void)
+{
+    float f = 1.0;
+    double d = 1.0;
+    float f2 = 1.0f;
+
+    float f3 = 1.0 + 2.0;
+    return 42;
+}

--- a/Cesium.Parser.Tests/ParserTests/FullParserTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/FullParserTests.cs
@@ -95,6 +95,14 @@ int main()
 }");
 
     [Fact]
+    public Task FloatingPointLiteral() => DoTest(@"int main()
+{
+    float f1 = 1.0;
+    float f2 = 1.0f;
+    long doubld ld1 = 1.0l;
+}");
+
+    [Fact]
     public Task NegationTest() => DoTest("void foo() { int x = -42; }");
 
     [Fact]

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.FloatingPointLiteral.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.FloatingPointLiteral.verified.txt
@@ -1,0 +1,136 @@
+﻿{
+  "$type": "Cesium.Ast.TranslationUnit, Cesium.Ast",
+  "Declarations": [
+    {
+      "$type": "Cesium.Ast.FunctionDefinition, Cesium.Ast",
+      "Specifiers": [
+        {
+          "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+          "TypeName": "int"
+        }
+      ],
+      "Declarator": {
+        "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+        "Pointer": null,
+        "DirectDeclarator": {
+          "$type": "Cesium.Ast.IdentifierListDirectDeclarator, Cesium.Ast",
+          "Base": {
+            "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+            "Identifier": "main",
+            "Base": null
+          },
+          "Identifiers": null
+        }
+      },
+      "Declarations": null,
+      "Statement": {
+        "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",
+        "Block": [
+          {
+            "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+            "Specifiers": [
+              {
+                "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                "TypeName": "float"
+              }
+            ],
+            "InitDeclarators": [
+              {
+                "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+                "Declarator": {
+                  "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                  "Pointer": null,
+                  "DirectDeclarator": {
+                    "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                    "Identifier": "f1",
+                    "Base": null
+                  }
+                },
+                "Initializer": {
+                  "$type": "Cesium.Ast.AssignmentInitializer, Cesium.Ast",
+                  "Expression": {
+                    "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                    "Constant": {
+                      "Kind": "FloatLiteral",
+                      "Text": "1.0"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+            "Specifiers": [
+              {
+                "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                "TypeName": "float"
+              }
+            ],
+            "InitDeclarators": [
+              {
+                "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+                "Declarator": {
+                  "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                  "Pointer": null,
+                  "DirectDeclarator": {
+                    "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                    "Identifier": "f2",
+                    "Base": null
+                  }
+                },
+                "Initializer": {
+                  "$type": "Cesium.Ast.AssignmentInitializer, Cesium.Ast",
+                  "Expression": {
+                    "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                    "Constant": {
+                      "Kind": "FloatLiteral",
+                      "Text": "1.0f"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "$type": "Cesium.Ast.Declaration, Cesium.Ast",
+            "Specifiers": [
+              {
+                "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+                "TypeName": "long"
+              },
+              {
+                "$type": "Cesium.Ast.NamedTypeSpecifier, Cesium.Ast",
+                "TypeDefName": "doubld"
+              }
+            ],
+            "InitDeclarators": [
+              {
+                "$type": "Cesium.Ast.InitDeclarator, Cesium.Ast",
+                "Declarator": {
+                  "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+                  "Pointer": null,
+                  "DirectDeclarator": {
+                    "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+                    "Identifier": "ld1",
+                    "Base": null
+                  }
+                },
+                "Initializer": {
+                  "$type": "Cesium.Ast.AssignmentInitializer, Cesium.Ast",
+                  "Expression": {
+                    "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+                    "Constant": {
+                      "Kind": "FloatLiteral",
+                      "Text": "1.0l"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Make typecast explicit operation in the IR.
- Due to fact that `IDeclarationScope` is inaccessible during Lower call. I put explicit typecasts during emit phase. That require subsequet changes in `IExpression` interface and possible in the `ToIntermediate` as well.
- `BinaryOperatorExpression.EmitConversion` consult now `CTypeSystem`, I plan to remove that method altogether and replace it by insertion of corresponding `TypeCastExpression` when needed.
- Changes in `PrimitiveTypes` test is artifact of typecast insertion. Once constant evaluation would start appearing, I expect changes in these area again. Same for `FloatConstTest2`, it will emit ldc.r4 becasue `(float)1.5` would be folded directly to `1.5f`

I did not close #246 with that PR because I need to invest in more tests for conversions, and rework of `ArithmeticBinaryOperatorExpression` to insert `TypeCastExpression`. Basically I expect during lowering following conversion `IntConstant(1) + CharConstant('c')` => `IntegerConstant(1) + IntegerConstant(99)`, but introduction of `TypeCastExpression` is allow to work on that issue.

Closes: #243