### PR TITLE
IDeclarationScope: add a using to import CompilationException

### DIFF
--- a/Cesium.CodeGen/Contexts/IDeclarationScope.cs
+++ b/Cesium.CodeGen/Contexts/IDeclarationScope.cs
@@ -1,6 +1,7 @@
 using Cesium.CodeGen.Contexts.Meta;
 using Cesium.CodeGen.Ir;
 using Cesium.CodeGen.Ir.Types;
+using Cesium.Core;
 
 namespace Cesium.CodeGen.Contexts;
 


### PR DESCRIPTION
Otherwise, `CompilationException` doesn't get resolved in the XML documentation.