### PR TITLE
Split emit and declaration scopes

### DIFF
--- a/Cesium.CodeGen/Contexts/ForScope.cs
+++ b/Cesium.CodeGen/Contexts/ForScope.cs
@@ -7,16 +7,16 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Contexts;
 
-internal record ForScope(IDeclarationScope Parent) : IDeclarationScope
+internal record ForScope(IEmitScope Parent) : IEmitScope
 {
     public AssemblyContext AssemblyContext => Parent.AssemblyContext;
     public ModuleDefinition Module => Parent.Module;
-    public TypeSystem TypeSystem => Parent.TypeSystem;
     public CTypeSystem CTypeSystem => Parent.CTypeSystem;
     public IReadOnlyDictionary<string, FunctionInfo> Functions => Parent.Functions;
     public TranslationUnitContext Context => Parent.Context;
     public MethodDefinition Method => Parent.Method;
     public IReadOnlyDictionary<string, IType> Variables => Parent.Variables; // no declarations for `for` now, so pass parent variables
+    public IReadOnlyDictionary<string, IType> GlobalFields => Parent.GlobalFields;
     public void AddVariable(string identifier, IType variable) =>
         throw new WipException(205, "Variable addition into a for loop scope is not implemented, yet.");
     public VariableDefinition ResolveVariable(string identifier) => Parent.ResolveVariable(identifier); // no declarations for `for` now, so pass parent variables

--- a/Cesium.CodeGen/Contexts/FunctionScope.cs
+++ b/Cesium.CodeGen/Contexts/FunctionScope.cs
@@ -7,7 +7,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Contexts;
 
-internal record FunctionScope(TranslationUnitContext Context, FunctionInfo FunctionInfo, MethodDefinition Method) : IDeclarationScope
+internal record FunctionScope(TranslationUnitContext Context, FunctionInfo FunctionInfo, MethodDefinition Method) : IEmitScope
 {
     public AssemblyContext AssemblyContext => Context.AssemblyContext;
     public ModuleDefinition Module => Context.Module;
@@ -18,6 +18,7 @@ internal record FunctionScope(TranslationUnitContext Context, FunctionInfo Funct
     private readonly Dictionary<string, IType> _variables = new();
     private readonly Dictionary<string, VariableDefinition> _variableDefinition = new();
     public IReadOnlyDictionary<string, IType> Variables => _variables;
+    public IReadOnlyDictionary<string, IType> GlobalFields => AssemblyContext.GlobalFields;
     public void AddVariable(string identifier, IType variable) => _variables.Add(identifier, variable);
     public VariableDefinition ResolveVariable(string identifier)
     {

--- a/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
+++ b/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
@@ -8,13 +8,14 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Contexts;
 
-internal record GlobalConstructorScope(TranslationUnitContext Context, MethodDefinition Method) : IDeclarationScope
+internal record GlobalConstructorScope(TranslationUnitContext Context, MethodDefinition Method) : IEmitScope
 {
     public AssemblyContext AssemblyContext => Context.AssemblyContext;
     public ModuleDefinition Module => Context.Module;
     public TypeSystem TypeSystem => Module.TypeSystem;
     public CTypeSystem CTypeSystem => Context.CTypeSystem;
     public IReadOnlyDictionary<string, FunctionInfo> Functions => Context.Functions;
+    public IReadOnlyDictionary<string, IType> GlobalFields => AssemblyContext.GlobalFields;
 
     public IReadOnlyDictionary<string, IType> Variables => ImmutableDictionary<string, IType>.Empty;
     public void AddVariable(string identifier, IType variable) =>

--- a/Cesium.CodeGen/Contexts/IDeclarationScope.cs
+++ b/Cesium.CodeGen/Contexts/IDeclarationScope.cs
@@ -2,22 +2,16 @@ using Cesium.CodeGen.Contexts.Meta;
 using Cesium.CodeGen.Ir;
 using Cesium.CodeGen.Ir.Types;
 using Mono.Cecil;
-using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Contexts;
 
 internal interface IDeclarationScope
 {
-    AssemblyContext AssemblyContext { get; }
-    ModuleDefinition Module { get; }
-    TypeSystem TypeSystem { get; }
+
     CTypeSystem CTypeSystem { get; }
     IReadOnlyDictionary<string, FunctionInfo> Functions { get; }
-    TranslationUnitContext Context { get; }
-    MethodDefinition Method { get; }
     IReadOnlyDictionary<string, IType> Variables { get; }
+    IReadOnlyDictionary<string, IType> GlobalFields { get; }
     void AddVariable(string identifier, IType variable);
-    VariableDefinition ResolveVariable(string identifier);
     ParameterInfo? GetParameterInfo(string name);
-    ParameterDefinition ResolveParameter(string name);
 }

--- a/Cesium.CodeGen/Contexts/IEmitScope.cs
+++ b/Cesium.CodeGen/Contexts/IEmitScope.cs
@@ -1,0 +1,14 @@
+namespace Cesium.CodeGen.Contexts;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+internal interface IEmitScope : IDeclarationScope
+{
+    MethodDefinition Method { get; }
+    AssemblyContext AssemblyContext { get; }
+    ModuleDefinition Module { get; }
+    TranslationUnitContext Context { get; }
+    VariableDefinition ResolveVariable(string identifier);
+    ParameterDefinition ResolveParameter(string name);
+}

--- a/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
+++ b/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
@@ -15,13 +15,13 @@ public record TranslationUnitContext(AssemblyContext AssemblyContext)
 
     internal Dictionary<string, FunctionInfo> Functions => AssemblyContext.Functions;
 
-    private IDeclarationScope? _initializerScope;
+    private IEmitScope? _initializerScope;
 
     /// <remarks>
     /// Architecturally, there's only one global initializer at the assembly level. But every translation unit may have
     /// its own set of definitions and thus its own initializer scope built around the same method body.
     /// </remarks>
-    internal IDeclarationScope GetInitializerScope() =>
+    internal IEmitScope GetInitializerScope() =>
         _initializerScope ??= new GlobalConstructorScope(this, AssemblyContext.GetGlobalInitializer());
 
     private readonly Dictionary<IGeneratedType, TypeReference> _generatedTypes = new();

--- a/Cesium.CodeGen/Extensions/CodeGenEx.cs
+++ b/Cesium.CodeGen/Extensions/CodeGenEx.cs
@@ -6,10 +6,10 @@ namespace Cesium.CodeGen.Extensions;
 
 internal static class CodeGenEx
 {
-    private static void AddInstruction(this IDeclarationScope scope, Instruction instruction) =>
+    private static void AddInstruction(this IEmitScope scope, Instruction instruction) =>
         scope.Method.Body.Instructions.Add(instruction);
 
-    public static void StLoc(this IDeclarationScope scope, VariableDefinition variable)
+    public static void StLoc(this IEmitScope scope, VariableDefinition variable)
     {
         scope.AddInstruction(variable.Index switch
         {
@@ -22,22 +22,22 @@ internal static class CodeGenEx
         });
     }
 
-    public static void LdSFld(this IDeclarationScope scope, FieldReference field)
+    public static void LdSFld(this IEmitScope scope, FieldReference field)
     {
         scope.AddInstruction(Instruction.Create(OpCodes.Ldsfld, field));
     }
 
-    public static void LdSFldA(this IDeclarationScope scope, FieldReference field)
+    public static void LdSFldA(this IEmitScope scope, FieldReference field)
     {
         scope.AddInstruction(Instruction.Create(OpCodes.Ldsflda, field));
     }
 
-    public static void StSFld(this IDeclarationScope scope, FieldReference field)
+    public static void StSFld(this IEmitScope scope, FieldReference field)
     {
         scope.AddInstruction(Instruction.Create(OpCodes.Stsfld, field));
     }
 
-    public static void LdFtn(this IDeclarationScope scope, MethodReference method)
+    public static void LdFtn(this IEmitScope scope, MethodReference method)
     {
         scope.AddInstruction(Instruction.Create(OpCodes.Ldftn, method));
     }

--- a/Cesium.CodeGen/Ir/BlockItems/AmbiguousBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/AmbiguousBlockItem.cs
@@ -26,7 +26,7 @@ internal class AmbiguousBlockItem : IBlockItem
 
     public IBlockItem Lower(IDeclarationScope scope) => this;
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         // Check if this can be a valid variable declaration:
         var typeReference = scope.Context.GetTypeReference(_item1);
@@ -50,12 +50,12 @@ internal class AmbiguousBlockItem : IBlockItem
                 $" but it's ambiguous which it is, since both a function and a type of name {_item1} exist.");
     }
 
-    private void EmitVariableDeclaration(IDeclarationScope scope)
+    private void EmitVariableDeclaration(IEmitScope scope)
     {
         throw new WipException(213, "Ambiguous variable declarations aren't supported, yet.");
     }
 
-    private void EmitFunctionCall(IDeclarationScope scope)
+    private void EmitFunctionCall(IEmitScope scope)
     {
         CToken CreateFakeToken(string id) => new(new Range(), id, new Range(), id, CTokenType.Identifier);
 

--- a/Cesium.CodeGen/Ir/BlockItems/BreakStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/BreakStatement.cs
@@ -8,7 +8,7 @@ internal class BreakStatement : IBlockItem
 {
     public IBlockItem Lower(IDeclarationScope scope) => this;
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         if (scope is not ForScope forScope)
             throw new CompilationException("Can't break not from for statement");

--- a/Cesium.CodeGen/Ir/BlockItems/CompoundStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/CompoundStatement.cs
@@ -21,7 +21,7 @@ internal class CompoundStatement : IBlockItem
 
     public IBlockItem Lower(IDeclarationScope scope) => this; // since actual lowering of child items is done on emit, anyway
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         foreach (var item in _items)
         {

--- a/Cesium.CodeGen/Ir/BlockItems/DeclarationBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/DeclarationBlockItem.cs
@@ -43,7 +43,7 @@ internal class DeclarationBlockItem : IBlockItem
     }
 
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         switch (_declaration)
         {
@@ -58,7 +58,7 @@ internal class DeclarationBlockItem : IBlockItem
         }
     }
 
-    private static void EmitScopedIdentifier(IDeclarationScope scope, ScopedIdentifierDeclaration scopedDeclaration)
+    private static void EmitScopedIdentifier(IEmitScope scope, ScopedIdentifierDeclaration scopedDeclaration)
     {
         scopedDeclaration.Deconstruct(out var declarations);
         foreach (var (declaration, initializer) in declarations)

--- a/Cesium.CodeGen/Ir/BlockItems/ExpressionStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ExpressionStatement.cs
@@ -17,5 +17,5 @@ internal class ExpressionStatement : IBlockItem
     }
 
     public IBlockItem Lower(IDeclarationScope scope) => new ExpressionStatement(_expression?.Lower(scope));
-    public void EmitTo(IDeclarationScope scope) => _expression?.EmitTo(scope);
+    public void EmitTo(IEmitScope scope) => _expression?.EmitTo(scope);
 }

--- a/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
@@ -45,7 +45,7 @@ internal class ForStatement : IBlockItem
 
     bool IBlockItem.HasDefiniteReturn => _body.HasDefiniteReturn;
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         var forScope = new ForScope(scope);
 

--- a/Cesium.CodeGen/Ir/BlockItems/IBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/IBlockItem.cs
@@ -7,5 +7,5 @@ internal interface IBlockItem
     bool HasDefiniteReturn => false;
 
     IBlockItem Lower(IDeclarationScope scope);
-    void EmitTo(IDeclarationScope scope);
+    void EmitTo(IEmitScope scope);
 }

--- a/Cesium.CodeGen/Ir/BlockItems/IfElseStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/IfElseStatement.cs
@@ -30,7 +30,7 @@ internal class IfElseStatement : IBlockItem
 
     public IBlockItem Lower(IDeclarationScope scope) => new IfElseStatement(_expression.Lower(scope), _trueBranch.Lower(scope), _falseBranch?.Lower(scope));
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         var bodyProcessor = scope.Method.Body.GetILProcessor();
         var ifFalseLabel = bodyProcessor.Create(OpCodes.Nop);

--- a/Cesium.CodeGen/Ir/BlockItems/ReturnStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ReturnStatement.cs
@@ -23,7 +23,7 @@ internal class ReturnStatement : IBlockItem
 
     public IBlockItem Lower(IDeclarationScope scope) => new ReturnStatement(_expression.Lower(scope));
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         _expression.EmitTo(scope);
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));

--- a/Cesium.CodeGen/Ir/Expressions/AssignmentExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/AssignmentExpression.cs
@@ -50,7 +50,7 @@ internal class AssignmentExpression : BinaryOperatorExpression
         return new AssignmentExpression(left, BinaryOperator.Assign, right);
     }
 
