### PR TITLE
Fix failing multidimecional.c test

### DIFF
--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.StandardMain.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.StandardMain.verified.txt
@@ -31,13 +31,11 @@ System.Int32 <Module>::<SyntheticEntrypoint>(System.String[] args)
   IL_001f: ldelema System.Byte*
   IL_0024: call System.Int32 <Module>::main(System.Int32,System.Byte**)
   IL_0029: stloc.s V_4
-  IL_002b: leave.s IL_002d
-  IL_002d: nop
-  IL_002e: ldnull
-  IL_002f: stloc.3
-  IL_0030: ldloc.1
-  IL_0031: call System.Void Cesium.Runtime.RuntimeHelpers::FreeArgv(System.Byte*[])
-  IL_0036: ldloc.s V_4
-  IL_0038: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
-  IL_003d: ldloc.s V_4
-  IL_003f: ret
+  IL_002b: ldnull
+  IL_002c: stloc.3
+  IL_002d: ldloc.1
+  IL_002e: call System.Void Cesium.Runtime.RuntimeHelpers::FreeArgv(System.Byte*[])
+  IL_0033: ldloc.s V_4
+  IL_0035: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_003a: ldloc.s V_4
+  IL_003c: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.StandardMain.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.StandardMain.verified.txt
@@ -31,12 +31,13 @@ System.Int32 <Module>::<SyntheticEntrypoint>(System.String[] args)
   IL_001f: ldelema System.Byte*
   IL_0024: call System.Int32 <Module>::main(System.Int32,System.Byte**)
   IL_0029: stloc.s V_4
-  IL_002b: leave.s IL_0035
-  IL_002d: ldnull
-  IL_002e: stloc.3
-  IL_002f: ldloc.1
-  IL_0030: call System.Void Cesium.Runtime.RuntimeHelpers::FreeArgv(System.Byte*[])
-  IL_0035: ldloc.s V_4
-  IL_0037: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
-  IL_003c: ldloc.s V_4
-  IL_003e: ret
+  IL_002b: leave.s IL_002d
+  IL_002d: nop
+  IL_002e: ldnull
+  IL_002f: stloc.3
+  IL_0030: ldloc.1
+  IL_0031: call System.Void Cesium.Runtime.RuntimeHelpers::FreeArgv(System.Byte*[])
+  IL_0036: ldloc.s V_4
+  IL_0038: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_003d: ldloc.s V_4
+  IL_003f: ret

--- a/Cesium.CodeGen/Ir/BlockItems/FunctionDefinition.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/FunctionDefinition.cs
@@ -186,7 +186,7 @@ internal class FunctionDefinition : IBlockItem
         syntheticEntrypoint.Body.Variables.Add(exitCode);
 
         var instructions = syntheticEntrypoint.Body.Instructions;
-        var atExitLdLocExitCode = Instruction.Create(OpCodes.Ldloc_S, exitCode);
+        var atExitLdLocExitCode = Instruction.Create(OpCodes.Nop);
 
         // argC = args.Length;
         instructions.Add(Instruction.Create(OpCodes.Ldarg_0)); // args
@@ -223,6 +223,7 @@ internal class FunctionDefinition : IBlockItem
                 instructions.Add(Instruction.Create(OpCodes.Leave_S, atExitLdLocExitCode));
             }
             //unpin
+            instructions.Add(atExitLdLocExitCode);
             {
                 instructions.Add(Instruction.Create(OpCodes.Ldnull));
                 instructions.Add(Instruction.Create(OpCodes.Stloc_3)); // 3 = argVPinned.Index
@@ -232,7 +233,7 @@ internal class FunctionDefinition : IBlockItem
             instructions.Add(Instruction.Create(OpCodes.Ldloc_1)); // 1 = argV.Index
             instructions.Add(Instruction.Create(OpCodes.Call, freeArgv));
         }
-        instructions.Add(atExitLdLocExitCode);
+        instructions.Add(Instruction.Create(OpCodes.Ldloc_S, exitCode));
         instructions.Add(Instruction.Create(OpCodes.Call, exit)); // exit(exitCode)
         instructions.Add(Instruction.Create(OpCodes.Ldloc_S, exitCode));
         instructions.Add(Instruction.Create(OpCodes.Ret));

--- a/Cesium.CodeGen/Ir/BlockItems/FunctionDefinition.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/FunctionDefinition.cs
@@ -186,7 +186,6 @@ internal class FunctionDefinition : IBlockItem
         syntheticEntrypoint.Body.Variables.Add(exitCode);
 
         var instructions = syntheticEntrypoint.Body.Instructions;
-        var atExitLdLocExitCode = Instruction.Create(OpCodes.Nop);
 
         // argC = args.Length;
         instructions.Add(Instruction.Create(OpCodes.Ldarg_0)); // args
@@ -220,10 +219,8 @@ internal class FunctionDefinition : IBlockItem
                 instructions.Add(Instruction.Create(OpCodes.Ldelema, bytePtrType));
                 instructions.Add(Instruction.Create(OpCodes.Call, userEntrypoint));
                 instructions.Add(Instruction.Create(OpCodes.Stloc_S, exitCode));
-                instructions.Add(Instruction.Create(OpCodes.Leave_S, atExitLdLocExitCode));
             }
             //unpin
-            instructions.Add(atExitLdLocExitCode);
             {
                 instructions.Add(Instruction.Create(OpCodes.Ldnull));
                 instructions.Add(Instruction.Create(OpCodes.Stloc_3)); // 3 = argVPinned.Index

--- a/Cesium.IntegrationTests/array/multidimensional.c
+++ b/Cesium.IntegrationTests/array/multidimensional.c
@@ -1,4 +1,4 @@
-int b[10][2];
+int b[10][10];
 
 int main(int argc, char *argv[])
 {

--- a/Cesium.Runtime/RuntimeHelpers.cs
+++ b/Cesium.Runtime/RuntimeHelpers.cs
@@ -24,9 +24,9 @@ public static unsafe class RuntimeHelpers
         byte* AllocateUtf8String(string s)
         {
             var bytes = encoding.GetBytes(s);
-            var buffer = (byte*)Marshal.AllocHGlobal(s.Length + 1);
+            var buffer = (byte*)Marshal.AllocHGlobal(bytes.Length + 1);
             Marshal.Copy(bytes, 0, (IntPtr)buffer, bytes.Length);
-            buffer[s.Length] = 0;
+            buffer[bytes.Length] = 0;
             return buffer;
         }
 


### PR DESCRIPTION
- varible b has incorrect dimensions leading to out of bounds error
- syntetic entry point do not cleaunp args
- and fix string allocation, if we have non-English parameters we can truncate args