### PR TITLE
Add initial support for conditional expressions

### DIFF
--- a/Cesium.Ast/Expressions.cs
+++ b/Cesium.Ast/Expressions.cs
@@ -21,7 +21,7 @@ public record PrefixIncrementExpression(Expression Target) : Expression;
 public record UnaryOperatorExpression(string Operator, Expression Target) : Expression;
 public record IndirectionExpression(Expression Target) : Expression;
 
-// 6.5.5–6.5.15: Various binary operators
+// 6.5.5–6.5.14: Various binary operators
 public record BinaryOperatorExpression(Expression Left, string Operator, Expression Right) : Expression;
 public record LogicalBinaryOperatorExpression(Expression Left, string Operator, Expression Right)
     : BinaryOperatorExpression(Left, Operator, Right);
@@ -31,6 +31,10 @@ public record BitwiseBinaryOperatorExpression(Expression Left, string Operator, 
     : BinaryOperatorExpression(Left, Operator, Right);
 public record ComparisonBinaryOperatorExpression(Expression Left, string Operator, Expression Right)
     : BinaryOperatorExpression(Left, Operator, Right);
+
+// 6.5.15: Conditional operator
+public record ConditionalExpression(Expression Condition, Expression TrueExpression, Expression FalseExpression)
+    : Expression;
 
 // 6.5.16 Assignment operators
 public record AssignmentExpression(Expression Left, string Operator, Expression Right)

--- a/Cesium.CodeGen.Tests/CodeGenOperatorTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenOperatorTests.cs
@@ -15,4 +15,13 @@ public class CodeGenOperatorTests: CodeGenTestBase
 
     [Fact]
     public Task SubtractIntFromInt() => DoTest(@"int main() { int x = 2 - 1; }");
+
+    [Fact]
+    public Task ConditionalVoid() => DoTest(@"void foo() {} int main() { 1 ? foo() : foo(); }");
+
+    [Fact]
+    public Task ConditionalInt() => DoTest(@"int main() { int x = 1 ? 2 : 3; }");
+
+    [Fact]
+    public Task ConditionalFloatAndInt() => DoTest(@"int main() { float x = 1 ? 2.0f : 3; }");
 }

--- a/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.ConditionalFloatAndInt.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.ConditionalFloatAndInt.verified.txt
@@ -1,0 +1,24 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Single V_0
+  IL_0000: ldc.i4.1
+  IL_0001: brfalse IL_0010
+  IL_0006: ldc.r4 2
+  IL_000b: br IL_0013
+  IL_0010: nop
+  IL_0011: ldc.i4.3
+  IL_0012: conv.r4
+  IL_0013: nop
+  IL_0014: stloc.0
+  IL_0015: ldc.i4.0
+  IL_0016: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.ConditionalInt.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.ConditionalInt.verified.txt
@@ -1,0 +1,23 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32 V_0
+  IL_0000: ldc.i4.1
+  IL_0001: brfalse IL_000c
+  IL_0006: ldc.i4.2
+  IL_0007: br IL_000e
+  IL_000c: nop
+  IL_000d: ldc.i4.3
+  IL_000e: nop
+  IL_000f: stloc.0
+  IL_0010: ldc.i4.0
+  IL_0011: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.ConditionalVoid.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.ConditionalVoid.verified.txt
@@ -1,0 +1,23 @@
+﻿System.Void <Module>::foo()
+  IL_0000: ret
+
+System.Int32 <Module>::main()
+  IL_0000: ldc.i4.1
+  IL_0001: brfalse IL_0010
+  IL_0006: call System.Void <Module>::foo()
+  IL_000b: br IL_0016
+  IL_0010: nop
+  IL_0011: call System.Void <Module>::foo()
+  IL_0016: nop
+  IL_0017: ldc.i4.0
+  IL_0018: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen/Extensions/ExpressionEx.cs
+++ b/Cesium.CodeGen/Extensions/ExpressionEx.cs
@@ -27,6 +27,8 @@ internal static class ExpressionEx
         Ast.BitwiseBinaryOperatorExpression e => new BitwiseBinaryOperatorExpression(e),
         Ast.ComparisonBinaryOperatorExpression e => new ComparisonBinaryOperatorExpression(e),
 
+        Ast.ConditionalExpression e => new ConditionalExpression(e),
+
         Ast.SubscriptingExpression e => new SubscriptingExpression(e),
         Ast.MemberAccessExpression e => new MemberAccessExpression(e),
         Ast.PointerMemberAccessExpression e => new PointerMemberAccessExpression(e),

