### PR TITLE
Allow nativeints to be coerced

### DIFF
--- a/Cesium.CodeGen/Extensions/TypeSystemEx.cs
+++ b/Cesium.CodeGen/Extensions/TypeSystemEx.cs
@@ -172,7 +172,13 @@ internal static class TypeSystemEx
     /// <remarks>See 6.3.1.8 Usual arithmetic conversions in the C standard.</remarks>
     public static IType GetCommonNumericType(this CTypeSystem ts, IType a, IType b)
     {
-        // First, if the corresponding real type of either operand is (long) double,
+        // First, if the corresponding real type of either operand is native int,
+        // the other operand is converted, without change of type domain, to a type whose corresponding real type is native int.
+        // Pointer arithmetics is constrained to few special operators, so there's no narrowing problems
+        if (a.IsEqualTo(ts.NativeInt) || b.IsEqualTo(ts.NativeInt))
+            return ts.NativeInt;
+
+        // Otherwise, if the corresponding real type of either operand is (long) double,
         // the other operand is converted, without change of type domain, to a type whose corresponding real type is (long) double.
         if (a.IsEqualTo(ts.Double) || b.IsEqualTo(ts.Double))
             return ts.Double;

--- a/Cesium.CodeGen/Ir/Types/CTypeSystem.cs
+++ b/Cesium.CodeGen/Ir/Types/CTypeSystem.cs
@@ -29,7 +29,7 @@ internal class CTypeSystem
             || (this.IsBool(targetType) && this.IsInteger(type)))
             return true;
 
-        if (!this.IsNumeric(type))
+        if (!type.IsEqualTo(NativeInt) && !this.IsNumeric(type))
             return false;
 
         if (targetType.Equals(SignedChar))
@@ -52,6 +52,8 @@ internal class CTypeSystem
             return true;
         else if (targetType.Equals(Double))
             return true;
+        else if (targetType.Equals(NativeInt))
+            return true;
         else
             return false;
     }
@@ -61,7 +63,7 @@ internal class CTypeSystem
         if (type.IsEqualTo(targetType))
             return false;
 
-        if (!this.IsNumeric(type))
+        if (!type.IsEqualTo(NativeInt) && !this.IsNumeric(type))
             throw new CompilationException($"Conversion from {type} to {targetType} is not supported.");
 
         if (targetType.Equals(SignedChar))


### PR DESCRIPTION
This allows nativeints to participate in few math operations without narrowing to explicit ints/longs/whatever.

#373 and #374 should rebase on this if merged