-    public override void EmitTo(IDeclarationScope scope)
+    public override void EmitTo(IEmitScope scope)
     {
         if (Operator != BinaryOperator.Assign)
             throw new AssertException($"Operator {Operator} should've been lowered before emitting.");

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperators/ArithmeticBinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperators/ArithmeticBinaryOperatorExpression.cs
@@ -72,7 +72,7 @@ internal class ArithmeticBinaryOperatorExpression: BinaryOperatorExpression
         return new ArithmeticBinaryOperatorExpression(left, Operator, right);
     }
 
-    public override void EmitTo(IDeclarationScope scope)
+    public override void EmitTo(IEmitScope scope)
     {
         Left.EmitTo(scope);
         Right.EmitTo(scope);

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BinaryOperatorExpression.cs
@@ -29,7 +29,7 @@ internal abstract class BinaryOperatorExpression : IExpression
 
     public abstract IExpression Lower(IDeclarationScope scope);
     public abstract IType GetExpressionType(IDeclarationScope scope);
-    public abstract void EmitTo(IDeclarationScope scope);
+    public abstract void EmitTo(IEmitScope scope);
 
     private static BinaryOperator GetOperatorKind(string @operator) => @operator switch
     {

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BitwiseBinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BitwiseBinaryOperatorExpression.cs
@@ -22,7 +22,7 @@ internal class BitwiseBinaryOperatorExpression: BinaryOperatorExpression
 
     public override IExpression Lower(IDeclarationScope scope) => new BitwiseBinaryOperatorExpression(Left.Lower(scope), Operator, Right.Lower(scope));
 
-    public override void EmitTo(IDeclarationScope scope)
+    public override void EmitTo(IEmitScope scope)
     {
         Left.EmitTo(scope);
         Right.EmitTo(scope);

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperators/ComparisonBinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperators/ComparisonBinaryOperatorExpression.cs
@@ -66,7 +66,7 @@ internal class ComparisonBinaryOperatorExpression: BinaryOperatorExpression
         };
     }
 
-    public override void EmitTo(IDeclarationScope scope)
+    public override void EmitTo(IEmitScope scope)
     {
         Left.EmitTo(scope);
         Right.EmitTo(scope);

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperators/LogicalBinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperators/LogicalBinaryOperatorExpression.cs
@@ -21,7 +21,7 @@ internal class LogicalBinaryOperatorExpression : BinaryOperatorExpression
 
     public override IExpression Lower(IDeclarationScope scope) => new LogicalBinaryOperatorExpression(Left.Lower(scope), Operator, Right.Lower(scope));
 
-    public override void EmitTo(IDeclarationScope scope)
+    public override void EmitTo(IEmitScope scope)
     {
         switch (Operator)
         {
@@ -38,7 +38,7 @@ internal class LogicalBinaryOperatorExpression : BinaryOperatorExpression
 
     public override IType GetExpressionType(IDeclarationScope scope) => scope.CTypeSystem.Bool;
 
-    private void EmitLogicalAnd(IDeclarationScope scope)
+    private void EmitLogicalAnd(IEmitScope scope)
     {
         var bodyProcessor = scope.Method.Body.GetILProcessor();
         var fastExitLabel = bodyProcessor.Create(OpCodes.Ldc_I4_0);
@@ -58,7 +58,7 @@ internal class LogicalBinaryOperatorExpression : BinaryOperatorExpression
         bodyProcessor.Append(exitLabel);
     }
 
-    private void EmitLogicalOr(IDeclarationScope scope)
+    private void EmitLogicalOr(IEmitScope scope)
     {
         var bodyProcessor = scope.Method.Body.GetILProcessor();
         var fastExitLabel = bodyProcessor.Create(OpCodes.Ldc_I4_1);

--- a/Cesium.CodeGen/Ir/Expressions/ConstantExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/ConstantExpression.cs
@@ -22,7 +22,7 @@ internal class ConstantExpression : IExpression
 
     public IExpression Lower(IDeclarationScope scope) => this;
 
-    public void EmitTo(IDeclarationScope scope) => _constant.EmitTo(scope);
+    public void EmitTo(IEmitScope scope) => _constant.EmitTo(scope);
 
     public IType GetExpressionType(IDeclarationScope scope) => _constant.GetConstantType(scope);
 

--- a/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
@@ -14,7 +14,7 @@ internal class CharConstant : IConstant
         _value = checked((byte)UnescapeCharacter(value));
     }
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         var instructions = scope.Method.Body.Instructions;
         instructions.Add(Instruction.Create(OpCodes.Ldc_I4_S, (sbyte) _value));

--- a/Cesium.CodeGen/Ir/Expressions/Constants/FloatingPointConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/FloatingPointConstant.cs
@@ -15,7 +15,7 @@ internal class FloatingPointConstant : IConstant
         _isFloat = isFloat;
     }
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         if (_isFloat)
         {

--- a/Cesium.CodeGen/Ir/Expressions/Constants/IConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/IConstant.cs
@@ -5,7 +5,7 @@ namespace Cesium.CodeGen.Ir.Expressions.Constants;
 
 internal interface IConstant
 {
-    void EmitTo(IDeclarationScope scope);
+    void EmitTo(IEmitScope scope);
 
     IType GetConstantType(IDeclarationScope scope);
 }

--- a/Cesium.CodeGen/Ir/Expressions/Constants/IntegerConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/IntegerConstant.cs
@@ -20,7 +20,7 @@ internal class IntegerConstant : IConstant
         _value = value;
     }
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         scope.Method.Body.Instructions.Add(_value switch
         {

--- a/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
@@ -18,7 +18,7 @@ internal class StringConstant : IConstant
         _value = token.UnwrapStringLiteral();
     }
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         var fieldReference = scope.AssemblyContext.GetConstantPoolReference(_value);
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldsflda, fieldReference));

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -33,7 +33,7 @@ internal class FunctionCallExpression : IExpression
         (IdentifierExpression)_function.Lower(scope),
         _arguments.Select(a => a.Lower(scope)).ToList());
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         foreach (var argument in _arguments)
             argument.EmitTo(scope);

--- a/Cesium.CodeGen/Ir/Expressions/IExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IExpression.cs
@@ -6,6 +6,6 @@ namespace Cesium.CodeGen.Ir.Expressions;
 internal interface IExpression
 {
     IExpression Lower(IDeclarationScope scope);
-    void EmitTo(IDeclarationScope scope);
+    void EmitTo(IEmitScope scope);
     IType GetExpressionType(IDeclarationScope scope);
 }

--- a/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
@@ -32,7 +32,7 @@ internal class IdentifierExpression : IExpression, IValueExpression
 
     public IExpression Lower(IDeclarationScope scope) => this;
 
-    public void EmitTo(IDeclarationScope scope) => Resolve(scope).EmitGetValue(scope);
+    public void EmitTo(IEmitScope scope) => Resolve(scope).EmitGetValue(scope);
 
     public IType GetExpressionType(IDeclarationScope scope) => Resolve(scope).GetValueType();
 
@@ -41,7 +41,7 @@ internal class IdentifierExpression : IExpression, IValueExpression
         scope.Variables.TryGetValue(Identifier, out var var);
         scope.Functions.TryGetValue(Identifier, out FunctionInfo? fun);
         var par = scope.GetParameterInfo(Identifier);
-        scope.Context.AssemblyContext.GlobalFields.TryGetValue(Identifier, out var globalType);
+        scope.GlobalFields.TryGetValue(Identifier, out var globalType);
 
         if (var is not null && par is not null)
             throw new CompilationException($"Variable {Identifier} is both available as a local and as a function parameter.");
@@ -54,14 +54,12 @@ internal class IdentifierExpression : IExpression, IValueExpression
 
         if (var is not null)
         {
-            var variableDefinition = scope.ResolveVariable(Identifier);
-            return new LValueLocalVariable(var, variableDefinition);
+            return new LValueLocalVariable(var, Identifier);
         }
 
         if (par is not null)
         {
-            var parameterInfo = scope.ResolveParameter(Identifier);
-            return new LValueParameter(par, parameterInfo);
+            return new LValueParameter(par);
         }
 
         if (fun is not null)
@@ -71,8 +69,7 @@ internal class IdentifierExpression : IExpression, IValueExpression
 
         if (globalType != null)
         {
-            var globalField = scope.Context.AssemblyContext.ResolveGlobalField(Identifier, scope.Context);
-            return new LValueGlobalVariable(globalType, globalField);
+            return new LValueGlobalVariable(globalType, Identifier);
         }
 
         throw new CompilationException($"Cannot find a local variable, a function parameter, a global variable or a function {Identifier}.");

--- a/Cesium.CodeGen/Ir/Expressions/IndirectionExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IndirectionExpression.cs
@@ -23,7 +23,7 @@ internal class IndirectionExpression : IExpression, IValueExpression
 
     public IExpression Lower(IDeclarationScope scope) => new IndirectionExpression(_target.Lower(scope));
 
-    public void EmitTo(IDeclarationScope scope) => Resolve(scope).EmitGetValue(scope);
+    public void EmitTo(IEmitScope scope) => Resolve(scope).EmitGetValue(scope);
 
     public IType GetExpressionType(IDeclarationScope scope) => Resolve(scope).GetValueType();
 

--- a/Cesium.CodeGen/Ir/Expressions/MemberAccessExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/MemberAccessExpression.cs
@@ -29,7 +29,7 @@ internal class MemberAccessExpression : IExpression, IValueExpression
             new UnaryOperatorExpression(UnaryOperator.AddressOf, _target.Lower(scope)),
             _memberIdentifier.Lower(scope));
 
