### PR TITLE
Compiler: architecture sets

### DIFF
--- a/Cesium.CodeGen.Tests/ArchitectureDependentCodeTests.cs
+++ b/Cesium.CodeGen.Tests/ArchitectureDependentCodeTests.cs
@@ -1,0 +1,27 @@
+using JetBrains.Annotations;
+
+namespace Cesium.CodeGen.Tests;
+
+public class ArchitectureDependentCodeTests : CodeGenTestBase
+{
+    [MustUseReturnValue]
+    private static Task DoTest(string source, string @namespace = "", string globalTypeFqn = "")
+    {
+        Assert.True(false, "TODO: Provide architecture for tests");
+        var assembly = GenerateAssembly(default, @namespace, globalTypeFqn, source);
+        return VerifyMethods(assembly);
+    }
+
+    [Theory]
+    [InlineData()] // TODO: 64b
+    [InlineData()] // TODO: 32b
+    [InlineData()] // TODO: dynamic
+    public Task StaticArray() => DoTest("""
+int main(void)
+{
+    int x[300];
+    x[299] = 0;
+    return x[299];
+}
+""");
+}

--- a/Cesium.CodeGen.Tests/ArchitectureDependentCodeTests.cs
+++ b/Cesium.CodeGen.Tests/ArchitectureDependentCodeTests.cs
@@ -9,7 +9,8 @@ public class ArchitectureDependentCodeTests : CodeGenTestBase
     {
         Assert.True(false, "TODO: Provide architecture for tests");
         var assembly = GenerateAssembly(default, @namespace, globalTypeFqn, source);
-        return VerifyMethods(assembly);
+        var moduleType = assembly.Modules.Single().GetType("<Module>");
+        return VerifyMethods(moduleType);
     }
 
     [Theory]

--- a/Cesium.CodeGen.Tests/ArchitectureDependentCodeTests.cs
+++ b/Cesium.CodeGen.Tests/ArchitectureDependentCodeTests.cs
@@ -5,22 +5,21 @@ namespace Cesium.CodeGen.Tests;
 public class ArchitectureDependentCodeTests : CodeGenTestBase
 {
     [MustUseReturnValue]
-    private static Task DoTest(string source, string @namespace = "", string globalTypeFqn = "")
+    private static Task DoTest(TargetArchitectureSet arch, string source)
     {
-        Assert.True(false, "TODO: Provide architecture for tests");
-        var assembly = GenerateAssembly(default, @namespace, globalTypeFqn, source);
+        var assembly = GenerateAssembly(runtime: default, arch: arch, sources: source);
         var moduleType = assembly.Modules.Single().GetType("<Module>");
-        return VerifyMethods(moduleType);
+        return VerifyMethods(moduleType, arch);
     }
 
     [Theory]
-    [InlineData()] // TODO: 64b
-    [InlineData()] // TODO: 32b
-    [InlineData()] // TODO: dynamic
-    public Task StaticArray() => DoTest("""
+    [InlineData(TargetArchitectureSet.Bit64)]
+    [InlineData(TargetArchitectureSet.Bit32)]
+    [InlineData(TargetArchitectureSet.Dynamic)]
+    public Task StaticArray(TargetArchitectureSet arch) => DoTest(arch, """
 int main(void)
 {
-    int x[300];
+    int *x[300];
     x[299] = 0;
     return x[299];
 }

--- a/Cesium.CodeGen.Tests/ArchitectureDependentTypeTests.cs
+++ b/Cesium.CodeGen.Tests/ArchitectureDependentTypeTests.cs
@@ -1,0 +1,33 @@
+using JetBrains.Annotations;
+
+namespace Cesium.CodeGen.Tests;
+
+public class ArchitectureDependentTypeTests : CodeGenTestBase
+{
+    [MustUseReturnValue]
+    private static Task DoTest(string source, string @namespace = "", string globalTypeFqn = "")
+    {
+        Assert.True(false, "TODO: Provide architecture for tests");
+        var assembly = GenerateAssembly(default, @namespace, globalTypeFqn, source);
+        return VerifyTypes(assembly);
+    }
+
+    [Theory]
+    [InlineData()] // TODO: 64b
+    [InlineData()] // TODO: 32b
+    public Task StructWithPointer() => DoTest("""
+struct foo
+{
+    char *x[1];
+};
+""");
+
+    [Fact(DisplayName = "Struct with a fixed array of a pointer type isn't supported for dynamic architecture")]
+    // TODO: Provide the architecture.
+    public void StructWithPointerDynamic() => DoesNotCompile("""
+struct foo
+{
+    char *x[1];
+};
+""", "Dynamic architecture doesn't support fixed struct member of architecture-dependent size.");
+}

--- a/Cesium.CodeGen.Tests/ArchitectureDependentTypeTests.cs
+++ b/Cesium.CodeGen.Tests/ArchitectureDependentTypeTests.cs
@@ -8,7 +8,7 @@ public class ArchitectureDependentTypeTests : CodeGenTestBase
     private static Task DoTest(string source, string @namespace = "", string globalTypeFqn = "")
     {
         Assert.True(false, "TODO: Provide architecture for tests");
-        var assembly = GenerateAssembly(default, @namespace, globalTypeFqn, source);
+        var assembly = GenerateAssembly(default, @namespace: @namespace, globalTypeFqn: globalTypeFqn, sources: source);
         return VerifyTypes(assembly);
     }
 

--- a/Cesium.CodeGen.Tests/ArchitectureDependentTypeTests.cs
+++ b/Cesium.CodeGen.Tests/ArchitectureDependentTypeTests.cs
@@ -5,29 +5,34 @@ namespace Cesium.CodeGen.Tests;
 public class ArchitectureDependentTypeTests : CodeGenTestBase
 {
     [MustUseReturnValue]
-    private static Task DoTest(string source, string @namespace = "", string globalTypeFqn = "")
+    private static Task DoTest(TargetArchitectureSet arch, string source, string @namespace = "", string globalTypeFqn = "")
     {
-        Assert.True(false, "TODO: Provide architecture for tests");
-        var assembly = GenerateAssembly(default, @namespace: @namespace, globalTypeFqn: globalTypeFqn, sources: source);
-        return VerifyTypes(assembly);
+        var assembly = GenerateAssembly(
+            default,
+            arch,
+            @namespace: @namespace,
+            globalTypeFqn: globalTypeFqn,
+            sources: source);
+        return VerifyTypes(assembly, arch);
     }
 
     [Theory]
-    [InlineData()] // TODO: 64b
-    [InlineData()] // TODO: 32b
-    public Task StructWithPointer() => DoTest("""
-struct foo
+    [InlineData(TargetArchitectureSet.Bit64)]
+    [InlineData(TargetArchitectureSet.Bit32)]
+    public Task StructWithPointer(TargetArchitectureSet arch) => DoTest(arch, """
+typedef struct
 {
     char *x[1];
-};
+} foo;
 """);
 
     [Fact(DisplayName = "Struct with a fixed array of a pointer type isn't supported for dynamic architecture")]
-    // TODO: Provide the architecture.
     public void StructWithPointerDynamic() => DoesNotCompile("""
-struct foo
+typedef struct
 {
     char *x[1];
-};
-""", "Dynamic architecture doesn't support fixed struct member of architecture-dependent size.");
+} foo;
+""",
+        "Cannot statically determine a size of type",
+        arch: TargetArchitectureSet.Dynamic);
 }

--- a/Cesium.CodeGen.Tests/CodeGenTestBase.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTestBase.cs
@@ -22,7 +22,7 @@ public abstract class CodeGenTestBase : VerifyTestBase
     }
     protected static AssemblyDefinition GenerateAssembly(TargetRuntimeDescriptor? runtime, string @namespace = "", string globalTypeFqn = "", params string[] sources)
     {
-        var context = CreateAssembly(runtime, @namespace, globalTypeFqn);
+        var context = CreateAssembly(runtime, @namespace: @namespace, globalTypeFqn: globalTypeFqn);
         GenerateCode(context, sources);
         return EmitAssembly(context);
     }
