### PR TITLE
TypeDef as block item

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenTestBase.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTestBase.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Cesium.CodeGen.Contexts;
-using Cesium.CodeGen.Extensions;
 using Cesium.Core;
 using Cesium.Parser;
 using Cesium.Test.Framework;
@@ -66,7 +65,7 @@ public abstract class CodeGenTestBase : VerifyTestBase
             if (parser.TokenStream.Peek().Kind != CTokenType.End)
                 throw new ParseException($"Excessive output after the end of a translation unit at {lexer.Position}.");
 
-            context.EmitTranslationUnit(translationUnit.Ok.Value.ToIntermediate());
+            context.EmitTranslationUnit(translationUnit.Ok.Value);
         }
     }
 

--- a/Cesium.CodeGen/Contexts/AssemblyContext.cs
+++ b/Cesium.CodeGen/Contexts/AssemblyContext.cs
@@ -39,8 +39,9 @@ public class AssemblyContext
         return assemblyContext;
     }
 
-    public void EmitTranslationUnit(IEnumerable<ITopLevelNode> nodes)
+    public void EmitTranslationUnit(Ast.TranslationUnit translationUnit)
     {
+        IEnumerable<ITopLevelNode> nodes = translationUnit.ToIntermediate();
         var context = new TranslationUnitContext(this);
         foreach (var node in nodes)
             node.EmitTo(context);

--- a/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
+++ b/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
@@ -8,11 +8,14 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Contexts;
 
-internal record GlobalConstructorScope(TranslationUnitContext Context, MethodDefinition Method) : IEmitScope, IDeclarationScope
+internal record GlobalConstructorScope(TranslationUnitContext Context) : IEmitScope, IDeclarationScope
 {
+    private MethodDefinition? _method;
     public AssemblyContext AssemblyContext => Context.AssemblyContext;
     public ModuleDefinition Module => Context.Module;
     public TypeSystem TypeSystem => Module.TypeSystem;
+
+    public MethodDefinition Method => _method ??= Context.AssemblyContext.GetGlobalInitializer();
     public CTypeSystem CTypeSystem => Context.CTypeSystem;
     public IReadOnlyDictionary<string, FunctionInfo> Functions => Context.Functions;
     public IReadOnlyDictionary<string, IType> GlobalFields => AssemblyContext.GlobalFields;

--- a/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
+++ b/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
@@ -22,7 +22,7 @@ public record TranslationUnitContext(AssemblyContext AssemblyContext)
     /// its own set of definitions and thus its own initializer scope built around the same method body.
     /// </remarks>
     internal GlobalConstructorScope GetInitializerScope() =>
-        _initializerScope ??= new GlobalConstructorScope(this, AssemblyContext.GetGlobalInitializer());
+        _initializerScope ??= new GlobalConstructorScope(this);
 
     private readonly Dictionary<IGeneratedType, TypeReference> _generatedTypes = new();
     private readonly Dictionary<string, TypeReference> _types = new();

--- a/Cesium.CodeGen/Extensions/TranslationUnitEx.cs
+++ b/Cesium.CodeGen/Extensions/TranslationUnitEx.cs
@@ -5,7 +5,7 @@ using FunctionDefinition = Cesium.CodeGen.Ir.TopLevel.FunctionDefinition;
 
 namespace Cesium.CodeGen.Extensions;
 
-public static class TranslationUnitEx
+internal static class TranslationUnitEx
 {
     public static IEnumerable<ITopLevelNode> ToIntermediate(this TranslationUnit translationUnit) =>
         translationUnit.Declarations.Select(x => (ITopLevelNode)(x switch

--- a/Cesium.CodeGen/Ir/BlockItems/DeclarationBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/DeclarationBlockItem.cs
@@ -11,7 +11,7 @@ namespace Cesium.CodeGen.Ir.BlockItems;
 internal class DeclarationBlockItem : IBlockItem
 {
     private readonly IScopedDeclarationInfo _declaration;
-    private DeclarationBlockItem(IScopedDeclarationInfo declaration)
+    internal DeclarationBlockItem(IScopedDeclarationInfo declaration)
     {
         _declaration = declaration;
     }
@@ -60,7 +60,8 @@ internal class DeclarationBlockItem : IBlockItem
 
                 return new DeclarationBlockItem(new ScopedIdentifierDeclaration(newItems));
             }
-            case TypeDefDeclaration: return this;
+            case TypeDefDeclaration typeDefDeclaration:
+                return new TypeDefBlockItem(typeDefDeclaration);
             default: throw new WipException(212, $"Unknown kind of declaration: {_declaration}.");
         }
     }
@@ -74,8 +75,7 @@ internal class DeclarationBlockItem : IBlockItem
                 EmitScopedIdentifier(scope, declaration);
                 break;
             case TypeDefDeclaration declaration:
-                EmitTypeDef(declaration);
-                break;
+                throw new AssertException("Should be lowered");
             default:
                 throw new WipException(212, $"Unknown kind of declaration: {_declaration}.");
         }
@@ -103,7 +103,4 @@ internal class DeclarationBlockItem : IBlockItem
             scope.StLoc(variable);
         }
     }
-
-    private static void EmitTypeDef(TypeDefDeclaration declaration) =>
-        throw new WipException(214, $"typedef is not supported at block level, yet: {declaration}.");
 }

--- a/Cesium.CodeGen/Ir/BlockItems/TypeDefBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/TypeDefBlockItem.cs
@@ -1,0 +1,40 @@
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Ir.Declarations;
+using Cesium.CodeGen.Ir.Types;
+using Cesium.Core;
+
+namespace Cesium.CodeGen.Ir.BlockItems;
+
+internal class TypeDefBlockItem : IBlockItem
+{
+    private readonly TypeDefDeclaration _declaration;
+
+    public TypeDefBlockItem(TypeDefDeclaration declaration)
+    {
+        _declaration = declaration;
+    }
+
+    public IBlockItem Lower(IDeclarationScope scope)
+    {
+        return this;
+    }
+
+    public void EmitTo(IEmitScope scope)
+    {
+        _declaration.Deconstruct(out var types);
+        foreach (var typeDef in types)
+        {
+            var (type, identifier, cliImportMemberName) = typeDef;
+            if (identifier == null)
+                throw new CompilationException($"Anonymous typedef not supported: {type}.");
+
+            if (cliImportMemberName != null)
+                throw new CompilationException($"typedef for CLI import not supported: {cliImportMemberName}.");
+
+            if (type is IGeneratedType t)
+                scope.Context.GenerateType(t, identifier);
+            else
+                scope.Context.AddPlainType(type, identifier);
+        }
+    }
+}

--- a/Cesium.Compiler/Compilation.cs
+++ b/Cesium.Compiler/Compilation.cs
@@ -82,7 +82,7 @@ internal static class Compilation
         if (parser.TokenStream.Peek().Kind != CTokenType.End)
             throw new ParseException($"Excessive output after the end of a translation unit {inputFilePath} at {lexer.Position}.");
 
-        context.EmitTranslationUnit(translationUnit.ToIntermediate());
+        context.EmitTranslationUnit(translationUnit);
     }
 
     private static void SaveAssembly(


### PR DESCRIPTION
IDeclarationScope is internal, so I have to shake code a bit.
Lazy instantiation of global initialization method needed if I want to have lowering, otherwise that produce noise in the tests.
Actual addition of lowering is blocked by fact that decarations and ITopNode tightly coupled, so I cannot extract one simple thing.
Also create BlockItem node for TypeDef declarations. That step towards #214, and most likely allow have NamedTypes to point to real types, and not type names of the CLR projection