### PR TITLE
Allocate global array variables on the heap

### DIFF
--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalArrayAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalArrayAssignment.verified.txt
@@ -1,9 +1,9 @@
 ﻿System.Void <Module>::.cctor()
   IL_0000: ldc.i4 40
   IL_0005: conv.u
-  IL_0006: localloc
-  IL_0008: stsfld System.Int32* <Module>::a
-  IL_000d: ret
+  IL_0006: call System.Void* Cesium.Runtime.RuntimeHelpers::AllocateGlobalField(System.UInt32)
+  IL_000b: stsfld System.Int32* <Module>::a
+  IL_0010: ret
 
 System.Int32 <Module>::main()
   IL_0000: ldsflda System.Int32* <Module>::a

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalMultidimensionalArrayAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalMultidimensionalArrayAssignment.verified.txt
@@ -1,9 +1,9 @@
 ﻿System.Void <Module>::.cctor()
   IL_0000: ldc.i4 160
   IL_0005: conv.u
-  IL_0006: localloc
-  IL_0008: stsfld System.Int32* <Module>::a
-  IL_000d: ret
+  IL_0006: call System.Void* Cesium.Runtime.RuntimeHelpers::AllocateGlobalField(System.UInt32)
+  IL_000b: stsfld System.Int32* <Module>::a
+  IL_0010: ret
 
 System.Int32 <Module>::main()
   IL_0000: ldsfld System.Int32* <Module>::a

--- a/Cesium.CodeGen/Ir/Types/InPlaceArrayType.cs
+++ b/Cesium.CodeGen/Ir/Types/InPlaceArrayType.cs
@@ -57,7 +57,15 @@ internal record InPlaceArrayType(IType Base, int Size) : IType
         var method = scope.Method.Body.GetILProcessor();
         method.Emit(OpCodes.Ldc_I4, arraySizeInBytes);
         method.Emit(OpCodes.Conv_U);
-        method.Emit(OpCodes.Localloc);
+        if (scope is GlobalConstructorScope)
+        {
+            var allocateGlobalFieldMethod = scope.Context.GetRuntimeHelperMethod("AllocateGlobalField");
+            method.Emit(OpCodes.Call, allocateGlobalFieldMethod);
+        }
+        else
+        {
+            method.Emit(OpCodes.Localloc);
+        }
     }
 
     public int SizeInBytes => Base.SizeInBytes * Size;

--- a/Cesium.Runtime.Tests/Cesium.Runtime.Tests.csproj
+++ b/Cesium.Runtime.Tests/Cesium.Runtime.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net6.0;net48</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">$(TargetFrameworks);net48</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Cesium.Runtime.Tests/Cesium.Runtime.Tests.csproj
+++ b/Cesium.Runtime.Tests/Cesium.Runtime.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>netcoreapp3.1;net6.0;net48</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Cesium.Runtime\Cesium.Runtime.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Cesium.Runtime.Tests/RuntimeHelpersTests.cs
+++ b/Cesium.Runtime.Tests/RuntimeHelpersTests.cs
@@ -1,0 +1,23 @@
+namespace Cesium.Runtime.Tests;
+
+public class RuntimeHelpersTests
+{
+    [Fact]
+    public unsafe void AllocateGlobalFieldTest()
+    {
+        const int size = 300;
+        var memory = (byte*)RuntimeHelpers.AllocateGlobalField(size);
+        try
+        {
+            for (var i = 0; i < size; ++i)
+                memory[i] = (byte)i;
+
+            for (var i = 0; i < size; ++i)
+                Assert.Equal((byte)i, memory[i]);
+        }
+        finally
+        {
+            RuntimeHelpers.FreeGlobalField(memory);
+        }
+    }
+}

--- a/Cesium.Runtime.Tests/Usings.cs
+++ b/Cesium.Runtime.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Cesium.Runtime/RuntimeHelpers.cs
+++ b/Cesium.Runtime/RuntimeHelpers.cs
@@ -53,4 +53,13 @@ public static unsafe class RuntimeHelpers
     {
         System.Environment.Exit(exitCode);
     }
+
+    public static void* AllocateGlobalField(uint size)
+    {
+#if NETSTANDARD2_0
+        throw new NotImplementedException();
+#else
+        return NativeMemory.Alloc(size);
+#endif
+    }
 }

--- a/Cesium.Runtime/RuntimeHelpers.cs
+++ b/Cesium.Runtime/RuntimeHelpers.cs
@@ -51,15 +51,16 @@ public static unsafe class RuntimeHelpers
 
     public static void Exit(int exitCode)
     {
-        System.Environment.Exit(exitCode);
+        Environment.Exit(exitCode);
     }
 
     public static void* AllocateGlobalField(uint size)
     {
-#if NETSTANDARD2_0
-        throw new NotImplementedException();
-#else
-        return NativeMemory.Alloc(size);
-#endif
+        return (void*)Marshal.AllocHGlobal(checked((int)size));
+    }
+
+    public static void FreeGlobalField(void* field)
+    {
+        Marshal.FreeHGlobal((IntPtr)field);
     }
 }

--- a/Cesium.sln
+++ b/Cesium.sln
@@ -73,6 +73,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "perform-common-steps", "per
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cesium.Core", "Cesium.Core\Cesium.Core.csproj", "{C83A5A9A-5667-4574-B75C-EFF38FA0FE79}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cesium.Runtime.Tests", "Cesium.Runtime.Tests\Cesium.Runtime.Tests.csproj", "{526D8E61-6143-490F-BB9D-E7CD78512E55}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -123,6 +125,10 @@ Global
 		{C83A5A9A-5667-4574-B75C-EFF38FA0FE79}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C83A5A9A-5667-4574-B75C-EFF38FA0FE79}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C83A5A9A-5667-4574-B75C-EFF38FA0FE79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{526D8E61-6143-490F-BB9D-E7CD78512E55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{526D8E61-6143-490F-BB9D-E7CD78512E55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{526D8E61-6143-490F-BB9D-E7CD78512E55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{526D8E61-6143-490F-BB9D-E7CD78512E55}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,10 @@
 <Project>
-    <PropertyGroup>
+    <PropertyGroup Label="Versioning">
+        <VersionPrefix>0.0.1</VersionPrefix>
+    </PropertyGroup>
+    <PropertyGroup Label="Language">
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
-        <VersionPrefix>0.0.1</VersionPrefix>
+        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
In previous PR I allocate global array variables using localalloc in the module constructor. That's obviously does not work, but small integration tests does nto catch that. Only after I start running GOL I discover that issue. For now I allocate on the heap and only in .NET 6 configuration. following issues
- Provide netstandard implementation for memory allocation (basically port NativeMemory)
- Codegen for memory deallocation if module is unloaded.

**After merge (F):**
- [ ] open a new issue about module deinitializers