@@ -38,10 +38,15 @@ public abstract class CodeGenTestBase : VerifyTestBase
         Assert.Contains(expectedMessage, ex.Message);
     }
 
-    private static AssemblyContext CreateAssembly(TargetRuntimeDescriptor? targetRuntime, string @namespace = "", string globalTypeFqn = "")
+    private static AssemblyContext CreateAssembly(
+        TargetRuntimeDescriptor? targetRuntime,
+        TargetArchitectureSet targetArchitectureSet = TargetArchitectureSet.Dynamic,
+        string @namespace = "",
+        string globalTypeFqn = "")
     {
         CompilationOptions compilationOptions = new CompilationOptions(
             targetRuntime ?? TargetRuntimeDescriptor.Net60,
+            targetArchitectureSet,
             ModuleKind.Console,
             typeof(Math).Assembly.Location,
             typeof(Runtime.RuntimeHelpers).Assembly.Location,

--- a/Cesium.CodeGen.Tests/CodeGenTestBase.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTestBase.cs
@@ -31,14 +31,26 @@ public abstract class CodeGenTestBase : VerifyTestBase
         return EmitAssembly(context);
     }
 
-    protected static void DoesNotCompile(string source, string expectedMessage)
+    protected static void DoesNotCompile(
+        string source,
+        string expectedMessage,
+        TargetRuntimeDescriptor? runtime = null,
+        TargetArchitectureSet arch = TargetArchitectureSet.Dynamic,
+        string @namespace = "",
+        string globalTypeFqn = "")
     {
-        DoesNotCompile<CompilationException>(source, expectedMessage);
+        DoesNotCompile<CompilationException>(source, expectedMessage, runtime, arch, @namespace, globalTypeFqn);
     }
 
-    protected static void DoesNotCompile<T>(string source, string expectedMessage) where T : CesiumException
+    protected static void DoesNotCompile<T>(
+        string source,
+        string expectedMessage,
+        TargetRuntimeDescriptor? runtime = null,
+        TargetArchitectureSet arch = TargetArchitectureSet.Dynamic,
+        string @namespace = "",
+        string globalTypeFqn = "") where T : CesiumException
     {
-        var ex = Assert.Throws<T>(() => GenerateAssembly(default, source));
+        var ex = Assert.Throws<T>(() => GenerateAssembly(runtime, arch, @namespace, globalTypeFqn, source));
         Assert.Contains(expectedMessage, ex.Message);
     }
 
@@ -91,7 +103,7 @@ public abstract class CodeGenTestBase : VerifyTestBase
     }
 
     [MustUseReturnValue]
-    protected static Task VerifyTypes(AssemblyDefinition assembly)
+    protected static Task VerifyTypes(AssemblyDefinition assembly, params object[] parameters)
     {
         var result = new StringBuilder();
         foreach (var module in assembly.Modules)
@@ -100,7 +112,7 @@ public abstract class CodeGenTestBase : VerifyTestBase
             DumpTypes(module.Types, result, 1);
         }
 
-        return Verify(result, GetSettings());
+        return Verify(result, GetSettings(parameters));
     }
 
     [MustUseReturnValue]

--- a/Cesium.CodeGen.Tests/CodeGenTestBase.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTestBase.cs
@@ -20,9 +20,13 @@ public abstract class CodeGenTestBase : VerifyTestBase
         GenerateCode(context, sources);
         return EmitAssembly(context);
     }
-    protected static AssemblyDefinition GenerateAssembly(TargetRuntimeDescriptor? runtime, string @namespace = "", string globalTypeFqn = "", params string[] sources)
+    protected static AssemblyDefinition GenerateAssembly(
+        TargetRuntimeDescriptor? runtime,
+        TargetArchitectureSet arch = TargetArchitectureSet.Dynamic,
+        string @namespace = "",
+        string globalTypeFqn = "", params string[] sources)
     {
-        var context = CreateAssembly(runtime, @namespace: @namespace, globalTypeFqn: globalTypeFqn);
+        var context = CreateAssembly(runtime, arch, @namespace: @namespace, globalTypeFqn: globalTypeFqn);
         GenerateCode(context, sources);
         return EmitAssembly(context);
     }
@@ -100,12 +104,12 @@ public abstract class CodeGenTestBase : VerifyTestBase
     }
 
     [MustUseReturnValue]
-    protected static Task VerifyMethods(TypeDefinition type)
+    protected static Task VerifyMethods(TypeDefinition type, params object[] parameters)
     {
         var result = new StringBuilder();
         DumpMethods(type, result);
 
-        return Verify(result, GetSettings());
+        return Verify(result, GetSettings(parameters));
     }
 
     private static void DumpTypes(IEnumerable<TypeDefinition> types, StringBuilder result, int indent)

--- a/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTypeTests.cs
@@ -7,7 +7,7 @@ public class CodeGenTypeTests : CodeGenTestBase
     [MustUseReturnValue]
     private static Task DoTest(string source, string @namespace = "", string globalTypeFqn = "")
     {
-        var assembly = GenerateAssembly(default, @namespace, globalTypeFqn, source);
+        var assembly = GenerateAssembly(default, @namespace: @namespace, globalTypeFqn: globalTypeFqn, sources: source);
         return VerifyTypes(assembly);
     }
 