-    public void EmitTo(IDeclarationScope scope) => throw new AssertException("Should be lowered");
+    public void EmitTo(IEmitScope scope) => throw new AssertException("Should be lowered");
 
     public IType GetExpressionType(IDeclarationScope scope) => throw new AssertException("Should be lowered");
 

--- a/Cesium.CodeGen/Ir/Expressions/PointerMemberAccessExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/PointerMemberAccessExpression.cs
@@ -28,9 +28,9 @@ internal class PointerMemberAccessExpression : IExpression, IValueExpression
     public IExpression Lower(IDeclarationScope scope)
         => new PointerMemberAccessExpression(_target.Lower(scope), _memberIdentifier.Lower(scope));
 
-    public void EmitTo(IDeclarationScope scope) => Resolve(scope).EmitGetValue(scope);
+    public void EmitTo(IEmitScope scope) => Resolve(scope).EmitGetValue(scope);
 
-    public IType GetExpressionType(IDeclarationScope scope) => Resolve(scope).GetValueType();
+    public IType GetExpressionType(IDeclarationScope scope) => _target.GetExpressionType(scope);
 
     public IValue Resolve(IDeclarationScope scope)
     {
@@ -38,12 +38,6 @@ internal class PointerMemberAccessExpression : IExpression, IValueExpression
             throw new CompilationException($"\"{_memberIdentifier}\" is not a valid identifier");
 
         var valueType = _target.GetExpressionType(scope);
-        var valueTypeReference = valueType.Resolve(scope.Context);
-        var valueTypeDef = valueTypeReference.Resolve();
-
-        var field = valueTypeDef.Fields.FirstOrDefault(f => f?.Name == memberIdentifier.Identifier)
-                    ?? throw new CompilationException(
-                        $"\"{valueTypeDef.Name}\" has no member named \"{memberIdentifier.Identifier}\"");
-        return new LValueField(_target, valueType, new FieldReference(field.Name, field.FieldType, field.DeclaringType));
+        return new LValueField(_target, valueType, memberIdentifier.Identifier);
     }
 }

