### PR TITLE
Fix type of GetAddressValueExpression

### DIFF
--- a/Cesium.CodeGen/Ir/Expressions/GetAddressValueExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/GetAddressValueExpression.cs
@@ -1,4 +1,5 @@
 using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Extensions;
 using Cesium.CodeGen.Ir.Expressions.Values;
 using Cesium.CodeGen.Ir.Types;
 using Mono.Cecil.Cil;
@@ -22,5 +23,5 @@ internal class GetAddressValueExpression : IExpression
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Conv_U));
     }
 
-    public IType GetExpressionType(IDeclarationScope scope) => _value.GetValueType();
+    public IType GetExpressionType(IDeclarationScope scope) => _value.GetValueType().MakePointerType();
 }


### PR DESCRIPTION
While working pointer support for #297, I believe I discovered a bug in `GetAddressValueExpression`. The type of the expression was the type of the value the address was taken of, but it should be a pointer to the type of the value.