--- a/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Bit32.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Bit32.verified.txt
@@ -1,0 +1,35 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32* V_0
+  IL_0000: ldc.i4 1200
+  IL_0005: conv.u
+  IL_0006: localloc
+  IL_0008: stloc.0
+  IL_0009: ldloc.0
+  IL_000a: conv.u
+  IL_000b: ldc.i4.4
+  IL_000c: ldc.i4 299
+  IL_0011: mul
+  IL_0012: conv.i
+  IL_0013: add
+  IL_0014: ldc.i4.0
+  IL_0015: stind.i
+  IL_0016: ldloc.0
+  IL_0017: conv.u
+  IL_0018: ldc.i4.4
+  IL_0019: ldc.i4 299
+  IL_001e: mul
+  IL_001f: conv.i
+  IL_0020: add
+  IL_0021: ldind.i
+  IL_0022: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Bit64.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Bit64.verified.txt
@@ -1,0 +1,35 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32* V_0
+  IL_0000: ldc.i4 2400
+  IL_0005: conv.u
+  IL_0006: localloc
+  IL_0008: stloc.0
+  IL_0009: ldloc.0
+  IL_000a: conv.u
+  IL_000b: ldc.i4.8
+  IL_000c: ldc.i4 299
+  IL_0011: mul
+  IL_0012: conv.i
+  IL_0013: add
+  IL_0014: ldc.i4.0
+  IL_0015: stind.i
+  IL_0016: ldloc.0
+  IL_0017: conv.u
+  IL_0018: ldc.i4.8
+  IL_0019: ldc.i4 299
+  IL_001e: mul
+  IL_001f: conv.i
+  IL_0020: add
+  IL_0021: ldind.i
+  IL_0022: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Dynamic.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Dynamic.verified.txt
@@ -1,0 +1,37 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32* V_0
+  IL_0000: sizeof System.Int32*
+  IL_0006: ldc.i4 300
+  IL_000b: mul
+  IL_000c: conv.u
+  IL_000d: localloc
+  IL_000f: stloc.0
+  IL_0010: ldloc.0
+  IL_0011: conv.u
+  IL_0012: sizeof System.Int32*
+  IL_0018: ldc.i4 299
+  IL_001d: mul
+  IL_001e: conv.i
+  IL_001f: add
+  IL_0020: ldc.i4.0
+  IL_0021: stind.i
+  IL_0022: ldloc.0
+  IL_0023: conv.u
+  IL_0024: sizeof System.Int32*
+  IL_002a: ldc.i4 299
+  IL_002f: mul
+  IL_0030: conv.i
+  IL_0031: add
+  IL_0032: ldind.i
+  IL_0033: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/ArchitectureDependentTypeTests.StructWithPointer_arch=Bit32.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/ArchitectureDependentTypeTests.StructWithPointer_arch=Bit32.verified.txt
@@ -1,0 +1,19 @@
+﻿Module: Primary
+  Type: <Module>
+
+  Type: foo
+  Nested types:
+    Type: foo/<SyntheticBuffer>x
+    Pack: 0
+    Size: 4
+    Custom attributes:
+    - CompilerGeneratedAttribute()
+    - UnsafeValueTypeAttribute()
+
+    Fields:
+      System.Byte* foo/<SyntheticBuffer>x::FixedElementField
+  Fields:
+    foo/<SyntheticBuffer>x foo::x
+    Custom attributes:
+    - FixedBufferAttribute(System.Byte*, 4)
+

--- a/Cesium.CodeGen.Tests/verified/ArchitectureDependentTypeTests.StructWithPointer_arch=Bit64.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/ArchitectureDependentTypeTests.StructWithPointer_arch=Bit64.verified.txt
@@ -1,0 +1,19 @@
+﻿Module: Primary
+  Type: <Module>
+
+  Type: foo
+  Nested types:
+    Type: foo/<SyntheticBuffer>x
+    Pack: 0
+    Size: 8
+    Custom attributes:
+    - CompilerGeneratedAttribute()
+    - UnsafeValueTypeAttribute()
+
+    Fields:
+      System.Byte* foo/<SyntheticBuffer>x::FixedElementField
+  Fields:
+    foo/<SyntheticBuffer>x foo::x
+    Custom attributes:
+    - FixedBufferAttribute(System.Byte*, 8)
+

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayAddressOf.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayAddressOf.verified.txt
@@ -2,20 +2,20 @@
   Locals:
     System.Int32* V_0
     System.Int32* V_1
-  IL_0000: ldc.i4 40
-  IL_0005: conv.u
-  IL_0006: localloc
-  IL_0008: stloc.0
-  IL_0009: ldloc.0
-  IL_000a: ldc.i4.2
-  IL_000b: conv.i
-  IL_000c: ldc.i4 4
-  IL_0011: mul
-  IL_0012: add
-  IL_0013: conv.u
-  IL_0014: stloc.1
-  IL_0015: ldc.i4.0
-  IL_0016: ret
+  IL_0000: ldc.i4.s 40
+  IL_0002: conv.u
+  IL_0003: localloc
+  IL_0005: stloc.0
+  IL_0006: ldloc.0
+  IL_0007: ldc.i4.2
+  IL_0008: conv.i
+  IL_0009: ldc.i4 4
+  IL_000e: mul
+  IL_000f: add
+  IL_0010: conv.u
+  IL_0011: stloc.1
+  IL_0012: ldc.i4.0
+  IL_0013: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayAssignment.verified.txt
@@ -1,28 +1,28 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32* V_0
-  IL_0000: ldc.i4 40
-  IL_0005: conv.u
-  IL_0006: localloc
-  IL_0008: stloc.0
-  IL_0009: ldloc.0
-  IL_000a: conv.u
-  IL_000b: ldc.i4.4
-  IL_000c: ldc.i4.1
-  IL_000d: mul
-  IL_000e: conv.i
-  IL_000f: add
-  IL_0010: ldc.i4.2
-  IL_0011: stind.i4
-  IL_0012: ldloc.0
-  IL_0013: conv.u
-  IL_0014: ldc.i4.4
-  IL_0015: ldc.i4.1
-  IL_0016: mul
-  IL_0017: conv.i
-  IL_0018: add
-  IL_0019: ldind.i4
-  IL_001a: ret
+  IL_0000: ldc.i4.s 40
+  IL_0002: conv.u
+  IL_0003: localloc
+  IL_0005: stloc.0
+  IL_0006: ldloc.0
+  IL_0007: conv.u
+  IL_0008: ldc.i4.4
+  IL_0009: ldc.i4.1
+  IL_000a: mul
+  IL_000b: conv.i
+  IL_000c: add
+  IL_000d: ldc.i4.2
+  IL_000e: stind.i4
+  IL_000f: ldloc.0
+  IL_0010: conv.u
+  IL_0011: ldc.i4.4
+  IL_0012: ldc.i4.1
+  IL_0013: mul
+  IL_0014: conv.i
+  IL_0015: add
+  IL_0016: ldind.i4
+  IL_0017: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayElementIndexInComparison.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayElementIndexInComparison.verified.txt
@@ -1,28 +1,28 @@
 ﻿System.Int32 <Module>::main()
   Locals:
     System.Int32* V_0
