### PR TITLE
Pass varargs via stack allocated buffer

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
@@ -137,6 +137,34 @@ void test()
 }");
 
     [Fact]
+    public void ImplicitVarargDeclarationCanBeIgnored() => DoTest(@"void console_read();
+
+void console_read()
+{
+}");
+
+    [Fact]
+    public void ImplicitVarargDefinitionCanBeIgnored() => DoTest(@"void console_read(void);
+
+void console_read()
+{
+}");
+
+    [Fact]
+    public void ExplicitVarargDeclarationShouldHaveExplicitDefinition() => DoesNotCompile(@"void console_read(int x, ...);
+
+void console_read(int x)
+{
+}", "Function console_read declared with varargs but defined without varargs.");
+
+    [Fact]
+    public void ExplicitVarargDefinitionShouldHaveExplicitDeclaration() => DoesNotCompile(@"void console_read(int x);
+
+void console_read(int x, ...)
+{
+}", "Function console_read declared without varargs but defined with varargs.");
+
+    [Fact]
     public void CanHaveTwoFunctionDeclarations() => DoTest(@"
 int console_read(void);
 

--- a/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
@@ -123,6 +123,20 @@ __cli_import(""System.Console::Read"")
 int console_read(void);");
 
     [Fact]
+    public void VarargCall() => DoTest(@"void console_read(int arg, ...);
+
+void console_read(int arg, ...)
+{
+}
+
+void test()
+{
+    console_read(5, 32);
+    console_read(5, 2.21f);
+    console_read(5, 67.44);
+}");
+
+    [Fact]
     public void CanHaveTwoFunctionDeclarations() => DoTest(@"
 int console_read(void);
 

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.VarargCall.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.VarargCall.verified.txt
@@ -1,0 +1,43 @@
+﻿System.Void <Module>::console_read(System.Int32 arg, System.Void* varargs)
+  IL_0000: ret
+
+System.Void <Module>::test()
+  Locals:
+    System.Void* V_0
+    System.Void* V_1
+    System.Void* V_2
+  IL_0000: ldc.i4 8
+  IL_0005: localloc
+  IL_0007: stloc V_0
+  IL_000b: ldc.i4.5
+  IL_000c: ldloc V_0
+  IL_0010: ldc.i4 0
+  IL_0015: add
+  IL_0016: ldc.i4.s 32
+  IL_0018: stind.i
+  IL_0019: ldloc V_0
+  IL_001d: call System.Void <Module>::console_read(System.Int32,System.Void*)
+  IL_0022: ldc.i4 8
+  IL_0027: localloc
+  IL_0029: stloc V_1
+  IL_002d: ldc.i4.5
+  IL_002e: ldloc V_1
+  IL_0032: ldc.i4 0
+  IL_0037: add
+  IL_0038: ldc.r4 2.21
+  IL_003d: conv.r8
+  IL_003e: stind.i
+  IL_003f: ldloc V_1
+  IL_0043: call System.Void <Module>::console_read(System.Int32,System.Void*)
+  IL_0048: ldc.i4 8
+  IL_004d: localloc
+  IL_004f: stloc V_2
+  IL_0053: ldc.i4.5
+  IL_0054: ldloc V_2
+  IL_0058: ldc.i4 0
+  IL_005d: add
+  IL_005e: ldc.r8 67.44
+  IL_0067: stind.i
+  IL_0068: ldloc V_2
+  IL_006c: call System.Void <Module>::console_read(System.Int32,System.Void*)
+  IL_0071: ret

--- a/Cesium.CodeGen/Contexts/Meta/FunctionInfo.cs
+++ b/Cesium.CodeGen/Contexts/Meta/FunctionInfo.cs
@@ -17,15 +17,17 @@ internal record FunctionInfo(
             throw new CompilationException(
                 $"Incorrect return type for function {name} declared as {ReturnType}: {returnType}.");
 
-        if (Parameters?.IsVarArg == true && parameters?.IsVarArg != true)
+        var declaredWithVarargs = Parameters?.IsVarArg == true;
+        var definedWithVarargs = parameters?.IsVarArg == true;
+        if (declaredWithVarargs && !definedWithVarargs)
             throw new CompilationException(
                 $"Function {name} declared with varargs but defined without varargs.");
 
-        if (Parameters?.IsVarArg != true && parameters?.IsVarArg == true)
+        if (!declaredWithVarargs && definedWithVarargs)
             throw new CompilationException(
                 $"Function {name} declared without varargs but defined with varargs.");
 
-        if (Parameters?.IsVarArg != parameters?.IsVarArg)
+        if (declaredWithVarargs != definedWithVarargs)
             throw new CompilationException(
                 $"Var arg declarations does not matched for functionn {name}.");
 

--- a/Cesium.CodeGen/Contexts/Meta/FunctionInfo.cs
+++ b/Cesium.CodeGen/Contexts/Meta/FunctionInfo.cs
@@ -17,8 +17,17 @@ internal record FunctionInfo(
             throw new CompilationException(
                 $"Incorrect return type for function {name} declared as {ReturnType}: {returnType}.");
 
-        if (Parameters?.IsVarArg == true || parameters?.IsVarArg == true)
-            throw new WipException(196, $"Vararg parameter not supported, yet: {name}.");
+        if (Parameters?.IsVarArg == true && parameters?.IsVarArg != true)
+            throw new CompilationException(
+                $"Function {name} declared with varargs but defined without varargs.");
+
+        if (Parameters?.IsVarArg != true && parameters?.IsVarArg == true)
+            throw new CompilationException(
+                $"Function {name} declared without varargs but defined with varargs.");
+
+        if (Parameters?.IsVarArg != parameters?.IsVarArg)
+            throw new CompilationException(
+                $"Var arg declarations does not matched for functionn {name}.");
 
         var actualCount = parameters?.Parameters.Count ?? 0;
         var declaredCount = Parameters?.Parameters.Count ?? 0;

--- a/Cesium.CodeGen/Extensions/CodeGenEx.cs
+++ b/Cesium.CodeGen/Extensions/CodeGenEx.cs
@@ -16,6 +16,8 @@ internal static class CodeGenEx
         scope.Method.Body.Instructions.Add(Instruction.Create(opCode, value));
     public static void AddInstruction(this IEmitScope scope, OpCode opCode, MethodReference value) =>
         scope.Method.Body.Instructions.Add(Instruction.Create(opCode, value));
+    public static void AddInstruction(this IEmitScope scope, OpCode opCode, VariableDefinition value) =>
+        scope.Method.Body.Instructions.Add(Instruction.Create(opCode, value));
 
     public static void StLoc(this IEmitScope scope, VariableDefinition variable)
     {

--- a/Cesium.CodeGen/Extensions/TypeDefinitionEx.cs
+++ b/Cesium.CodeGen/Extensions/TypeDefinitionEx.cs
@@ -2,6 +2,8 @@ using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Ir;
 using Cesium.Core;
 using Mono.Cecil;
+using Mono.Cecil.Rocks;
+using System.Xml.Linq;
 
 namespace Cesium.CodeGen.Extensions;
 
@@ -31,8 +33,6 @@ internal static class TypeDefinitionEx
         if (parametersInfo == null) return;
         var (parameters, isVoid, isVarArg) = parametersInfo;
         if (isVoid) return;
-        if (isVarArg)
-            throw new WipException(196, $"VarArg functions not supported, yet: {method.Name}.");
 
         // TODO[#87]: Process empty (non-void) parameter list.
 
@@ -42,6 +42,14 @@ internal static class TypeDefinitionEx
             var parameterDefinition = new ParameterDefinition(type.Resolve(context))
             {
                 Name = name
+            };
+            method.Parameters.Add(parameterDefinition);
+        }
+        if (isVarArg)
+        {
+            var parameterDefinition = new ParameterDefinition(context.TypeSystem.Void.MakePointerType())
+            {
+                Name = "varargs"
             };
             method.Parameters.Add(parameterDefinition);
         }

--- a/Cesium.CodeGen/Extensions/TypeSystemEx.cs
+++ b/Cesium.CodeGen/Extensions/TypeSystemEx.cs
@@ -108,17 +108,22 @@ internal static class TypeSystemEx
 
         if (parameters.IsVarArg)
         {
-            var lastSrcParam = methodParameters.Last();
-            var paramsAttrType = context.GetParamArrayAttributeType();
-            if (lastSrcParam.ParameterType.IsArray == false)
+            if (parameters.Parameters.Count + 1 != method.Parameters.Count)
             {
-                similarMethods.Add((method, $"Signature does not match: accepts variadic arguments in declaration, but not in source. Last parameter is not an array."));
+                similarMethods.Add((method, $"Signature does not match: accepts variadic arguments in declaration, but not in source. Count of parameters does not match."));
                 return false;
             }
 
-            if (lastSrcParam.CustomAttributes.Any(x => x.AttributeType.IsEqualTo(paramsAttrType)) == false)
+            var lastSrcParam = methodParameters.Last();
+            if (lastSrcParam.ParameterType is not Mono.Cecil.PointerType pointerType)
             {
-                similarMethods.Add((method, $"Signature does not match: accepts variadic arguments in declaration, but not in source. Last parameter has not {paramsAttrType}"));
+                similarMethods.Add((method, $"Signature does not match: accepts variadic arguments in declaration, but not in source. Last parameter is not an pointer type."));
+                return false;
+            }
+
+            if (!pointerType.ElementType.IsEqualTo(context.TypeSystem.Void))
+            {
+                similarMethods.Add((method, $"Signature does not match: accepts variadic arguments in declaration, but not in source. Last parameter is not an void*."));
                 return false;
             }
         }
@@ -222,11 +227,6 @@ internal static class TypeSystemEx
                     return i;
             return null;
         }
-    }
-
-    public static TypeReference GetParamArrayAttributeType(this TranslationUnitContext context)
-    {
-        return context.Module.ImportReference(context.AssemblyContext.MscorlibAssembly.GetType("System.ParamArrayAttribute"));
     }
 
     public static TypeDefinition GetRuntimeHelperType(this TranslationUnitContext context)

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -75,6 +75,7 @@ internal class FunctionCallExpression : IExpression
         var varArgParametersCount = _arguments.Count - explicitParametersCount;
         if (_callee!.Parameters?.IsVarArg == true)
         {
+            // TODO: See https://github.com/ForNeVeR/Cesium/issues/285
             // Using sparse population of the parameters on the stack. 8 bytes should be enough for anybody.
             // Also we need perform localloc on empty stack, so we will use local variable to save vararg buffer to temporary variable.
             if (varArgParametersCount == 0)

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -80,7 +80,7 @@ internal class FunctionCallExpression : IExpression
             // Also we need perform localloc on empty stack, so we will use local variable to save vararg buffer to temporary variable.
             if (varArgParametersCount == 0)
             {
-                scope.AddInstruction(OpCodes.Ldc_I4_0);
+                scope.AddInstruction(OpCodes.Ldnull);
             }
             else
             {

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -40,12 +40,9 @@ internal class FunctionCallExpression : IExpression
         var callee = scope.Functions.GetValueOrDefault(functionName)
                      ?? throw new CompilationException($"Function \"{functionName}\" was not found.");
         int firstVarArgArgument = 0;
-        if (callee.Parameters is { } parameters)
+        if (callee.Parameters?.IsVarArg == true)
         {
-            if (parameters.IsVarArg)
-            {
-                firstVarArgArgument = parameters.Parameters.Count;
-            }
+            firstVarArgArgument = callee.Parameters.Parameters.Count;
         }
 
         return new FunctionCallExpression(

--- a/Cesium.IntegrationTests/stdlib/printf.c
+++ b/Cesium.IntegrationTests/stdlib/printf.c
@@ -10,6 +10,8 @@ int main(int argc, char *argv[])
     // Print variables
     int intValue = 5;
     printf("%d\n", intValue);
+    printf("%u\n", -1);
+    printf("%lu\n", -1);
 
     float floatValue = 5.99;
     printf("%f\n", floatValue);
@@ -18,6 +20,9 @@ int main(int argc, char *argv[])
 
     char myLetter = 'D';
     printf("%c\n%c", myLetter, '1');
+    // We cannot validate this automatically, but at least we can uncomment and check
+    // that this produce appropriate results.
+    //printf("%p", &doubleValue);
 
     return 42;
 }

--- a/Cesium.IntegrationTests/stdlib/printf.c
+++ b/Cesium.IntegrationTests/stdlib/printf.c
@@ -4,16 +4,20 @@
 int main(int argc, char *argv[])
 {
     printf("test");
-    // Create variables
-    int myNum = 5;             // Integer (whole number)
-    float myFloatNum = 5.99;   // Floating point number
-    char myLetter = 'D';       // Character
 
     printf("%s\n", "myNum");
+
     // Print variables
-    //printf("%d\n", myNum);
-    //printf("%f\n", myFloatNum);
-    //printf("%c\n", myLetter);
+    int intValue = 5;
+    printf("%d\n", intValue);
+
+    float floatValue = 5.99;
+    printf("%f\n", floatValue);
+    double doubleValue = 2.04;
+    printf("%f\n", doubleValue);
+
+    char myLetter = 'D';
+    printf("%c\n%c", myLetter, '1');
 
     return 42;
 }

--- a/Cesium.Runtime/StdIoFunctions.cs
+++ b/Cesium.Runtime/StdIoFunctions.cs
@@ -24,7 +24,7 @@ public unsafe static class StdIoFunctions
         }
     }
 
-    public static void PrintF(byte* str, params object[] varargs)
+    public static void PrintF(byte* str, void* varargs)
     {
         var formatString = Unmarshal(str);
         if (formatString == null)
@@ -42,7 +42,7 @@ public unsafe static class StdIoFunctions
             switch (formatSpecifier)
             {
                 case 's':
-                    Console.Write(Unmarshal((byte*)(IntPtr)varargs[consumedArgs]));
+                    Console.Write(Unmarshal((byte*)((long*)varargs)[consumedArgs]));
                     consumedArgs++;
                     break;
                 default:

--- a/Cesium.Runtime/StdIoFunctions.cs
+++ b/Cesium.Runtime/StdIoFunctions.cs
@@ -38,31 +38,48 @@ public unsafe static class StdIoFunctions
         while (formatStartPosition >= 0)
         {
             Console.Write(formatString.Substring(currentPosition, formatStartPosition - currentPosition));
-            var formatSpecifier = formatString[formatStartPosition + 1];
+            int addition = 1;
+            string formatSpecifier = formatString[formatStartPosition + addition].ToString();
+            if (formatString[formatStartPosition + addition] == 'l')
+            {
+                addition++;
+                formatSpecifier += formatString[formatStartPosition + addition].ToString();
+            }
+
             switch (formatSpecifier)
             {
-                case 's':
+                case "s":
                     Console.Write(Unmarshal((byte*)((long*)varargs)[consumedArgs]));
                     consumedArgs++;
                     break;
-                case 'c':
+                case "c":
                     Console.Write((char)(byte)((long*)varargs)[consumedArgs]);
                     consumedArgs++;
                     break;
-                case 'd':
+                case "d":
                     Console.Write((int)((long*)varargs)[consumedArgs]);
                     consumedArgs++;
                     break;
-                case 'f':
+                case "u":
+                case "lu":
+                    Console.Write((uint)((long*)varargs)[consumedArgs]);
+                    consumedArgs++;
+                    break;
+                case "f":
                     var floatNumber = ((double*)varargs)[consumedArgs];
                     Console.Write(floatNumber.ToString("F6"));
+                    consumedArgs++;
+                    break;
+                case "p":
+                    nint pointerValue = ((nint*)varargs)[consumedArgs];
+                    Console.Write(pointerValue.ToString("X"));
                     consumedArgs++;
                     break;
                 default:
                     throw new FormatException($"Format specifier {formatSpecifier} is not supported");
             }
 
-            currentPosition = formatStartPosition + 2;
+            currentPosition = formatStartPosition + addition + 1;
             formatStartPosition = formatString.IndexOf('%', currentPosition);
         }
 

--- a/Cesium.Runtime/StdIoFunctions.cs
+++ b/Cesium.Runtime/StdIoFunctions.cs
@@ -45,6 +45,19 @@ public unsafe static class StdIoFunctions
                     Console.Write(Unmarshal((byte*)((long*)varargs)[consumedArgs]));
                     consumedArgs++;
                     break;
+                case 'c':
+                    Console.Write((char)(byte)((long*)varargs)[consumedArgs]);
+                    consumedArgs++;
+                    break;
+                case 'd':
+                    Console.Write((int)((long*)varargs)[consumedArgs]);
+                    consumedArgs++;
+                    break;
+                case 'f':
+                    var floatNumber = ((double*)varargs)[consumedArgs];
+                    Console.Write(floatNumber.ToString("F6"));
+                    consumedArgs++;
+                    break;
                 default:
                     throw new FormatException($"Format specifier {formatSpecifier} is not supported");
             }


### PR DESCRIPTION
When invoke function annotated as vararg, created local buffer for the variable arguments. For each argument currently allocated 8 bytes. This should be enough for most common usage. 