--- a/Cesium.CodeGen/Ir/Expressions/PrefixIncrementExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/PrefixIncrementExpression.cs
@@ -30,7 +30,7 @@ internal class PrefixIncrementExpression : IExpression
         );
     }
 
-    public void EmitTo(IDeclarationScope scope) => throw new AssertException("Should be lowered");
+    public void EmitTo(IEmitScope scope) => throw new AssertException("Should be lowered");
 
     public IType GetExpressionType(IDeclarationScope scope) => _target.GetExpressionType(scope);
 }

--- a/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
@@ -27,7 +27,7 @@ internal class SubscriptingExpression : IExpression, IValueExpression
     public IExpression Lower(IDeclarationScope scope)
         => new SubscriptingExpression(_expression.Lower(scope), _index.Lower(scope));
 
-    public void EmitTo(IDeclarationScope scope) => Resolve(scope).EmitGetValue(scope);
+    public void EmitTo(IEmitScope scope) => Resolve(scope).EmitGetValue(scope);
 
     public IType GetExpressionType(IDeclarationScope scope) => Resolve(scope).GetValueType();
 

--- a/Cesium.CodeGen/Ir/Expressions/TypeCastExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/TypeCastExpression.cs
@@ -18,7 +18,7 @@ internal sealed class TypeCastExpression : IExpression
         _expression = expression;
     }
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         _expression.EmitTo(scope);
         var expressionType = _expression.GetExpressionType(scope);