-  IL_0000: ldc.i4 40
-  IL_0005: conv.u
-  IL_0006: localloc
-  IL_0008: stloc.0
-  IL_0009: ldloc.0
-  IL_000a: conv.u
-  IL_000b: ldc.i4.4
-  IL_000c: ldc.i4.1
-  IL_000d: mul
-  IL_000e: conv.i
-  IL_000f: add
-  IL_0010: ldind.i4
-  IL_0011: ldc.i4.s 13
+  IL_0000: ldc.i4.s 40
+  IL_0002: conv.u
+  IL_0003: localloc
+  IL_0005: stloc.0
+  IL_0006: ldloc.0
+  IL_0007: conv.u
+  IL_0008: ldc.i4.4
+  IL_0009: ldc.i4.1
+  IL_000a: mul
+  IL_000b: conv.i
+  IL_000c: add
+  IL_000d: ldind.i4
+  IL_000e: ldc.i4.s 13
+  IL_0010: ceq
+  IL_0012: ldc.i4.0
   IL_0013: ceq
-  IL_0015: ldc.i4.0
-  IL_0016: ceq
-  IL_0018: brfalse IL_001f
-  IL_001d: ldc.i4.m1
+  IL_0015: brfalse IL_001c
+  IL_001a: ldc.i4.m1
+  IL_001b: ret
+  IL_001c: nop
+  IL_001d: ldc.i4.0
   IL_001e: ret
-  IL_001f: nop
-  IL_0020: ldc.i4.0
-  IL_0021: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayElementIndexViaVariable.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayElementIndexViaVariable.verified.txt
@@ -2,30 +2,30 @@
   Locals:
     System.Int32* V_0
     System.Int32 V_1
-  IL_0000: ldc.i4 40
-  IL_0005: conv.u
-  IL_0006: localloc
-  IL_0008: stloc.0
-  IL_0009: ldc.i4.0
-  IL_000a: stloc.1
-  IL_000b: ldloc.0
-  IL_000c: ldloc.1
-  IL_000d: conv.i
-  IL_000e: ldc.i4 4
-  IL_0013: mul
-  IL_0014: add
-  IL_0015: conv.u
-  IL_0016: ldc.i4.4
-  IL_0017: ldc.i4.0
-  IL_0018: ldc.i4.s 10
-  IL_001a: mul
-  IL_001b: mul
-  IL_001c: conv.i
-  IL_001d: add
-  IL_001e: ldc.i4.s 13
-  IL_0020: stind.i4
-  IL_0021: ldc.i4.0
-  IL_0022: ret
+  IL_0000: ldc.i4.s 40
+  IL_0002: conv.u
+  IL_0003: localloc
+  IL_0005: stloc.0
+  IL_0006: ldc.i4.0
+  IL_0007: stloc.1
+  IL_0008: ldloc.0
+  IL_0009: ldloc.1
+  IL_000a: conv.i
+  IL_000b: ldc.i4 4
+  IL_0010: mul
+  IL_0011: add
+  IL_0012: conv.u
+  IL_0013: ldc.i4.4
+  IL_0014: ldc.i4.0
+  IL_0015: ldc.i4.s 10
+  IL_0017: mul
+  IL_0018: mul
+  IL_0019: conv.i
+  IL_001a: add
+  IL_001b: ldc.i4.s 13
+  IL_001d: stind.i4
+  IL_001e: ldc.i4.0
+  IL_001f: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalArrayAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalArrayAssignment.verified.txt
@@ -1,9 +1,9 @@
 ﻿System.Void <Module>::.cctor()
-  IL_0000: ldc.i4 40
-  IL_0005: conv.u
-  IL_0006: call System.Void* Cesium.Runtime.RuntimeHelpers::AllocateGlobalField(System.UInt32)
-  IL_000b: stsfld System.Int32* <Module>::a
-  IL_0010: ret
+  IL_0000: ldc.i4.s 40
+  IL_0002: conv.u
+  IL_0003: call System.Void* Cesium.Runtime.RuntimeHelpers::AllocateGlobalField(System.UInt32)
+  IL_0008: stsfld System.Int32* <Module>::a
+  IL_000d: ret
 
 System.Int32 <Module>::main()
   IL_0000: ldsflda System.Int32* <Module>::a

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ArrayDeclaration.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.ArrayDeclaration.verified.txt
@@ -4,12 +4,12 @@
     System.Int32 <Module>::main()
       Locals:
         System.Int32* V_0
