### PR TITLE
Primitive support for varargs

### DIFF
--- a/Cesium.CodeGen/Extensions/CodeGenEx.cs
+++ b/Cesium.CodeGen/Extensions/CodeGenEx.cs
@@ -8,6 +8,14 @@ internal static class CodeGenEx
 {
     private static void AddInstruction(this IEmitScope scope, Instruction instruction) =>
         scope.Method.Body.Instructions.Add(instruction);
+    public static void AddInstruction(this IEmitScope scope, OpCode opCode) =>
+        scope.Method.Body.Instructions.Add(Instruction.Create(opCode));
+    public static void AddInstruction(this IEmitScope scope, OpCode opCode, int value) =>
+        scope.Method.Body.Instructions.Add(Instruction.Create(opCode, value));
+    public static void AddInstruction(this IEmitScope scope, OpCode opCode, TypeReference value) =>
+        scope.Method.Body.Instructions.Add(Instruction.Create(opCode, value));
+    public static void AddInstruction(this IEmitScope scope, OpCode opCode, MethodReference value) =>
+        scope.Method.Body.Instructions.Add(Instruction.Create(opCode, value));
 
     public static void StLoc(this IEmitScope scope, VariableDefinition variable)
     {

--- a/Cesium.CodeGen/Extensions/TypeSystemEx.cs
+++ b/Cesium.CodeGen/Extensions/TypeSystemEx.cs
@@ -110,10 +110,15 @@ internal static class TypeSystemEx
         {
             var lastSrcParam = methodParameters.Last();
             var paramsAttrType = context.GetParamArrayAttributeType();
-            if (lastSrcParam.ParameterType.IsArray == false
-                || lastSrcParam.CustomAttributes.Any(x => x.AttributeType == paramsAttrType) == false)
+            if (lastSrcParam.ParameterType.IsArray == false)
             {
-                similarMethods.Add((method, $"Signature does not match: accepts variadic arguments in declaration, but not in source."));
+                similarMethods.Add((method, $"Signature does not match: accepts variadic arguments in declaration, but not in source. Last parameter is not an array."));
+                return false;
+            }
+
+            if (lastSrcParam.CustomAttributes.Any(x => x.AttributeType.IsEqualTo(paramsAttrType)) == false)
+            {
+                similarMethods.Add((method, $"Signature does not match: accepts variadic arguments in declaration, but not in source. Last parameter has not {paramsAttrType}"));
                 return false;
             }
         }

--- a/Cesium.Compiler/stdlib/stdio.h
+++ b/Cesium.Compiler/stdlib/stdio.h
@@ -1,5 +1,5 @@
 __cli_import("Cesium.Runtime.StdIoFunctions::PutS")
 void puts(char *s); // TODO[#156]: Change to int
 
-__cli_import("Cesium.Runtime.StdIoFunctions::PutS")
-void printf(char* s);
+__cli_import("Cesium.Runtime.StdIoFunctions::PrintF")
+void printf(char* s, ...);

--- a/Cesium.IntegrationTests/stdlib/printf.c
+++ b/Cesium.IntegrationTests/stdlib/printf.c
@@ -9,6 +9,7 @@ int main(int argc, char *argv[])
     float myFloatNum = 5.99;   // Floating point number
     char myLetter = 'D';       // Character
 
+    printf("%s\n", "myNum");
     // Print variables
     //printf("%d\n", myNum);
     //printf("%f\n", myFloatNum);

--- a/Cesium.Parser/TokenExtensions.cs
+++ b/Cesium.Parser/TokenExtensions.cs
@@ -12,6 +12,6 @@ public static class TokenExtensions
             throw new ParseException($"Non-string literal token: {token.Kind} {token.Text}");
 
         // TODO[#235]: More thorough unwrap for more literal types.
-        return token.Text.Trim('"');
+        return token.Text.Trim('"').Replace("\\n", "\n");
     }
 }

--- a/Cesium.Runtime/StdIoFunctions.cs
+++ b/Cesium.Runtime/StdIoFunctions.cs
@@ -45,6 +45,8 @@ public unsafe static class StdIoFunctions
                     Console.Write(Unmarshal((byte*)(IntPtr)varargs[consumedArgs]));
                     consumedArgs++;
                     break;
+                default:
+                    throw new FormatException($"Format specifier {formatSpecifier} is not supported");
             }
 
             currentPosition = formatStartPosition + 2;

--- a/Cesium.Runtime/StdIoFunctions.cs
+++ b/Cesium.Runtime/StdIoFunctions.cs
@@ -1,5 +1,7 @@
 using System.Runtime.InteropServices;
+#if NETSTANDARD
 using System.Text;
+#endif
 
 namespace Cesium.Runtime;
 
@@ -12,27 +14,7 @@ public unsafe static class StdIoFunctions
     {
         try
         {
-#if NETSTANDARD
-            Encoding encoding = Encoding.UTF8;
-            int byteLength = 0;
-            byte* search = str;
-            while (*search != '\0')
-            {
-                byteLength++;
-                search++;
-            }
-
-            int stringLength = encoding.GetCharCount(str, byteLength);
-            string s = new string('\0', stringLength);
-            fixed (char* pTempChars = s)
-            {
-                encoding.GetChars(str, byteLength, pTempChars, stringLength);
-            }
-
-            Console.Write(s);
-#else
-            Console.Write(Marshal.PtrToStringUTF8((nint)str));
-#endif
+            Console.Write(Unmarshal(str));
             // return 0; // TODO[#156]: Uncomment
         }
         catch (Exception) // TODO[#154]: Exception handling.
@@ -40,5 +22,60 @@ public unsafe static class StdIoFunctions
             const int EOF = -1; // TODO[#155]: Extract to some common place.
             // return EOF; // TODO[#156]: Uncomment
         }
+    }
+
+    public static void PrintF(byte* str, params object[] varargs)
+    {
+        var formatString = Unmarshal(str);
+        if (formatString == null)
+        {
+            return;
+        }
+
+        int currentPosition = 0;
+        var formatStartPosition = formatString.IndexOf('%', currentPosition);
+        int consumedArgs = 0;
+        while (formatStartPosition >= 0)
+        {
+            Console.Write(formatString.Substring(currentPosition, formatStartPosition - currentPosition));
+            var formatSpecifier = formatString[formatStartPosition + 1];
+            switch (formatSpecifier)
+            {
+                case 's':
+                    Console.Write(Unmarshal((byte*)(IntPtr)varargs[consumedArgs]));
+                    consumedArgs++;
+                    break;
+            }
+
+            currentPosition = formatStartPosition + 2;
+            formatStartPosition = formatString.IndexOf('%', currentPosition);
+        }
+
+        Console.Write(formatString.Substring(currentPosition));
+    }
+
+    private static string? Unmarshal(byte* str)
+    {
+#if NETSTANDARD
+        Encoding encoding = Encoding.UTF8;
+        int byteLength = 0;
+        byte* search = str;
+        while (*search != '\0')
+        {
+            byteLength++;
+            search++;
+        }
+
+        int stringLength = encoding.GetCharCount(str, byteLength);
+        string s = new string('\0', stringLength);
+        fixed (char* pTempChars = s)
+        {
+            encoding.GetChars(str, byteLength, pTempChars, stringLength);
+        }
+
+        return s;
+#else
+        return Marshal.PtrToStringUTF8((nint)str);
+#endif
     }
 }


### PR DESCRIPTION
For now only char* arguments supported. Cannot do much with integers, since during emit phase I have lost information about expression type, and I cannot imagin what kind of IR node I need to preserve that, and at the same time do not overcomplicate things. Related to #196