--- a/Cesium.CodeGen/Ir/Expressions/UnaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/UnaryOperatorExpression.cs
@@ -28,7 +28,7 @@ internal class UnaryOperatorExpression : IExpression
 
     public IExpression Lower(IDeclarationScope scope) => new UnaryOperatorExpression(_operator, _target.Lower(scope));
 
-    public void EmitTo(IDeclarationScope scope)
+    public void EmitTo(IEmitScope scope)
     {
         switch (_operator)
         {

--- a/Cesium.CodeGen/Ir/Expressions/Values/FunctionValue.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/FunctionValue.cs
@@ -18,12 +18,12 @@ internal class FunctionValue : IAddressableValue
         _methodReference = methodReference;
     }
 
-    public void EmitGetValue(IDeclarationScope scope)
+    public void EmitGetValue(IEmitScope scope)
     {
         throw new WipException(227, "Cannot directly get a value of a function, yet.");
     }
 
-    public void EmitGetAddress(IDeclarationScope scope)
+    public void EmitGetAddress(IEmitScope scope)
     {
         scope.LdFtn(_methodReference);
     }

--- a/Cesium.CodeGen/Ir/Expressions/Values/IValue.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/IValue.cs
@@ -5,7 +5,7 @@ namespace Cesium.CodeGen.Ir.Expressions.Values;
 
 internal interface IValue
 {
-    void EmitGetValue(IDeclarationScope scope);
+    void EmitGetValue(IEmitScope scope);
     IType GetValueType();
 }
 
@@ -14,10 +14,10 @@ internal interface IValue
 /// </remarks>
 internal interface IAddressableValue : IValue
 {
-    void EmitGetAddress(IDeclarationScope scope);
+    void EmitGetAddress(IEmitScope scope);
 }
 
 internal interface ILValue : IAddressableValue
 {
-    void EmitSetValue(IDeclarationScope scope, IExpression value);
+    void EmitSetValue(IEmitScope scope, IExpression value);
 }

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueArrayElement.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueArrayElement.cs
@@ -16,7 +16,7 @@ internal class LValueArrayElement : ILValue
         _index = index;
     }
 
