### PR TITLE
Support version command

### DIFF
--- a/Cesium.Compiler/Main.cs
+++ b/Cesium.Compiler/Main.cs
@@ -42,16 +42,21 @@ return await parserResult.MapResult(async args =>
     },
     _ =>
     {
-        DisplayHelp(parserResult);
+        string helpText = PrepareHelpText(parserResult);
+        Console.WriteLine(helpText);
         return Task.FromResult(-1);
     });
 
-static void DisplayHelp<T>(ParserResult<T> result)
+static string PrepareHelpText<T>(ParserResult<T> result)
 {
+    if (result is NotParsed<T> notParsed && notParsed.Errors.IsVersion())
+        return HelpText.AutoBuild(result);
+
     var helpText = HelpText.AutoBuild(result, h =>
     {
         h.AddEnumValuesToHelpText = true;
         return HelpText.DefaultParsingErrorsHandler(result, h);
     }, e => e);
-    Console.WriteLine(helpText);
+
+    return helpText;
 }


### PR DESCRIPTION
close #264 

This is why it work, code of AutoBuild:

```csharp
public static HelpText AutoBuild<T>(ParserResult<T> parserResult, Func<HelpText, HelpText> onError, int maxDisplayWidth = DefaultMaximumLength)
{
    if (parserResult.Tag != ParserResultType.NotParsed)
        throw new ArgumentException("Excepting NotParsed<T> type.", "parserResult");

    var errors = ((NotParsed<T>)parserResult).Errors;

    if (errors.Any(e => e.Tag == ErrorType.VersionRequestedError))
        return new HelpText($"{HeadingInfo.Default}{Environment.NewLine}") { MaximumDisplayWidth = maxDisplayWidth }.AddPreOptionsLine(Environment.NewLine);
```

So they handle ErrorType.VersionRequestedError and use build-in logic for formatting version.

![image](https://user-images.githubusercontent.com/22368203/193414858-2ab16542-e9d7-43cd-b3af-e7cf3e34bf34.png)
