### PR TITLE
Accept O3 and Wall

### DIFF
--- a/Cesium.Compiler/Arguments.cs
+++ b/Cesium.Compiler/Arguments.cs
@@ -49,4 +49,10 @@ public class Arguments
     [Option("runtime", HelpText = "Sets path to Cesium C Runtime assembly")]
     public string? CesiumCRuntime { get; init; }
 
+    [Option('O', HelpText = "Set optimization level to 3")]
+    public int OptimizationLevel { get; init; } = 0;
+
+    [Option('W', HelpText = "Enable warnings set")]
+    public string WarningsSet { get; init; } = "";
+
 }

--- a/Cesium.Compiler/Arguments.cs
+++ b/Cesium.Compiler/Arguments.cs
@@ -49,7 +49,7 @@ public class Arguments
     [Option("runtime", HelpText = "Sets path to Cesium C Runtime assembly")]
     public string? CesiumCRuntime { get; init; }
 
-    [Option('O', HelpText = "Set optimization level to 3")]
+    [Option('O', HelpText = "Set the optimization level")]
     public int OptimizationLevel { get; init; } = 0;
 
     [Option('W', HelpText = "Enable warnings set")]


### PR DESCRIPTION
For now this parameters do nothing. If we accept them even if we do nothing, that simplify using Cesium when invoking from Make. For example you can CC=/usr/bin/cesium and let Make do it's magic. Eventually