-    public void EmitGetValue(IDeclarationScope scope)
+    public void EmitGetValue(IEmitScope scope)
     {
         EmitPointerMoveToElement(scope);
 
@@ -24,12 +24,12 @@ internal class LValueArrayElement : ILValue
         scope.Method.Body.GetILProcessor().Emit(loadOp);
     }
 
-    public void EmitGetAddress(IDeclarationScope scope)
+    public void EmitGetAddress(IEmitScope scope)
     {
         EmitPointerMoveToElement(scope);
     }
 
-    public void EmitSetValue(IDeclarationScope scope, IExpression value)
+    public void EmitSetValue(IEmitScope scope, IExpression value)
     {
         EmitPointerMoveToElement(scope);
         value.EmitTo(scope);
@@ -51,7 +51,7 @@ internal class LValueArrayElement : ILValue
         return (PrimitiveType)type.Base;
     }
 
-    private void EmitPointerMoveToElement(IDeclarationScope scope)
+    private void EmitPointerMoveToElement(IEmitScope scope)
     {
         _array.EmitGetValue(scope);
         _index.EmitTo(scope);

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueField.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueField.cs
@@ -1,5 +1,6 @@
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Ir.Types;
+using Cesium.Core;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
@@ -8,34 +9,56 @@ namespace Cesium.CodeGen.Ir.Expressions.Values;
 internal class LValueField : ILValue
 {
     private readonly IExpression _expression;
-    private readonly FieldReference _field;
     private readonly IType _fieldType;
+    private readonly string _name;
+    private FieldReference? _field;
 
-    public LValueField(IExpression expression, IType fieldType, FieldReference field)
+    public LValueField(IExpression expression, IType fieldType, string name)
     {
         _expression = expression;
         _fieldType = fieldType;
-        _field = field;
+        _name = name;
     }
 
-    public void EmitGetValue(IDeclarationScope scope)
+    public void EmitGetValue(IEmitScope scope)
     {
+        var field = GetField(scope);
         _expression.EmitTo(scope);
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldfld, _field));
+        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldfld, field));
     }
 