-      IL_0000: ldc.i4 4
-      IL_0005: conv.u
-      IL_0006: localloc
-      IL_0008: stloc.0
-      IL_0009: ldc.i4.0
-      IL_000a: ret
+      IL_0000: ldc.i4.4
+      IL_0001: conv.u
+      IL_0002: localloc
+      IL_0004: stloc.0
+      IL_0005: ldc.i4.0
+      IL_0006: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen/CompilationOptions.cs
+++ b/Cesium.CodeGen/CompilationOptions.cs
@@ -4,6 +4,7 @@ namespace Cesium.CodeGen;
 
 public record CompilationOptions(
     TargetRuntimeDescriptor TargetRuntime,
+    TargetArchitectureSet TargetArchitectureSet,
     ModuleKind ModuleKind,
     string CorelibAssembly,
     string CesiumRuntime,

--- a/Cesium.CodeGen/Contexts/AssemblyContext.cs
+++ b/Cesium.CodeGen/Contexts/AssemblyContext.cs
@@ -12,6 +12,7 @@ namespace Cesium.CodeGen.Contexts;
 public class AssemblyContext
 {
     internal AssemblyDefinition Assembly { get; }
+    public TargetArchitectureSet ArchitectureSet { get; }
     internal AssemblyDefinition MscorlibAssembly { get; }
     internal AssemblyDefinition CesiumRuntimeAssembly { get; }
     public ModuleDefinition Module { get; }
@@ -75,6 +76,7 @@ public class AssemblyContext
         CompilationOptions compilationOptions)
     {
         Assembly = assembly;
+        ArchitectureSet = compilationOptions.TargetArchitectureSet;
         Module = module;
         MscorlibAssembly = AssemblyDefinition.ReadAssembly(compilationOptions.CorelibAssembly);
         CesiumRuntimeAssembly = AssemblyDefinition.ReadAssembly(compilationOptions.CesiumRuntime);

--- a/Cesium.CodeGen/Contexts/FunctionScope.cs
+++ b/Cesium.CodeGen/Contexts/FunctionScope.cs
@@ -11,8 +11,8 @@ internal record FunctionScope(TranslationUnitContext Context, FunctionInfo Funct
 {
     public AssemblyContext AssemblyContext => Context.AssemblyContext;
     public ModuleDefinition Module => Context.Module;
-    public TypeSystem TypeSystem => Context.TypeSystem;
     public CTypeSystem CTypeSystem => Context.CTypeSystem;
+    public TargetArchitectureSet ArchitectureSet => AssemblyContext.ArchitectureSet;
     public IReadOnlyDictionary<string, FunctionInfo> Functions => Context.Functions;
     public FunctionInfo? GetFunctionInfo(string identifier) =>
         Functions.GetValueOrDefault(identifier);

--- a/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
+++ b/Cesium.CodeGen/Contexts/GlobalConstructorScope.cs
@@ -13,10 +13,9 @@ internal record GlobalConstructorScope(TranslationUnitContext Context) : IEmitSc
     private MethodDefinition? _method;
     public AssemblyContext AssemblyContext => Context.AssemblyContext;
     public ModuleDefinition Module => Context.Module;
-    public TypeSystem TypeSystem => Module.TypeSystem;
-
     public MethodDefinition Method => _method ??= Context.AssemblyContext.GetGlobalInitializer();
     public CTypeSystem CTypeSystem => Context.CTypeSystem;
+    public TargetArchitectureSet ArchitectureSet => AssemblyContext.ArchitectureSet;
     public FunctionInfo? GetFunctionInfo(string identifier) =>
         Context.Functions.GetValueOrDefault(identifier);
     public IReadOnlyDictionary<string, IType> GlobalFields => AssemblyContext.GlobalFields;

--- a/Cesium.CodeGen/Contexts/IDeclarationScope.cs
+++ b/Cesium.CodeGen/Contexts/IDeclarationScope.cs
@@ -7,6 +7,7 @@ namespace Cesium.CodeGen.Contexts;
 
 internal interface IDeclarationScope
 {
+    TargetArchitectureSet ArchitectureSet { get; }
     CTypeSystem CTypeSystem { get; }
     FunctionInfo? GetFunctionInfo(string identifier);
     IReadOnlyDictionary<string, IType> GlobalFields { get; }

--- a/Cesium.CodeGen/Contexts/LoopScope.cs
+++ b/Cesium.CodeGen/Contexts/LoopScope.cs
@@ -12,6 +12,8 @@ internal record LoopScope(IEmitScope Parent) : IEmitScope, IDeclarationScope
     public AssemblyContext AssemblyContext => Parent.AssemblyContext;
     public ModuleDefinition Module => Parent.Module;
     public CTypeSystem CTypeSystem => Parent.CTypeSystem;
+    public TargetArchitectureSet ArchitectureSet => AssemblyContext.ArchitectureSet;
+
     public FunctionInfo? GetFunctionInfo(string identifier)
         => ((IDeclarationScope)Parent).GetFunctionInfo(identifier);
     public TranslationUnitContext Context => Parent.Context;

--- a/Cesium.CodeGen/Contexts/SwitchScope.cs
+++ b/Cesium.CodeGen/Contexts/SwitchScope.cs
@@ -12,6 +12,7 @@ internal record SwitchScope(IEmitScope Parent) : IEmitScope, IDeclarationScope
     public AssemblyContext AssemblyContext => Parent.AssemblyContext;
     public ModuleDefinition Module => Parent.Module;
     public CTypeSystem CTypeSystem => Parent.CTypeSystem;
+    public TargetArchitectureSet ArchitectureSet => AssemblyContext.ArchitectureSet;
     public FunctionInfo? GetFunctionInfo(string identifier)
         => ((IDeclarationScope)Parent).GetFunctionInfo(identifier);
     public TranslationUnitContext Context => Parent.Context;

--- a/Cesium.CodeGen/Extensions/CodeGenEx.cs
+++ b/Cesium.CodeGen/Extensions/CodeGenEx.cs
@@ -51,4 +51,7 @@ internal static class CodeGenEx
     {
         scope.AddInstruction(Instruction.Create(OpCodes.Ldftn, method));
     }
+
+    public static void SizeOf(this IEmitScope scope, TypeReference type) =>
+        scope.AddInstruction(Instruction.Create(OpCodes.Sizeof, type));
 }

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperators/ArithmeticBinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperators/ArithmeticBinaryOperatorExpression.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using Cesium.CodeGen.Contexts;
 using Cesium.CodeGen.Extensions;
-using Cesium.CodeGen.Ir.Expressions.Constants;
 using Cesium.CodeGen.Ir.Types;
 using Cesium.Core;
 using Mono.Cecil.Cil;
@@ -36,7 +35,7 @@ internal class ArithmeticBinaryOperatorExpression: BinaryOperatorExpression
                 right = new TypeCastExpression(
                     scope.CTypeSystem.NativeInt,
                     new ArithmeticBinaryOperatorExpression(
-                        new ConstantLiteralExpression(new IntegerConstant(leftPointerType.Base.SizeInBytes)),
+                        leftPointerType.Base.GetSizeInBytesExpression(scope.ArchitectureSet),
                         BinaryOperator.Multiply,
                         right));
 
@@ -48,7 +47,7 @@ internal class ArithmeticBinaryOperatorExpression: BinaryOperatorExpression
                 left = new TypeCastExpression(
                     scope.CTypeSystem.NativeInt,
                     new ArithmeticBinaryOperatorExpression(
-                        new ConstantLiteralExpression(new IntegerConstant(rightPointerType.Base.SizeInBytes)),
+                        rightPointerType.Base.GetSizeInBytesExpression(scope.ArchitectureSet),
                         BinaryOperator.Multiply,
                         left));
 

--- a/Cesium.CodeGen/Ir/Expressions/ConstantLiteralExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/ConstantLiteralExpression.cs
@@ -9,6 +9,8 @@ namespace Cesium.CodeGen.Ir.Expressions;
 
 internal class ConstantLiteralExpression : IExpression
 {
+    public static ConstantLiteralExpression OfInt32(int value) => new(new IntegerConstant(value));
+
     internal ConstantLiteralExpression(IConstant constant)
     {
         Constant = constant;

--- a/Cesium.CodeGen/Ir/Expressions/SizeOfExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SizeOfExpression.cs
@@ -1,0 +1,18 @@
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Extensions;
+using Cesium.CodeGen.Ir.Types;
+
+namespace Cesium.CodeGen.Ir.Expressions;
+
+internal record SizeOfExpression(IType Type) : IExpression
+{
+    public IExpression Lower(IDeclarationScope scope) => this;
+
+    public void EmitTo(IEmitScope scope)
+    {
+        var type = Type.Resolve(scope.Context);
+        scope.SizeOf(type);
+    }
+
+    public IType GetExpressionType(IDeclarationScope scope) => scope.CTypeSystem.UnsignedInt;
+}

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueIndirection.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueIndirection.cs
@@ -38,6 +38,7 @@ internal class LValueIndirection : ILValue
     private static (OpCode load, OpCode store) GetOpcodes(PointerType pointerType) => pointerType.Base switch
     {
         PrimitiveType primitiveType => PrimitiveTypeInfo.Opcodes[primitiveType.Kind],
+        PointerType => (OpCodes.Ldind_I, OpCodes.Stind_I),
         _ => throw new WipException(256, $"Unsupported type for indirection operator: {pointerType}")
     };
 }

--- a/Cesium.CodeGen/Ir/Types/ConstType.cs
+++ b/Cesium.CodeGen/Ir/Types/ConstType.cs
@@ -6,5 +6,7 @@ namespace Cesium.CodeGen.Ir.Types;
 internal record ConstType(IType Base) : IType
 {
     public TypeReference Resolve(TranslationUnitContext context) => Base.Resolve(context);
-    public int SizeInBytes => Base.SizeInBytes;
+
+    public int? GetSizeInBytes(TargetArchitectureSet arch) =>
+        Base.GetSizeInBytes(arch);
 }

--- a/Cesium.CodeGen/Ir/Types/FunctionType.cs
+++ b/Cesium.CodeGen/Ir/Types/FunctionType.cs
@@ -38,7 +38,8 @@ internal record FunctionType(ParametersInfo? Parameters, IType ReturnType) : ITy
         return pointer;
     }
 
-    public int SizeInBytes => throw new AssertException($"Function type {this} has no defined size.");
+    public int? GetSizeInBytes(TargetArchitectureSet arch) =>
+        throw new AssertException($"Function type {this} has no defined size.");
 
     public override string ToString() =>
         $"FunctionType {{ {nameof(Parameters)} = {Parameters}, {nameof(ReturnType)} = {ReturnType} }}";

--- a/Cesium.CodeGen/Ir/Types/NamedType.cs
+++ b/Cesium.CodeGen/Ir/Types/NamedType.cs
@@ -9,10 +9,6 @@ public record NamedType(string TypeName) : IType
     public TypeReference Resolve(TranslationUnitContext context) =>
         throw new AssertException($"Type {TypeName} was never resolved.");
 
-    public int SizeInBytes =>
+    public int? GetSizeInBytes(TargetArchitectureSet arch) =>
         throw new AssertException($"Type {TypeName} was never resolved.");
-
-    // explicit impl while Size not implemented
-    public override string ToString()
-        => $"NamedType {{ TypeName = {TypeName} }}";
 }

--- a/Cesium.CodeGen/Ir/Types/PointerType.cs
+++ b/Cesium.CodeGen/Ir/Types/PointerType.cs
@@ -1,4 +1,5 @@
 using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Ir.Expressions;
 using Cesium.Core;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
@@ -16,5 +17,23 @@ internal record PointerType(IType Base) : IType
     }
 
     public int? GetSizeInBytes(TargetArchitectureSet arch) =>
-        throw new WipException(132, "Could not calculate size yet.");
+        arch switch
+        {
+            TargetArchitectureSet.Dynamic => null,
+            TargetArchitectureSet.Bit32 => 4,
+            TargetArchitectureSet.Bit64 => 8,
+            _ => throw new AssertException($"Unknown architecture set: {arch}.")
+        };
+
+    public IExpression GetSizeInBytesExpression(TargetArchitectureSet arch)
+    {
+        var constSize = GetSizeInBytes(arch);
+        if (constSize != null)
+            return ConstantLiteralExpression.OfInt32(constSize.Value);
+
+        if (arch != TargetArchitectureSet.Dynamic)
+            throw new AssertException($"Architecture {arch} shouldn't enter dynamic pointer size calculation.");
+
+        return new SizeOfExpression(this);
+    }
 }

--- a/Cesium.CodeGen/Ir/Types/PointerType.cs
+++ b/Cesium.CodeGen/Ir/Types/PointerType.cs
@@ -15,9 +15,6 @@ internal record PointerType(IType Base) : IType
         return Base.Resolve(context).MakePointerType();
     }
 
