### PR TITLE
String escape sequence support

### DIFF
--- a/Cesium.IntegrationTests/strings/escape_sequence.c
+++ b/Cesium.IntegrationTests/strings/escape_sequence.c
@@ -3,7 +3,7 @@
 
 int main(int argc, char* argv[])
 {
-    printf("\'\"\?\\\a\b\f\n\r\t\v");
+    printf("\'hello, world\"\?\\\atest\b\f\n\r42\t\v");
 
     printf("\0");
     printf("\02");
@@ -16,8 +16,8 @@ int main(int argc, char* argv[])
     // printf("\xF0");
     // printf("\xFF");
 
-    printf("\u2200");
-    printf("\U0001f34c");
+    // printf("\u2200");
+    // printf("\U0001f34c");
 
     return 42;
 }

--- a/Cesium.IntegrationTests/strings/escape_sequence.c
+++ b/Cesium.IntegrationTests/strings/escape_sequence.c
@@ -1,14 +1,21 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
     printf("\'\"\?\\\a\b\f\n\r\t\v");
-    printf("\023");
+
+    printf("\024");
+    printf("\007");
     printf("\077");
+
+    printf("\x06");
+    printf("\x28");
     printf("\xF0");
     printf("\xFF");
+
     printf("\u2200");
     printf("\U0001f34c");
+
     return 42;
 }