-    public void EmitGetAddress(IDeclarationScope scope)
+    public void EmitGetAddress(IEmitScope scope)
     {
+        var field = GetField(scope);
         _expression.EmitTo(scope);
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldflda, _field));
+        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldflda, field));
     }
 
-    public void EmitSetValue(IDeclarationScope scope, IExpression value)
+    public void EmitSetValue(IEmitScope scope, IExpression value)
     {
+        var field = GetField(scope);
         _expression.EmitTo(scope);
         value.EmitTo(scope);
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Stfld, _field));
+        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Stfld, field));
     }
 
     public IType GetValueType() => _fieldType;
+
+    private FieldReference GetField(IEmitScope scope)
+    {
+        if (_field != null)
+        {
+            return _field;
+        }
+
+        var valueType = _expression.GetExpressionType(scope);
+        var valueTypeReference = valueType.Resolve(scope.Context);
+        var valueTypeDef = valueTypeReference.Resolve();
+
+        var field = valueTypeDef.Fields.FirstOrDefault(f => f?.Name == _name)
+                ?? throw new CompilationException(
+                    $"\"{valueTypeDef.Name}\" has no member named \"{_name}\"");
+        _field = new FieldReference(field.Name, field.FieldType, field.DeclaringType);
+        return _field;
+    }
 }

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueGlobalVariable.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueGlobalVariable.cs
@@ -8,26 +8,38 @@ namespace Cesium.CodeGen.Ir.Expressions.Values
     internal class LValueGlobalVariable : ILValue
     {
         private readonly IType _type;
-        private readonly FieldDefinition _definition;
+        private readonly string _name;
+        private FieldDefinition? _definition;
 
-        public LValueGlobalVariable(IType type, FieldDefinition definition)
+        public LValueGlobalVariable(IType type, string name)
         {
             _type = type;
-            _definition = definition;
+            _name = name;
         }
 
-        public void EmitGetValue(IDeclarationScope scope) =>
-            scope.LdSFld(_definition);
+        public void EmitGetValue(IEmitScope scope) =>
+            scope.LdSFld(GetVariableDefinition(scope));
 
-        public void EmitGetAddress(IDeclarationScope scope) =>
-            scope.LdSFldA(_definition);
+        public void EmitGetAddress(IEmitScope scope) =>
+            scope.LdSFldA(GetVariableDefinition(scope));
 
-        public void EmitSetValue(IDeclarationScope scope, IExpression value)
+        public void EmitSetValue(IEmitScope scope, IExpression value)
         {
             value.EmitTo(scope);
-            scope.StSFld(_definition);
+            scope.StSFld(GetVariableDefinition(scope));
         }
 
         public IType GetValueType() => _type;
+
+        private FieldDefinition GetVariableDefinition(IEmitScope scope)
+        {
+            if (_definition != null)
+            {
+                return _definition;
+            }
+
+            _definition = scope.Context.AssemblyContext.ResolveGlobalField(_name, scope.Context);
+            return _definition;
+        }
     }
 }

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueIndirection.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueIndirection.cs
@@ -16,16 +16,16 @@ internal class LValueIndirection : ILValue
         _pointerType = pointerType;
     }
 
-    public void EmitGetValue(IDeclarationScope scope)
+    public void EmitGetValue(IEmitScope scope)
     {
         _pointerExpression.EmitTo(scope);
         var (load, _) = GetOpcodes(_pointerType);
         scope.Method.Body.Instructions.Add(Instruction.Create(load));
     }
 
-    public void EmitGetAddress(IDeclarationScope scope) => _pointerExpression.EmitTo(scope);
+    public void EmitGetAddress(IEmitScope scope) => _pointerExpression.EmitTo(scope);
 