-    public virtual int SizeInBytes => throw new WipException(132, "Could not calculate size yet.");
-
-    // explicit impl while Size not implemented
-    public override string ToString()
-        => $"PointerType {{ Base = {Base} }}";
+    public int? GetSizeInBytes(TargetArchitectureSet arch) =>
+        throw new WipException(132, "Could not calculate size yet.");
 }

--- a/Cesium.CodeGen/Ir/Types/PrimitiveType.cs
+++ b/Cesium.CodeGen/Ir/Types/PrimitiveType.cs
@@ -94,7 +94,7 @@ internal record PrimitiveType(PrimitiveTypeKind Kind) : IType
         };
     }
 
-    public int SizeInBytes =>
+    public int? GetSizeInBytes(TargetArchitectureSet arch) =>
         Kind switch
         {
             // Basic
@@ -131,6 +131,14 @@ internal record PrimitiveType(PrimitiveTypeKind Kind) : IType
             PrimitiveTypeKind.LongLongInt => 8,
             PrimitiveTypeKind.SignedLongLongInt => 8,
             PrimitiveTypeKind.LongDouble => 8,
+
+            PrimitiveTypeKind.NativeInt => arch switch
+            {
+                TargetArchitectureSet.Dynamic => null,
+                TargetArchitectureSet.Bit32 => 4,
+                TargetArchitectureSet.Bit64 => 8,
+                _ => throw new AssertException($"Architecture set not supported: {arch}.")
+            },
 
             _ => throw new AssertException($"Could not calculate size for {Kind}."),
         };

--- a/Cesium.CodeGen/Ir/Types/PrimitiveType.cs
+++ b/Cesium.CodeGen/Ir/Types/PrimitiveType.cs
@@ -174,6 +174,6 @@ internal static class PrimitiveTypeInfo
         { PrimitiveTypeKind.Float, (OpCodes.Ldind_R4, OpCodes.Stind_R4) },
         { PrimitiveTypeKind.Long, (OpCodes.Ldind_I8, OpCodes.Stind_I8) },
         { PrimitiveTypeKind.UnsignedLong, (OpCodes.Ldind_I8, OpCodes.Stind_I8) },
