### PR TITLE
Add support for stdbool.h

### DIFF
--- a/Cesium.Compiler/stdlib/stdbool.h
+++ b/Cesium.Compiler/stdlib/stdbool.h
@@ -1,0 +1,6 @@
+#define bool    _Bool
+
+#define true    1
+#define false   0
+
+#define __bool_true_false_are_defined 1

--- a/Cesium.IntegrationTests/stdlib/stdbool.c
+++ b/Cesium.IntegrationTests/stdlib/stdbool.c
@@ -1,0 +1,30 @@
+#include <stdbool.h>
+
+int main(int argc, char *argv[])
+{
+#ifndef bool
+    return 1;
+#endif
+
+#ifndef true
+    return 2;
+#endif
+
+#ifndef false
+    return 3;
+#endif
+
+#ifndef __bool_true_false_are_defined
+    return 4;
+#endif
+
+    if (true != 1) {
+        return 5;
+    }
+
+    if (false != 0) {
+        return 6;
+    }
+
+    return 42;
+}


### PR DESCRIPTION
Closes #292.

I was thinking about adding an include guard, but decided against it, as currently no other stdlib header has one. Include guards should probably be added at some point to conform to 7.1.2 (4).