--- a/Cesium.IntegrationTests/strings/escape_sequence.c
+++ b/Cesium.IntegrationTests/strings/escape_sequence.c
@@ -5,14 +5,16 @@ int main(int argc, char* argv[])
 {
     printf("\'\"\?\\\a\b\f\n\r\t\v");
 
+    printf("\0");
+    printf("\02");
     printf("\024");
     printf("\007");
     printf("\077");
 
     printf("\x06");
     printf("\x28");
-    printf("\xF0");
-    printf("\xFF");
+    // printf("\xF0");
+    // printf("\xFF");
 
     printf("\u2200");
     printf("\U0001f34c");

--- a/Cesium.IntegrationTests/strings/escape_sequence.c
+++ b/Cesium.IntegrationTests/strings/escape_sequence.c
@@ -13,6 +13,7 @@ int main(int argc, char* argv[])
 
     printf("\x06");
     printf("\x28");
+    // TODO[#296]: Uncomment this.
     // printf("\xF0");
     // printf("\xFF");
 

--- a/Cesium.IntegrationTests/strings/escape_sequence.c
+++ b/Cesium.IntegrationTests/strings/escape_sequence.c
@@ -5,7 +5,9 @@ int main(int argc, char *argv[])
 {
     printf("\'\"\?\\\a\b\f\n\r\t\v");
     printf("\023");
+    printf("\077");
     printf("\xF0");
+    printf("\xFF");
     printf("\u2200");
     printf("\U0001f34c");
     return 42;

--- a/Cesium.Parser/TokenExtensions.cs
+++ b/Cesium.Parser/TokenExtensions.cs
@@ -51,7 +51,7 @@ public static class TokenExtensions
                         builder.Append('\v');
                         break;
                     default:
-                        // todo: maybe smarter handling of this edge case with errors/warnings
+                        // TODO[#295]: maybe smarter handling of this edge case with errors/warnings
                         builder.Append("\\");
                         --i; // don't skip next
                         break;

--- a/Cesium.Parser/TokenExtensions.cs
+++ b/Cesium.Parser/TokenExtensions.cs
@@ -28,7 +28,7 @@ public static class TokenExtensions
             .Replace("\\v", "\v");
 
         // numeric escape sequences
-        result = Regex.Replace(result, @"\\([0-7]{3})", m =>
+        result = Regex.Replace(result, @"\\([0-7]{1,3})", m =>
             char.ConvertFromUtf32(Convert.ToInt32(m.Groups[1].Value, 8)));
 
         result = Regex.Replace(result, @"\\[xX]([0-9a-fA-F]{2})", m =>

--- a/Cesium.Parser/TokenExtensions.cs
+++ b/Cesium.Parser/TokenExtensions.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.RegularExpressions;
 using Cesium.Core;
 using Yoakke.SynKit.C.Syntax;
 using Yoakke.SynKit.Lexer;
@@ -11,7 +13,33 @@ public static class TokenExtensions
         if (token.Kind != CTokenType.StringLiteral)
             throw new ParseException($"Non-string literal token: {token.Kind} {token.Text}");
 
-        // TODO[#235]: More thorough unwrap for more literal types.
-        return token.Text.Trim('"').Replace("\\n", "\n");
+        // simple escape sequences
+        var result = token.Text.Trim('"')
+            .Replace("\\'", "\'")
+            .Replace("\\\"", "\"")
+            .Replace("\\?", "?")
+            .Replace("\\\\", "\\")
+            .Replace("\\a", "\a")
+            .Replace("\\b", "\b")
+            .Replace("\\f", "\f")
+            .Replace("\\n", "\n")
+            .Replace("\\r", "\r")
+            .Replace("\\t", "\t")
+            .Replace("\\v", "\v");
+
+        // numeric escape sequences
+        result = Regex.Replace(result, @"\\([0-7]{3})", m =>
+            Convert.ToChar(Convert.ToUInt32(m.Groups[1].Value, 8)).ToString());
+
+        result = Regex.Replace(result, @"\\x([0-9a-fA-F]{2})", m =>
+            Convert.ToChar(Convert.ToUInt32(m.Groups[1].Value, 16)).ToString());
+
+        //todo: universal character names
+
+        //result = Regex.Replace(result, @"(\\u[0-9a-fA-F]{4})", "$1");
+
+        //result = Regex.Replace(result, @"(\\U[0-9a-fA-F]{8})", "$1");
+
+        return result;
     }
 }

--- a/Cesium.Parser/TokenExtensions.cs
+++ b/Cesium.Parser/TokenExtensions.cs
@@ -29,16 +29,17 @@ public static class TokenExtensions
 
         // numeric escape sequences
         result = Regex.Replace(result, @"\\([0-7]{3})", m =>
-            Convert.ToChar(Convert.ToUInt32(m.Groups[1].Value, 8)).ToString());
+            char.ConvertFromUtf32(Convert.ToInt32(m.Groups[1].Value, 8)));
 
-        result = Regex.Replace(result, @"\\x([0-9a-fA-F]{2})", m =>
-            Convert.ToChar(Convert.ToUInt32(m.Groups[1].Value, 16)).ToString());
+        result = Regex.Replace(result, @"\\[xX]([0-9a-fA-F]{2})", m =>
+            char.ConvertFromUtf32(Convert.ToInt32("0x" + m.Groups[1].Value, 16)));
 
-        //todo: universal character names
+        //universal character names
+        result = Regex.Replace(result, @"\\u([0-9a-fA-F]{4})", m =>
+            char.ConvertFromUtf32(Convert.ToInt32("0x" + m.Groups[1].Value, 16)));
 
-        //result = Regex.Replace(result, @"(\\u[0-9a-fA-F]{4})", "$1");
-
-        //result = Regex.Replace(result, @"(\\U[0-9a-fA-F]{8})", "$1");
+        result = Regex.Replace(result, @"\\U([0-9a-fA-F]{8})", m =>
+            char.ConvertFromUtf32(Convert.ToInt32("0x" + m.Groups[1].Value, 16)));
 
         return result;
     }


### PR DESCRIPTION
Hey folks!

I am trying to solve issue #235 but have two questions/problems:
- Did I choose the right direction to implement non-simple escape sequences or the solution with `Regex.Replace` is not what you expect to have?
- Two cases below are not interpreted by C (replaced by �) but interpreted by C# string/encoding utils. What did I miss?:(
```c
printf("\xF0"); // ð
printf("\xFF");// ÿ
```

Overall, I was trying to follow [this link](https://en.cppreference.com/w/c/language/character_constant) and fix [this integration test](https://github.com/ForNeVeR/Cesium/pull/275).

Closes #235.