-    public void EmitSetValue(IDeclarationScope scope, IExpression value)
+    public void EmitSetValue(IEmitScope scope, IExpression value)
     {
         _pointerExpression.EmitTo(scope);
         value.EmitTo(scope);

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueLocalVariable.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueLocalVariable.cs
@@ -53,14 +53,6 @@ internal class LValueLocalVariable : ILValue
 
     public IType GetValueType() => _variableType;
 
-    private VariableDefinition GetVariableDefinition(IEmitScope scope)
-    {
-        if (_definition != null)
-        {
-            return _definition;
-        }
-
-        _definition = scope.ResolveVariable(_name);
-        return _definition;
-    }
+    private VariableDefinition GetVariableDefinition(IEmitScope scope) =>
+        _definition ??= scope.ResolveVariable(_name);
 }

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueParameter.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueParameter.cs
@@ -1,5 +1,6 @@
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Ir.Types;
+using Cesium.Core;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
@@ -7,41 +8,54 @@ namespace Cesium.CodeGen.Ir.Expressions.Values;
 
 internal class LValueParameter : ILValue
 {
-    private readonly ParameterDefinition _definition;
     private readonly ParameterInfo _parameterInfo;
-    public LValueParameter(ParameterInfo parameterInfo, ParameterDefinition definition)
+    private ParameterDefinition? _definition;
+    public LValueParameter(ParameterInfo parameterInfo)
     {
         _parameterInfo = parameterInfo;
-        _definition = definition;
     }
 
-    public void EmitGetValue(IDeclarationScope scope)
+    public void EmitGetValue(IEmitScope scope)
     {
-        scope.Method.Body.Instructions.Add(_definition.Index switch
+        var parameterDefinition = GetParameterDefinition(scope);
+        scope.Method.Body.Instructions.Add(parameterDefinition.Index switch
         {
             0 => Instruction.Create(OpCodes.Ldarg_0),
             1 => Instruction.Create(OpCodes.Ldarg_1),
             2 => Instruction.Create(OpCodes.Ldarg_2),
             3 => Instruction.Create(OpCodes.Ldarg_3),
-            <= byte.MaxValue => Instruction.Create(OpCodes.Ldarg_S, _definition),
-            _ => Instruction.Create(OpCodes.Ldarg, _definition)
+            <= byte.MaxValue => Instruction.Create(OpCodes.Ldarg_S, parameterDefinition),
+            _ => Instruction.Create(OpCodes.Ldarg, parameterDefinition)
         });
     }
 
-    public void EmitGetAddress(IDeclarationScope scope)
+    public void EmitGetAddress(IEmitScope scope)
     {
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldarga, _definition));
+        var parameterDefinition = GetParameterDefinition(scope);
+        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldarga, parameterDefinition));
     }
 
-    public void EmitSetValue(IDeclarationScope scope, IExpression value)
+    public void EmitSetValue(IEmitScope scope, IExpression value)
     {
+        var parameterDefinition = GetParameterDefinition(scope);
         value.EmitTo(scope);
 
-        scope.Method.Body.Instructions.Add(_definition.Index switch
+        scope.Method.Body.Instructions.Add(parameterDefinition.Index switch
         {
-            <= byte.MaxValue => Instruction.Create(OpCodes.Starg_S, _definition),
-            _ => Instruction.Create(OpCodes.Starg, _definition)
+            <= byte.MaxValue => Instruction.Create(OpCodes.Starg_S, parameterDefinition),
+            _ => Instruction.Create(OpCodes.Starg, parameterDefinition)
         });
+    }
+    private ParameterDefinition GetParameterDefinition(IEmitScope scope)
+    {
+        if (_definition != null)
+        {
+            return _definition;
+        }
+
+        var parameterName = _parameterInfo.Name ?? throw new AssertException("Name of parameter does not specified");
+        _definition = scope.ResolveParameter(parameterName);
+        return _definition;
     }
 
     public IType GetValueType() => _parameterInfo.Type;

--- a/Cesium.CodeGen/Ir/Types/InPlaceArrayType.cs
+++ b/Cesium.CodeGen/Ir/Types/InPlaceArrayType.cs
@@ -44,7 +44,7 @@ internal record InPlaceArrayType(IType Base, int Size) : IType
         }
     }
 
-    public void EmitInitializer(IDeclarationScope scope)
+    public void EmitInitializer(IEmitScope scope)
     {
         if (Base is not PrimitiveType)
             throw new WipException(232, $"Array of complex type specifiers aren't supported, yet: {Base}");


### PR DESCRIPTION
- All IL related stuff should be in Emit scope
- Declaration scope should operate only on IR model.

Food for thoughts:
Inheritance relationship between IEmitScope and IDeclaration scope probably not needed. 
IValue is leaky abstraction, since it operates at emit level, but not at compile time level. That triggers compilation error much later in the compilation process, at the emit level, but it should be at Lower call or earlier. There should be one more step where types and identifiers would be resolved as per suggestion. Reason why this is needed - NamedType which has only identifier, but instead of should perform lookup on type in the global alias table and not inside assembly.

Moving towards: #201