--- a/Cesium.CodeGen/Ir/Expressions/ConditionalExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/ConditionalExpression.cs
@@ -1,0 +1,119 @@
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Extensions;
+using Cesium.CodeGen.Ir.Types;
+using Cesium.Core;
+using Mono.Cecil.Cil;
+
+namespace Cesium.CodeGen.Ir.Expressions;
+
+internal class ConditionalExpression : IExpression
+{
+    private readonly IExpression _condition;
+    private readonly IExpression _trueExpression;
+    private readonly IExpression _falseExpression;
+
+    private ConditionalExpression(IExpression condition, IExpression trueExpression, IExpression falseExpression)
+    {
+        _condition = condition;
+        _trueExpression = trueExpression;
+        _falseExpression = falseExpression;
+    }
+
+    public ConditionalExpression(Ast.ConditionalExpression expression)
+    {
+        _condition = expression.Condition.ToIntermediate();
+        _trueExpression = expression.TrueExpression.ToIntermediate();
+        _falseExpression = expression.FalseExpression.ToIntermediate();
+    }
+
+    public IExpression Lower(IDeclarationScope scope)
+    {
+        var condition = _condition.Lower(scope);
+        var conditionType = _condition.GetExpressionType(scope);
+
+        if (!(scope.CTypeSystem.IsNumeric(conditionType) || conditionType is PointerType))
+        {
+            throw new CompilationException("Conditional expression must have a condition of scalar type.");
+        }
+
+        var trueExpression = _trueExpression.Lower(scope);
+        var trueExpressionType = trueExpression.GetExpressionType(scope);
+
+        var falseExpression = _falseExpression.Lower(scope);
+        var falseExpressionType = falseExpression.GetExpressionType(scope);
+
+        // Check if both expressions are compatible and convert them to the same type if needed.
+        if (scope.CTypeSystem.IsNumeric(trueExpressionType) &&
+            scope.CTypeSystem.IsNumeric(falseExpressionType))
+        {
+            // Both operands have arithmetic type. Convert them to the same type by usual arithmetic conversions.
+            var commonType = scope.CTypeSystem.GetCommonNumericType(trueExpressionType, falseExpressionType);
+            if (!trueExpressionType.IsEqualTo(commonType))
+            {
+                trueExpression = new TypeCastExpression(commonType, trueExpression).Lower(scope);
+            }
+
+            if (!falseExpressionType.IsEqualTo(commonType))
+            {
+                falseExpression = new TypeCastExpression(commonType, falseExpression).Lower(scope);
+            }
+        }
+        else if (trueExpressionType.IsEqualTo(scope.CTypeSystem.Void) &&
+                 falseExpressionType.IsEqualTo(scope.CTypeSystem.Void))
+        {
+            // Both operands have void type. No conversion is needed.
+        }
+        else
+        {
+            // TODO[#208]: Support operands of same struct or union type; pointers to compatible types;
+            // pointer and null pointer constant; pointer to an object type and pointer to void.
+            throw new WipException(208, "Conditional expression with this type is not supported yet.");
+        }
+
+        return new ConditionalExpression(condition, trueExpression, falseExpression);
+    }
+
+    public void EmitTo(IEmitScope scope)
+    {
+        var bodyProcessor = scope.Method.Body.GetILProcessor();
+
+        _condition.EmitTo(scope);
+
+        var falseLabel = bodyProcessor.Create(OpCodes.Nop);
+        bodyProcessor.Emit(OpCodes.Brfalse, falseLabel);
+
+        _trueExpression.EmitTo(scope);
+
+        var endLabel = bodyProcessor.Create(OpCodes.Nop);
+        bodyProcessor.Emit(OpCodes.Br, endLabel);
+
+        bodyProcessor.Append(falseLabel);
+        _falseExpression.EmitTo(scope);
+
+        bodyProcessor.Append(endLabel);
+    }
+
+    public IType GetExpressionType(IDeclarationScope scope)
+    {
+        var trueExpressionType = _trueExpression.GetExpressionType(scope);
+        var falseExpressionType = _falseExpression.GetExpressionType(scope);
+
+        // Arithmetic types.
+        if (scope.CTypeSystem.IsNumeric(trueExpressionType) &&
+            scope.CTypeSystem.IsNumeric(falseExpressionType))
+        {
+            return scope.CTypeSystem.GetCommonNumericType(trueExpressionType, falseExpressionType);
+        }
+
+        // Void types.
+        if (trueExpressionType.IsEqualTo(scope.CTypeSystem.Void) &&
+            falseExpressionType.IsEqualTo(scope.CTypeSystem.Void))
+        {
+            return scope.CTypeSystem.Void;
+        }
+
+        // TODO[#208]: Support operands of same struct or union type; pointers to compatible types;
+        // pointer and null pointer constant; pointer to an object type and pointer to void.
+        throw new WipException(208, "Conditional expression with this type is not supported yet.");
+    }
+}