-        { PrimitiveTypeKind.Double, (OpCodes.Ldind_R8, OpCodes.Stind_R8) },
+        { PrimitiveTypeKind.Double, (OpCodes.Ldind_R8, OpCodes.Stind_R8) }
     };
 }

--- a/Cesium.CodeGen/Ir/Types/StructType.cs
+++ b/Cesium.CodeGen/Ir/Types/StructType.cs
@@ -46,5 +46,6 @@ internal class StructType : IGeneratedType
     public TypeReference Resolve(TranslationUnitContext context) =>
         context.GetTypeReference(this) ?? throw new CompilationException($"Type {this} was not found.");
 
-    public int SizeInBytes => throw new WipException(232, $"Could not calculate size for {this} yet.");
+    public int? GetSizeInBytes(TargetArchitectureSet arch) =>
+        throw new WipException(232, $"Could not calculate size for {this} yet.");
 }

--- a/Cesium.CodeGen/TargetArchitectureSet.cs
+++ b/Cesium.CodeGen/TargetArchitectureSet.cs
@@ -1,0 +1,20 @@
+namespace Cesium.CodeGen;
+
+/// <summary>Describes the set of system architectures targeted by the assembly.</summary>
+public enum TargetArchitectureSet
+{
+    /// <summary>
+    /// <para>Dynamic architecture.</para>
+    /// <para>
+    ///     May not support every feature of the C programming language, but compiles to AnyCPU assembly. Performs some
+    ///     calculations, such as pointer array size calculations, in runtime.
+    /// </para>
+    /// </summary>
+    Dynamic,
+
+    /// <summary>An architecture with 32-bit pointers. Targets ARM32 and x86 CPUs.</summary>
+    Bit32,
+
+    /// <summary>An architecture with 64-bit pointers. Targets ARM64 and x86-64 CPUs.</summary>
+    Bit64
+}

--- a/Cesium.Compiler/Arguments.cs
+++ b/Cesium.Compiler/Arguments.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Cesium.CodeGen;
 using CommandLine;
 using Mono.Cecil;
 
@@ -23,6 +24,9 @@ public class Arguments
 
     [Option("framework", Default = TargetFrameworkKind.Net)]
     public TargetFrameworkKind Framework { get; init; }
+
+    [Option("arch", Default = TargetArchitectureSet.Dynamic)]
+    public TargetArchitectureSet TargetArchitectureSet { get; init; }
 
     [Option("modulekind")]
     public ModuleKind? ModuleKind { get; init; } = null!;

--- a/Cesium.Compiler/Main.cs
+++ b/Cesium.Compiler/Main.cs
@@ -21,6 +21,7 @@ return await parserResult.MapResult(async args =>
             return 2;
         }
 
+        var targetArchitectureSet = args.TargetArchitectureSet;
         var targetRuntime = args.Framework switch
         {
             TargetFrameworkKind.NetFramework => TargetRuntimeDescriptor.Net48,
@@ -39,7 +40,15 @@ return await parserResult.MapResult(async args =>
             ".dll" => ModuleKind.Dll,
             var o => throw new CompilationException($"Unknown file extension: {o}. \"modulekind\" is not specified.")
         };
-        var compilationOptions = new CompilationOptions(targetRuntime, moduleKind, corelibAssembly, cesiumRuntime, defaultImportsAssembly, args.Namespace, args.GlobalClass);
+        var compilationOptions = new CompilationOptions(
+            targetRuntime,
+            targetArchitectureSet,
+            moduleKind,
+            corelibAssembly,
+            cesiumRuntime,
+            defaultImportsAssembly,
+            args.Namespace,
+            args.GlobalClass);
         return await Compilation.Compile(args.InputFilePaths, args.OutputFilePath, compilationOptions);
     },
     _ =>

--- a/Cesium.Test.Framework/VerifyTestBase.cs
+++ b/Cesium.Test.Framework/VerifyTestBase.cs
@@ -10,10 +10,11 @@ public abstract class VerifyTestBase
         Environment.SetEnvironmentVariable("Verify_DisableClipboard", "true");
     }
 
-    protected static VerifySettings GetSettings()
+    protected static VerifySettings GetSettings(params object?[] parameters)
     {
         var settings = new VerifySettings();
         settings.UseDirectory("verified");
+        settings.UseParameters(parameters);
         return settings;
     }
 }

--- a/Cesium.Test.Framework/VerifyTestBase.cs
+++ b/Cesium.Test.Framework/VerifyTestBase.cs
@@ -14,7 +14,8 @@ public abstract class VerifyTestBase
     {
         var settings = new VerifySettings();
         settings.UseDirectory("verified");
-        settings.UseParameters(parameters);
+        if (parameters.Length > 0)
+            settings.UseParameters(parameters);
         return settings;
     }
 }

