### PR TITLE
Prepare for refactoring of declaration scopes

### DIFF
--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.ForTest_NoInit.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.ForTest_NoInit.verified.txt
@@ -16,8 +16,9 @@
   IL_0010: ldc.i4.s 10
   IL_0012: clt
   IL_0014: brtrue IL_0007
-  IL_0019: ldc.i4.0
-  IL_001a: ret
+  IL_0019: nop
+  IL_001a: ldc.i4.0
+  IL_001b: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_Empty.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_Empty.verified.txt
@@ -8,8 +8,9 @@
   IL_0008: stloc.0
   IL_0009: ldc.i4.1
   IL_000a: brtrue IL_0005
-  IL_000f: ldc.i4.0
-  IL_0010: ret
+  IL_000f: nop
+  IL_0010: ldc.i4.0
+  IL_0011: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoTest.verified.txt
@@ -14,8 +14,9 @@
   IL_000e: stloc.0
   IL_000f: ldc.i4.1
   IL_0010: brtrue IL_0007
-  IL_0015: ldc.i4.0
-  IL_0016: ret
+  IL_0015: nop
+  IL_0016: ldc.i4.0
+  IL_0017: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoUpdate.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.For_NoUpdate.verified.txt
@@ -12,8 +12,9 @@
   IL_000c: ldc.i4.s 10
   IL_000e: clt
   IL_0010: brtrue IL_0007
-  IL_0015: ldc.i4.0
-  IL_0016: ret
+  IL_0015: nop
+  IL_0016: ldc.i4.0
+  IL_0017: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenForTests.SimpleFor.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenForTests.SimpleFor.verified.txt
@@ -16,8 +16,9 @@
   IL_0010: ldc.i4.s 10
   IL_0012: clt
   IL_0014: brtrue IL_0007
-  IL_0019: ldc.i4.0
-  IL_001a: ret
+  IL_0019: nop
+  IL_001a: ldc.i4.0
+  IL_001b: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen/Contexts/ForScope.cs
+++ b/Cesium.CodeGen/Contexts/ForScope.cs
@@ -39,7 +39,6 @@ internal record ForScope(IEmitScope Parent) : IEmitScope, IDeclarationScope
     public ParameterDefinition ResolveParameter(string name) => Parent.ResolveParameter(name);
     public ParameterInfo? GetParameterInfo(string name) => ((IDeclarationScope)Parent).GetParameterInfo(name);
 
-    public Instruction? EndInstruction { get; set; }
     /// <inheritdoc />
     public IType ResolveType(IType type) => Context.ResolveType(type);
     public void AddTypeDefinition(string identifier, IType type) => throw new AssertException("Not supported");
@@ -54,5 +53,19 @@ internal record ForScope(IEmitScope Parent) : IEmitScope, IDeclarationScope
     public Instruction ResolveLabel(string label)
     {
         return Parent.ResolveLabel(label);
+    }
+
+    /// <inheritdoc />
+    public void RegisterChildScope(IDeclarationScope childScope)
+    {
+
+    }
+
+    private string _breakLabel = Guid.NewGuid().ToString();
+
+    /// <inheritdoc />
+    public string? GetBreakLabel()
+    {
+        return _breakLabel;
     }
 }

--- a/Cesium.CodeGen/Contexts/ForScope.cs
+++ b/Cesium.CodeGen/Contexts/ForScope.cs
@@ -4,6 +4,8 @@ using Cesium.CodeGen.Ir.Types;
 using Cesium.Core;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Cesium.CodeGen.Contexts;
 
@@ -12,10 +14,23 @@ internal record ForScope(IEmitScope Parent) : IEmitScope, IDeclarationScope
     public AssemblyContext AssemblyContext => Parent.AssemblyContext;
     public ModuleDefinition Module => Parent.Module;
     public CTypeSystem CTypeSystem => Parent.CTypeSystem;
-    public IReadOnlyDictionary<string, FunctionInfo> Functions => ((IDeclarationScope)Parent).Functions;
+    public bool TryGetFunctionInfo(string identifier, [NotNullWhen(true)] out FunctionInfo? functionInfo)
+        => ((IDeclarationScope)Parent).TryGetFunctionInfo(identifier, out functionInfo);
     public TranslationUnitContext Context => Parent.Context;
     public MethodDefinition Method => Parent.Method;