--- a/Cesium.CodeGen/Ir/Types/CTypeSystem.cs
+++ b/Cesium.CodeGen/Ir/Types/CTypeSystem.cs
@@ -7,6 +7,7 @@ namespace Cesium.CodeGen.Ir.Types;
 
 internal class CTypeSystem
 {
+    public IType Void { get; } = new PrimitiveType(PrimitiveTypeKind.Void);
     public IType Bool { get; } = new PrimitiveType(PrimitiveTypeKind.Int); // TODO[#179]: Figure out the right type.
     public IType Char { get; } = new PrimitiveType(PrimitiveTypeKind.Char);
     public IType SignedChar { get; } = new PrimitiveType(PrimitiveTypeKind.SignedChar);

--- a/Cesium.IntegrationTests/tertiary_operator.c
+++ b/Cesium.IntegrationTests/tertiary_operator.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+int main(void)
+{
+    // True case.
+    int time = 12;
+    (time < 18) ? printf("Good day.") : printf("Good evening.");
+
+    // False case.
+    time = 20;
+    (time < 18) ? printf("Good day.") : printf("Good evening.");
+
+    return 42;
+}

--- a/Cesium.IntegrationTests/tertiary_operator.ignore.c
+++ b/Cesium.IntegrationTests/tertiary_operator.ignore.c
@@ -1,8 +1,0 @@
-#include <stdio.h>
-
-int main(void)
-{
-    int time = 20;
-    (time < 18) ? printf("Good day.") : printf("Good evening.");
-    return 42;
-}

--- a/Cesium.Parser.Tests/ParserTests/StatementParserTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/StatementParserTests.cs
@@ -58,6 +58,9 @@ if (1)
     public Task LogicalOrOperator() => DoTest("return 1 || 2;");
 
     [Fact]
+    public Task ConditionalOperator() => DoTest("return 1 ? 2 ? 3 : 4 ? 5 : 6 : 7;");
+
+    [Fact]
     public Task ForStatement_Full() => DoTest("for (i = 1; i < 0; ++i) ++i;");
 
     [Fact]

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ConditionalOperator.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ConditionalOperator.verified.txt
@@ -1,0 +1,61 @@
+{
+  "$type": "Cesium.Ast.ReturnStatement, Cesium.Ast",
+  "Expression": {
+    "$type": "Cesium.Ast.ConditionalExpression, Cesium.Ast",
+    "Condition": {
+      "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+      "Constant": {
+        "Kind": "IntLiteral",
+        "Text": "1"
+      }
+    },
+    "TrueExpression": {
+      "$type": "Cesium.Ast.ConditionalExpression, Cesium.Ast",
+      "Condition": {
+        "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+        "Constant": {
+          "Kind": "IntLiteral",
+          "Text": "2"
+        }
+      },
+      "TrueExpression": {
+        "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+        "Constant": {
+          "Kind": "IntLiteral",
+          "Text": "3"
+        }
+      },
+      "FalseExpression": {
+        "$type": "Cesium.Ast.ConditionalExpression, Cesium.Ast",
+        "Condition": {
+          "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+          "Constant": {
+            "Kind": "IntLiteral",
+            "Text": "4"
+          }
+        },
+        "TrueExpression": {
+          "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+          "Constant": {
+            "Kind": "IntLiteral",
+            "Text": "5"
+          }
+        },
+        "FalseExpression": {
+          "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+          "Constant": {
+            "Kind": "IntLiteral",
+            "Text": "6"
+          }
+        }
+      }
+    },
+    "FalseExpression": {
+      "$type": "Cesium.Ast.ConstantExpression, Cesium.Ast",
+      "Constant": {
+        "Kind": "IntLiteral",
+        "Text": "7"
+      }
+    }
+  }
+}

--- a/Cesium.Parser/CParser.cs
+++ b/Cesium.Parser/CParser.cs
@@ -207,7 +207,10 @@ public partial class CParser
     private static Expression MakeLogicalOrExpression(Expression a, ICToken @operator, Expression b) =>
         new LogicalBinaryOperatorExpression(a, @operator.Text, b);
 
-    // TODO[#207]: 6.5.15 Conditional operator
+    // 6.5.15 Conditional operator
+    [Rule("conditional_expression: logical_OR_expression '?' expression ':' conditional_expression")]
+    private static Expression MakeConditionalExpression(Expression a, ICToken _, Expression b, ICToken __, Expression c) =>
+        new ConditionalExpression(a, b, c);
 
     // 6.5.16 Assignment operators
     [Rule("assignment_expression: unary_expression assignment_operator assignment_expression")]


### PR DESCRIPTION
Conditional expressions can be parsed and code generation works, but only for arithmetic types and the void type.

Relates to #207 and #208.

These cases from 6.5.15 are not yet supported (because I don't know how to properly handle these cases):
* both operands have the same structure or union type
* both operands are pointers to qualified or unqualified versions of compatible types
* one operand is a pointer and the other is a null pointer constant
* one operand is a pointer to an object type and the other is a pointer to a qualified or unqualified version of `void`