--- a/Cesium.sln
+++ b/Cesium.sln
@@ -59,6 +59,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{986C6A13-2
 		docs\language-extensions.md = docs\language-extensions.md
 		docs\tests.md = docs\tests.md
 		docs\type-system.md = docs\type-system.md
+		docs\architecture-sets.md = docs\architecture-sets.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cesium.Preprocessor", "Cesium.Preprocessor\Cesium.Preprocessor.csproj", "{0CDF730D-2A2A-437F-B27F-2BB04770C709}"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Documentation
 
 - [Cesium Tests][docs.tests]
 - [Cesium Type System][docs.type-system]
+- [Architecture Sets][docs.architecture-sets]
 - [CLI-Related Language Extensions][docs.language-extensions]
 - [Exceptions in the Compiler Code][docs.exceptions]
 
@@ -64,6 +65,10 @@ $ mono ./out.exe # run with Mono
   - `NetFramework` for .NET Framework
   - `NetStandard` for .NET Standard
   - `Net` for .NET 5+
+- `--arch <architecture-set>`: specifies the [target architecture set][docs.architecture-sets], defaults to `Dynamic`. Possible values are:
+  - `Dynamic`
+  - `Bit32`
+  - `Bit64`
 - `--modulekind <moduleKind>`: specifies the output module kind; by default, it is autodetected from the output file extension
   - `Dll`: gets detected from a `.dll` extension
   - `Console`: gets detected from an `.exe` extension
@@ -115,6 +120,7 @@ Documentation
 [andivionian-status-classifier]: https://github.com/ForNeVeR/andivionian-status-classifier#status-enfer-
 [c17-draft]: http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2310.pdf
 [discussions]: https://github.com/ForNeVeR/Cesium/discussions
+[docs.architecture-sets]: docs/architecture-sets.md
 [docs.contributing]: CONTRIBUTING.md
 [docs.exceptions]: docs/exceptions.md
 [docs.language-extensions]: docs/language-extensions.md

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ $ mono ./out.exe # run with Mono
   - `NetStandard` for .NET Standard
   - `Net` for .NET 5+
 - `--arch <architecture-set>`: specifies the [target architecture set][docs.architecture-sets], defaults to `Dynamic`. Possible values are:
-  - `Dynamic`
-  - `Bit32`
-  - `Bit64`
+  - `Dynamic` (machine-independent),
+  - `Bit32` (for 32-bit CPUs),
+  - `Bit64` (for 64-bit CPUs).
 - `--modulekind <moduleKind>`: specifies the output module kind; by default, it is autodetected from the output file extension
   - `Dll`: gets detected from a `.dll` extension
   - `Console`: gets detected from an `.exe` extension

--- a/docs/architecture-sets.md
+++ b/docs/architecture-sets.md
@@ -10,7 +10,7 @@ To manage that, Cesium introduces a concept of the _architecture sets_. An _arch
 Architecture set influences the following features of compiled programs:
 - pointer size,
 - size of pointer-dependent memory areas (such as stack arrays and arrays embedded into structures),
-- target architecture of the produced .NET assembly (not implemented yet, see issue #TODO),
+- target architecture of the produced .NET assembly (not implemented yet, see issue #353),
 - ability to compile certain C constructs.
 
 Cesium aims to support the following architecture sets:
@@ -25,6 +25,6 @@ Cesium aims to support the following architecture sets:
   Not every C construct allows to use dynamically-calculated size (in particular, it's impossible for pointer-dependent arrays embedded into structures), so this architecture doesn't support all the C standard. It still should be practical for many applications.
 
   **This architecture is machine-independent** and results in producing of an Any CPU-targeting assembly.
-- **Wide** architecture **is not implemented, yet** (see #TODO), and uses the fixed pointer size of 64 bits on all computers. This allows it to cover all the features of the C standard, for the cost of some redundancy on 32-bit architectures, and slightly different method signatures for .NET interop.
+- **Wide** architecture **is not implemented, yet** (see issue #354), and uses the fixed pointer size of 64 bits on all computers. This allows it to cover all the features of the C standard, for the cost of some redundancy on 32-bit architectures, and slightly different method signatures for .NET interop.
 
   **This architecture is machine-independent** and results in producing of an Any CPU-targeting assembly.

--- a/docs/architecture-sets.md
+++ b/docs/architecture-sets.md
@@ -1,0 +1,30 @@
+Architecture Sets
+=================
+
+Cesium targets .NET virtual machine, the CLI, which is independent of the target computer architecture in its nature.
+
+At the same time, there are a lot of samples of C code that are machine-dependent. Certain parts of the C standard are impossible to represent in the platform-independent manner.
+
+To manage that, Cesium introduces a concept of the _architecture sets_. An _architecture set_ describes CPU architecture sets that share a common set of memory layout features for a Cesium program. Cesium cannot guarantee that all features of the C standard are supported on every architecture set.
+
+Architecture set influences the following features of compiled programs:
+- pointer size,
+- size of pointer-dependent memory areas (such as stack arrays and arrays embedded into structures),
+- target architecture of the produced .NET assembly (not implemented yet, see issue #TODO),
+- ability to compile certain C constructs.
+
+Cesium aims to support the following architecture sets:
+- `Bit32`: the set of architectures where the pointers are 32-bit-wide. Supports the C standard completely.
+
+  **Example architectures** of this architecture set are x86 and ARM32.
+- `Bit64`: the set of architectures where the pointers are 64-bit-wide. Supports the C standard completely.
+
+  **Example architectures** of this architecture set are x86_64 and ARM64.
+- `Dynamic` architecture has no fixed pointer size, and will calculate it in the runtime when required.
+
+  Not every C construct allows to use dynamically-calculated size (in particular, it's impossible for pointer-dependent arrays embedded into structures), so this architecture doesn't support all the C standard. It still should be practical for many applications.
+
+  **This architecture is machine-independent** and results in producing of an Any CPU-targeting assembly.
+- `Wide` architecture **is not implemented, yet** (see #TODO), and uses the fixed pointer size of 64 bits on all computers. This allows it to cover all the features of the C standard, for the cost of some redundancy on 32-bit architectures, and slightly different method signatures for .NET interop.
+
+  **This architecture is machine-independent** and results in producing of an Any CPU-targeting assembly.

--- a/docs/architecture-sets.md
+++ b/docs/architecture-sets.md
@@ -14,17 +14,17 @@ Architecture set influences the following features of compiled programs:
 - ability to compile certain C constructs.
 
 Cesium aims to support the following architecture sets:
-- `Bit32`: the set of architectures where the pointers are 32-bit-wide. Supports the C standard completely.
+- **32b** (aka `Bit32`): the set of architectures where the pointers are 32-bit-wide. Supports the C standard completely.
 
   **Example architectures** of this architecture set are x86 and ARM32.
-- `Bit64`: the set of architectures where the pointers are 64-bit-wide. Supports the C standard completely.
+- **64b** (aka `Bit64`): the set of architectures where the pointers are 64-bit-wide. Supports the C standard completely.
 
   **Example architectures** of this architecture set are x86_64 and ARM64.
-- `Dynamic` architecture has no fixed pointer size, and will calculate it in the runtime when required.
+- **Dynamic** architecture has no fixed pointer size, and will calculate it in the runtime when required.
 
   Not every C construct allows to use dynamically-calculated size (in particular, it's impossible for pointer-dependent arrays embedded into structures), so this architecture doesn't support all the C standard. It still should be practical for many applications.
 
   **This architecture is machine-independent** and results in producing of an Any CPU-targeting assembly.
-- `Wide` architecture **is not implemented, yet** (see #TODO), and uses the fixed pointer size of 64 bits on all computers. This allows it to cover all the features of the C standard, for the cost of some redundancy on 32-bit architectures, and slightly different method signatures for .NET interop.
+- **Wide** architecture **is not implemented, yet** (see #TODO), and uses the fixed pointer size of 64 bits on all computers. This allows it to cover all the features of the C standard, for the cost of some redundancy on 32-bit architectures, and slightly different method signatures for .NET interop.
 
   **This architecture is machine-independent** and results in producing of an Any CPU-targeting assembly.


### PR DESCRIPTION
Part of #132.

This will introduce 32b, 64b and dynamic architectures.

### TODO
- [x] make the tests work
- [x] add the documentation for the architecture sets
- [x] check the new TODOs
- [x] check the remaining TODOs for #132
- [x] review the changes

#### After merge
- [x] create a new issue about wide architecture