### PR TITLE
Add declarations for stddef.h

### DIFF
--- a/Cesium.CodeGen/Ir/Declarations/LocalDeclarationInfo.cs
+++ b/Cesium.CodeGen/Ir/Declarations/LocalDeclarationInfo.cs
@@ -303,6 +303,7 @@ internal record LocalDeclarationInfo(
                 ("long", null, null, null) => PrimitiveTypeKind.Long,
                 ("float", null, null, null) => PrimitiveTypeKind.Float,
                 ("double", null, null, null) => PrimitiveTypeKind.Double,
+                ("__nint", null, null, null) => PrimitiveTypeKind.NativeInt,
                 _ => throw new WipException(
                     224,
                     $"Simple type specifiers are not supported: {string.Join(" ", typeNames)}"),

--- a/Cesium.Compiler/stdlib/stddef.h
+++ b/Cesium.Compiler/stdlib/stddef.h
@@ -1,0 +1,8 @@
+typedef __nint ptrdiff_t;
+typedef unsigned int size_t;
+
+typedef unsigned int max_align_t;
+
+typedef unsigned short wchar_t;
+
+#define NULL ((void*)0)


### PR DESCRIPTION
- exposes nint type. That's Cesium specific type which maps to `System.IntPtr`. That allow implement `ptrdiff_t`, `intptr_t` and `uintptr_t` in unified manner.
- `offsetof` does not implemented. See #276