-    public IReadOnlyDictionary<string, IType> Variables => ((IDeclarationScope)Parent).Variables; // no declarations for `for` now, so pass parent variables
+    private readonly Dictionary<string, IType> _variables = new();
+
+    public bool TryGetVariable(string identifier, [NotNullWhen(true)] out IType? type)
+    {
+        var hasLocalDeclarations = _variables.TryGetValue(identifier, out type);
+        if (hasLocalDeclarations)
+        {
+            Debug.Assert(type != null);
+            return true;
+        }
+
+        return ((IDeclarationScope)Parent).TryGetVariable(identifier, out type);
+    }
     public IReadOnlyDictionary<string, IType> GlobalFields => ((IDeclarationScope)Parent).GlobalFields;
     public void AddVariable(string identifier, IType variable) =>
         throw new WipException(205, "Variable addition into a for loop scope is not implemented, yet.");

--- a/Cesium.CodeGen/Contexts/ForScope.cs
+++ b/Cesium.CodeGen/Contexts/ForScope.cs
@@ -7,7 +7,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Contexts;
 
-internal record LoopScope(IEmitScope Parent) : IEmitScope, IDeclarationScope
+internal record ForScope(IEmitScope Parent) : IEmitScope, IDeclarationScope
 {
     public AssemblyContext AssemblyContext => Parent.AssemblyContext;
     public ModuleDefinition Module => Parent.Module;

--- a/Cesium.CodeGen/Contexts/FunctionScope.cs
+++ b/Cesium.CodeGen/Contexts/FunctionScope.cs
@@ -4,7 +4,6 @@ using Cesium.CodeGen.Ir.Types;
 using Cesium.Core;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Cesium.CodeGen.Contexts;
 
@@ -15,9 +14,10 @@ internal record FunctionScope(TranslationUnitContext Context, FunctionInfo Funct
     public TypeSystem TypeSystem => Context.TypeSystem;
     public CTypeSystem CTypeSystem => Context.CTypeSystem;
     public IReadOnlyDictionary<string, FunctionInfo> Functions => Context.Functions;
-    public bool TryGetFunctionInfo(string identifier, [NotNullWhen(true)] out FunctionInfo? functionInfo)
+    public FunctionInfo? GetFunctionInfo(string identifier)
     {
-        return Context.Functions.TryGetValue(identifier, out functionInfo);
+        Context.Functions.TryGetValue(identifier, out var functionInfo);
+        return functionInfo;
     }
 
     private readonly Dictionary<string, IType> _variables = new();
@@ -26,9 +26,10 @@ internal record FunctionScope(TranslationUnitContext Context, FunctionInfo Funct
     public IReadOnlyDictionary<string, IType> GlobalFields => AssemblyContext.GlobalFields;
     public void AddVariable(string identifier, IType variable) => _variables.Add(identifier, variable);
 
-    public bool TryGetVariable(string identifier, [NotNullWhen(true)] out IType? type)
+    public IType? GetVariable(string identifier)
     {
-        return _variables.TryGetValue(identifier, out type);
+        _variables.TryGetValue(identifier, out var type);
+        return type;
     }
 
     public VariableDefinition ResolveVariable(string identifier)
@@ -79,12 +80,6 @@ internal record FunctionScope(TranslationUnitContext Context, FunctionInfo Funct
     public Instruction ResolveLabel(string label)
     {
         return _labels[label];
-    }
-
-    /// <inheritdoc />
-    public void RegisterChildScope(IDeclarationScope childScope)
-    {
-
     }
 
     /// <inheritdoc />

--- a/Cesium.CodeGen/Contexts/FunctionScope.cs
+++ b/Cesium.CodeGen/Contexts/FunctionScope.cs
@@ -4,6 +4,7 @@ using Cesium.CodeGen.Ir.Types;
 using Cesium.Core;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Cesium.CodeGen.Contexts;
 
@@ -14,13 +15,22 @@ internal record FunctionScope(TranslationUnitContext Context, FunctionInfo Funct
     public TypeSystem TypeSystem => Context.TypeSystem;
     public CTypeSystem CTypeSystem => Context.CTypeSystem;
     public IReadOnlyDictionary<string, FunctionInfo> Functions => Context.Functions;
+    public bool TryGetFunctionInfo(string identifier, [NotNullWhen(true)] out FunctionInfo? functionInfo)
+    {
+        return Context.Functions.TryGetValue(identifier, out functionInfo);
+    }
 
     private readonly Dictionary<string, IType> _variables = new();
     private readonly Dictionary<string, Instruction> _labels = new();
     private readonly Dictionary<string, VariableDefinition> _variableDefinition = new();
-    public IReadOnlyDictionary<string, IType> Variables => _variables;
     public IReadOnlyDictionary<string, IType> GlobalFields => AssemblyContext.GlobalFields;
     public void AddVariable(string identifier, IType variable) => _variables.Add(identifier, variable);
+
+    public bool TryGetVariable(string identifier, [NotNullWhen(true)] out IType? type)
+    {
+        return _variables.TryGetValue(identifier, out type);
+    }
+
     public VariableDefinition ResolveVariable(string identifier)
     {
         if (!_variables.TryGetValue(identifier, out var variableType))

--- a/Cesium.CodeGen/Contexts/FunctionScope.cs
+++ b/Cesium.CodeGen/Contexts/FunctionScope.cs
@@ -80,4 +80,16 @@ internal record FunctionScope(TranslationUnitContext Context, FunctionInfo Funct
     {
         return _labels[label];
     }
+
+    /// <inheritdoc />
+    public void RegisterChildScope(IDeclarationScope childScope)
+    {
+
+    }
+
+    /// <inheritdoc />
+    public string? GetBreakLabel()
+    {
+        return null;
+    }
 }

--- a/Cesium.CodeGen/Contexts/FunctionScope.cs
+++ b/Cesium.CodeGen/Contexts/FunctionScope.cs
@@ -14,11 +14,8 @@ internal record FunctionScope(TranslationUnitContext Context, FunctionInfo Funct
     public TypeSystem TypeSystem => Context.TypeSystem;
     public CTypeSystem CTypeSystem => Context.CTypeSystem;
     public IReadOnlyDictionary<string, FunctionInfo> Functions => Context.Functions;
-    public FunctionInfo? GetFunctionInfo(string identifier)
-    {
-        Context.Functions.TryGetValue(identifier, out var functionInfo);
-        return functionInfo;
-    }
+    public FunctionInfo? GetFunctionInfo(string identifier) =>
+        Functions.GetValueOrDefault(identifier);
 
     private readonly Dictionary<string, IType> _variables = new();
     private readonly Dictionary<string, Instruction> _labels = new();
@@ -26,11 +23,7 @@ internal record FunctionScope(TranslationUnitContext Context, FunctionInfo Funct
     public IReadOnlyDictionary<string, IType> GlobalFields => AssemblyContext.GlobalFields;
     public void AddVariable(string identifier, IType variable) => _variables.Add(identifier, variable);
 
-    public IType? GetVariable(string identifier)
-    {
-        _variables.TryGetValue(identifier, out var type);
-        return type;
-    }
+    public IType? GetVariable(string identifier) => _variables.GetValueOrDefault(identifier);
 
     public VariableDefinition ResolveVariable(string identifier)
     {

--- a/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
+++ b/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
@@ -1,6 +1,4 @@
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics;
 using Cesium.CodeGen.Contexts.Meta;
 using Cesium.CodeGen.Ir;
 using Cesium.CodeGen.Ir.Types;
@@ -19,9 +17,10 @@ internal record GlobalConstructorScope(TranslationUnitContext Context) : IEmitSc
 
     public MethodDefinition Method => _method ??= Context.AssemblyContext.GetGlobalInitializer();
     public CTypeSystem CTypeSystem => Context.CTypeSystem;
-    public bool TryGetFunctionInfo(string identifier, [NotNullWhen(true)] out FunctionInfo? functionInfo)
+    public FunctionInfo? GetFunctionInfo(string identifier)
     {
-        return Context.Functions.TryGetValue(identifier, out functionInfo);
+        Context.Functions.TryGetValue(identifier, out var functionInfo);
+        return functionInfo;
     }
     public IReadOnlyDictionary<string, IType> GlobalFields => AssemblyContext.GlobalFields;
 
@@ -29,10 +28,9 @@ internal record GlobalConstructorScope(TranslationUnitContext Context) : IEmitSc
     public void AddVariable(string identifier, IType variable) =>
         throw new AssertException("Cannot add a variable into a global constructor scope");
 
-    public bool TryGetVariable(string identifier, [NotNullWhen(true)] out IType? type)
+    public IType? GetVariable(string identifier)
     {
-        type = null;
-        return false;
+        return null;
     }
     public VariableDefinition ResolveVariable(string identifier) =>
         throw new AssertException("Cannot add a variable into a global constructor scope");
@@ -55,12 +53,6 @@ internal record GlobalConstructorScope(TranslationUnitContext Context) : IEmitSc
     public Instruction ResolveLabel(string label)
     {
         throw new AssertException("Cannot define label into a global constructor scope");
-    }
-
-    /// <inheritdoc />
-    public void RegisterChildScope(IDeclarationScope childScope)
-    {
-        throw new AssertException("Cannot add child scope to a global constructor scope");
     }
 
     /// <inheritdoc />

--- a/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
+++ b/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
@@ -17,11 +17,8 @@ internal record GlobalConstructorScope(TranslationUnitContext Context) : IEmitSc
 
     public MethodDefinition Method => _method ??= Context.AssemblyContext.GetGlobalInitializer();
     public CTypeSystem CTypeSystem => Context.CTypeSystem;
-    public FunctionInfo? GetFunctionInfo(string identifier)
-    {
-        Context.Functions.TryGetValue(identifier, out var functionInfo);
-        return functionInfo;
-    }
+    public FunctionInfo? GetFunctionInfo(string identifier) =>
+        Context.Functions.GetValueOrDefault(identifier);
     public IReadOnlyDictionary<string, IType> GlobalFields => AssemblyContext.GlobalFields;
 
     public IReadOnlyDictionary<string, IType> Variables => ImmutableDictionary<string, IType>.Empty;

--- a/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
+++ b/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
-using System.Reflection.Emit;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 using Cesium.CodeGen.Contexts.Meta;
 using Cesium.CodeGen.Ir;
 using Cesium.CodeGen.Ir.Types;
@@ -18,12 +19,21 @@ internal record GlobalConstructorScope(TranslationUnitContext Context) : IEmitSc
 
     public MethodDefinition Method => _method ??= Context.AssemblyContext.GetGlobalInitializer();
     public CTypeSystem CTypeSystem => Context.CTypeSystem;
-    public IReadOnlyDictionary<string, FunctionInfo> Functions => Context.Functions;
+    public bool TryGetFunctionInfo(string identifier, [NotNullWhen(true)] out FunctionInfo? functionInfo)
+    {
+        return Context.Functions.TryGetValue(identifier, out functionInfo);
+    }
     public IReadOnlyDictionary<string, IType> GlobalFields => AssemblyContext.GlobalFields;
 
     public IReadOnlyDictionary<string, IType> Variables => ImmutableDictionary<string, IType>.Empty;
     public void AddVariable(string identifier, IType variable) =>
         throw new AssertException("Cannot add a variable into a global constructor scope");
+
+    public bool TryGetVariable(string identifier, [NotNullWhen(true)] out IType? type)
+    {
+        type = null;
+        return false;
+    }
     public VariableDefinition ResolveVariable(string identifier) =>
         throw new AssertException("Cannot add a variable into a global constructor scope");
 

--- a/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
+++ b/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
@@ -56,4 +56,16 @@ internal record GlobalConstructorScope(TranslationUnitContext Context) : IEmitSc
     {
         throw new AssertException("Cannot define label into a global constructor scope");
     }
+
+    /// <inheritdoc />
+    public void RegisterChildScope(IDeclarationScope childScope)
+    {
+        throw new AssertException("Cannot add child scope to a global constructor scope");
+    }
+
+    /// <inheritdoc />
+    public string? GetBreakLabel()
+    {
+        return null;
+    }
 }

--- a/Cesium.CodeGen/Contexts/IDeclarationScope.cs
+++ b/Cesium.CodeGen/Contexts/IDeclarationScope.cs
@@ -2,17 +2,16 @@ using Cesium.CodeGen.Contexts.Meta;
 using Cesium.CodeGen.Ir;
 using Cesium.CodeGen.Ir.Types;
 using Cesium.Core;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Cesium.CodeGen.Contexts;
 
 internal interface IDeclarationScope
 {
     CTypeSystem CTypeSystem { get; }
-    bool TryGetFunctionInfo(string identifier, [NotNullWhen(true)] out FunctionInfo? functionInfo);
+    FunctionInfo? GetFunctionInfo(string identifier);
     IReadOnlyDictionary<string, IType> GlobalFields { get; }
     void AddVariable(string identifier, IType variable);
-    bool TryGetVariable(string identifier, [NotNullWhen(true)]out IType? type);
+    IType? GetVariable(string identifier);
 
     /// <summary>
     /// Recursively resolve the passed type and all its members, replacing `NamedType` in any points with their actual instantiations in the current context.
@@ -29,12 +28,6 @@ internal interface IDeclarationScope
     /// </summary>
     /// <param name="identifier">Label to add to the current scope.</param>
     void AddLabel(string identifier);
-
-    /// <summary>
-    /// Registers child declaration scope.
-    /// </summary>
-    /// <param name="childScope">Child scope to add to the current one.</param>
-    void RegisterChildScope(IDeclarationScope childScope);
 
     /// <summary>
     /// Gets name of the virtual label which point to exit location from the scope.

--- a/Cesium.CodeGen/Contexts/IDeclarationScope.cs
+++ b/Cesium.CodeGen/Contexts/IDeclarationScope.cs
@@ -2,16 +2,18 @@ using Cesium.CodeGen.Contexts.Meta;
 using Cesium.CodeGen.Ir;
 using Cesium.CodeGen.Ir.Types;
 using Cesium.Core;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Cesium.CodeGen.Contexts;
 
 internal interface IDeclarationScope
 {
     CTypeSystem CTypeSystem { get; }
-    IReadOnlyDictionary<string, FunctionInfo> Functions { get; }
-    IReadOnlyDictionary<string, IType> Variables { get; }
+    bool TryGetFunctionInfo(string identifier, [NotNullWhen(true)] out FunctionInfo? functionInfo);
     IReadOnlyDictionary<string, IType> GlobalFields { get; }
     void AddVariable(string identifier, IType variable);
+    bool TryGetVariable(string identifier, [NotNullWhen(true)]out IType? type);
+
     /// <summary>
     /// Recursively resolve the passed type and all its members, replacing `NamedType` in any points with their actual instantiations in the current context.
     /// </summary>

--- a/Cesium.CodeGen/Contexts/IDeclarationScope.cs
+++ b/Cesium.CodeGen/Contexts/IDeclarationScope.cs
@@ -31,7 +31,7 @@ internal interface IDeclarationScope
     void AddLabel(string identifier);
 
     /// <summary>
-    // Registers child declaration scope.
+    /// Registers child declaration scope.
     /// </summary>
     /// <param name="childScope">Child scope to add to the current one.</param>
     void RegisterChildScope(IDeclarationScope childScope);

--- a/Cesium.CodeGen/Contexts/IDeclarationScope.cs
+++ b/Cesium.CodeGen/Contexts/IDeclarationScope.cs
@@ -29,4 +29,16 @@ internal interface IDeclarationScope
     /// </summary>
     /// <param name="identifier">Label to add to the current scope.</param>
     void AddLabel(string identifier);
+
+    /// <summary>
+    // Registers child declaration scope.
+    /// </summary>
+    /// <param name="childScope">Child scope to add to the current one.</param>
+    void RegisterChildScope(IDeclarationScope childScope);
+
+    /// <summary>
+    /// Gets name of the virtual label which point to exit location from the scope.
+    /// </summary>
+    /// <returns>Name of the virtual label which can be used by break statement</returns>
+    string? GetBreakLabel();
 }

--- a/Cesium.CodeGen/Ir/BlockItems/AmbiguousBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/AmbiguousBlockItem.cs
@@ -27,10 +27,10 @@ internal class AmbiguousBlockItem : IBlockItem
     public IBlockItem Lower(IDeclarationScope scope)
     {
         // Check if this can be a valid variable declaration:
-        var isValidVariableDeclaration = scope.Variables.TryGetValue(_item1, out _);
+        var isValidVariableDeclaration = scope.TryGetVariable(_item1, out _);
 
         // Check if this can be a function call:
-        var function = scope.Functions.GetValueOrDefault(_item1);
+        scope.TryGetFunctionInfo(_item1, out var function);
         var isValidFunctionCall = function != null;
         if (!isValidVariableDeclaration && !isValidFunctionCall)
             throw new CompilationException(

--- a/Cesium.CodeGen/Ir/BlockItems/AmbiguousBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/AmbiguousBlockItem.cs
@@ -27,10 +27,10 @@ internal class AmbiguousBlockItem : IBlockItem
     public IBlockItem Lower(IDeclarationScope scope)
     {
         // Check if this can be a valid variable declaration:
-        var isValidVariableDeclaration = scope.TryGetVariable(_item1, out _);
+        var isValidVariableDeclaration = scope.GetVariable(_item1) != null;
 
         // Check if this can be a function call:
-        scope.TryGetFunctionInfo(_item1, out var function);
+        var function = scope.GetFunctionInfo(_item1);
         var isValidFunctionCall = function != null;
         if (!isValidVariableDeclaration && !isValidFunctionCall)
             throw new CompilationException(

--- a/Cesium.CodeGen/Ir/BlockItems/BreakStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/BreakStatement.cs
@@ -6,16 +6,14 @@ namespace Cesium.CodeGen.Ir.BlockItems;
 
 internal class BreakStatement : IBlockItem
 {
-    public IBlockItem Lower(IDeclarationScope scope) => this;
-
-    public void EmitTo(IEmitScope scope)
+    public IBlockItem Lower(IDeclarationScope scope)
     {
-        if (scope is not ForScope forScope)
+        var breakLabel = scope.GetBreakLabel();
+        if (breakLabel is null)
             throw new CompilationException("Can't break not from for statement");
 
-        var endInstruction = scope.Method.Body.GetILProcessor().Create(OpCodes.Nop);
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Br, endInstruction));
-
-        forScope.EndInstruction = endInstruction;
+        return new GoToStatement(breakLabel);
     }
+
+    public void EmitTo(IEmitScope scope) => throw new AssertException("Break statement should be lowered");
 }

--- a/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
@@ -4,7 +4,6 @@ using Cesium.CodeGen.Extensions;
 using Cesium.CodeGen.Ir.Expressions;
 using Cesium.CodeGen.Ir.Expressions.Constants;
 using Mono.Cecil.Cil;
-using ConstantExpression = Cesium.CodeGen.Ir.Expressions.ConstantExpression;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
@@ -44,6 +43,7 @@ internal class ForStatement : IBlockItem
     {
         var forScope = new ForScope((IEmitScope)scope);
         var breakLabel = forScope.GetBreakLabel();
+        // TODO[#201]: Remove side effects from Lower, migrate labels to a separate compilation stage.
         scope.AddLabel(breakLabel);
         return new ForStatement(
             _initExpression?.Lower(forScope),

--- a/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
@@ -42,15 +42,15 @@ internal class ForStatement : IBlockItem
 
     public IBlockItem Lower(IDeclarationScope scope)
     {
-        var forScope = new ForScope((IEmitScope)scope);
+        var forScope = new LoopScope((IEmitScope)scope);
         var breakLabel = forScope.GetBreakLabel();
-        scope.AddLabel(breakLabel!);
+        scope.AddLabel(breakLabel);
         return new ForStatement(
             _initExpression?.Lower(forScope),
             _testExpression.Lower(forScope),
             _updateExpression?.Lower(forScope),
             _body.Lower(forScope),
-            breakLabel!);
+            breakLabel);
     }
 
     bool IBlockItem.HasDefiniteReturn => _body.HasDefiniteReturn;

--- a/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
@@ -42,7 +42,7 @@ internal class ForStatement : IBlockItem
 
     public IBlockItem Lower(IDeclarationScope scope)
     {
-        var forScope = new LoopScope((IEmitScope)scope);
+        var forScope = new ForScope((IEmitScope)scope);
         var breakLabel = forScope.GetBreakLabel();
         scope.AddLabel(breakLabel);
         return new ForStatement(

--- a/Cesium.CodeGen/Ir/BlockItems/GoToStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/GoToStatement.cs
@@ -12,7 +12,7 @@ internal class GoToStatement : IBlockItem
         _identifier = statement.Identifier;
     }
 
-    private GoToStatement(string identifier)
+    public GoToStatement(string identifier)
     {
         _identifier = identifier;
     }

--- a/Cesium.CodeGen/Ir/BlockItems/LabelStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/LabelStatement.cs
@@ -1,7 +1,5 @@
-using Cesium.Ast;
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Extensions;
-using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
@@ -26,6 +24,7 @@ internal class LabelStatement : IBlockItem
 
     public IBlockItem Lower(IDeclarationScope scope)
     {
+        // TODO[#201]: Remove side effects from Lower, migrate labels to a separate compilation stage.
         scope.AddLabel(_identifier);
         return new LabelStatement(_identifier, _expression.Lower(scope));
     }

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -37,7 +37,7 @@ internal class FunctionCallExpression : IExpression
     public IExpression Lower(IDeclarationScope scope)
     {
         var functionName = _function.Identifier;
-        scope.TryGetFunctionInfo(functionName, out var callee);
+        var callee = scope.GetFunctionInfo(functionName);
         if (callee is null)
         {
             throw new CompilationException($"Function \"{functionName}\" was not found.");

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -37,8 +37,12 @@ internal class FunctionCallExpression : IExpression
     public IExpression Lower(IDeclarationScope scope)
     {
         var functionName = _function.Identifier;
-        var callee = scope.Functions.GetValueOrDefault(functionName)
-                     ?? throw new CompilationException($"Function \"{functionName}\" was not found.");
+        scope.TryGetFunctionInfo(functionName, out var callee);
+        if (callee is null)
+        {
+            throw new CompilationException($"Function \"{functionName}\" was not found.");
+        }
+
         int firstVarArgArgument = 0;
         if (callee.Parameters?.IsVarArg == true)
         {

--- a/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
@@ -41,8 +41,8 @@ internal class IdentifierExpression : IExpression, IValueExpression
 
     public IValue Resolve(IDeclarationScope scope)
     {
-        scope.TryGetVariable(Identifier, out var var);
-        scope.TryGetFunctionInfo(Identifier, out var fun);
+        var var = scope.GetVariable(Identifier);
+        var fun = scope.GetFunctionInfo(Identifier);
         var par = scope.GetParameterInfo(Identifier);
         scope.GlobalFields.TryGetValue(Identifier, out var globalType);
 

--- a/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
@@ -41,8 +41,8 @@ internal class IdentifierExpression : IExpression, IValueExpression
 
     public IValue Resolve(IDeclarationScope scope)
     {
-        scope.Variables.TryGetValue(Identifier, out var var);
-        scope.Functions.TryGetValue(Identifier, out FunctionInfo? fun);
+        scope.TryGetVariable(Identifier, out var var);
+        scope.TryGetFunctionInfo(Identifier, out var fun);
         var par = scope.GetParameterInfo(Identifier);
         scope.GlobalFields.TryGetValue(Identifier, out var globalType);
 


### PR DESCRIPTION
Declaration scopes inherently hierarchical, and we need to preserve that hierarchy. By exposing separate dictionaries we show too much of internal structure, even if all we need is resolve identifier, and know what kind of identifier it is. For example GlobalFields and Variables is essentially the same, except they are declared in different scopes. This is mostly not important until emit phase.

Rework for statement to not rely on `EndInstruction`
That makes emit scopes hierarchical, but we really want to have declaration scopes as hierarchical.