### PR TITLE
Implement offsetof as builtin

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenPointersTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenPointersTests.cs
@@ -34,4 +34,110 @@ public class CodeGenPointersTests : CodeGenTestBase
     public void CannotAddPointerTypes() => DoesNotCompile(
         "void foo (int *x) { x = x +x; }",
         "Operator Add is not supported for pointer/pointer operands");
+
+    [Fact]
+    public Task CanUseBuiltinOffsetOfOnDeclaredStruct() => DoTest(
+        "typedef struct { int x; } a; int m() { return &__builtin_offsetof_instance((a*) 0).x; }"
+    );
+
+    [Fact]
+    public Task CanUseBuiltinOffsetOfOnTaggedStruct() => DoTest(
+        "struct a { int x; }; int m() { return &__builtin_offsetof_instance((struct a*) 0).x; }"
+    );
+
+    [Fact]
+    public Task CanUseBuiltinOffsetOfOnBothDeclaredAndStruct() => DoTest(
+        "typedef struct a_s { int x; } a_t; int m() { return (int)&__builtin_offsetof_instance((a_t*)0).x + (int)&__builtin_offsetof_instance((struct a_s*) 0).x; }"
+    );
+
+    [Fact]
+    public Task CanUseBuiltinOffsetOfOnDeepMembers() => DoTest(
+        "typedef struct { int x; } a; typedef struct { a a; } b; int m() { return &__builtin_offsetof_instance((b*)0).a.x; }"
+    );
+
+    [Fact]
+    public void CannotUseBuiltinOffsetOfOnInvalidMembers() => DoesNotCompile(
+        "typedef struct { int x; } a; int m() { return &__builtin_offsetof_instance((a*)0).y; }",
+        "\"a\" has no member named \"y\""
+    );
+
+    [Fact]
+    public void CannotUseBuiltinOffsetOfOnPlainType() => DoesNotCompile(
+        "int m() { return &__builtin_offsetof_instance((int*)0).x; }",
+        "__builtin_offsetof_instance: type \"PrimitiveType { Kind = Int }\" is not a struct type."
+    );
+
+    [Fact]
+    public void CannotUseBuiltinOffsetOfOnPointerType() => DoesNotCompile(
+        "typedef struct { int x; } a; int m() { return &__builtin_offsetof_instance((a**)0).x; }",
+        "__builtin_offsetof_instance: type \"PointerType { Base = Cesium.CodeGen.Ir.Types.StructType }\" is not a struct type."
+    );
+
+    [Fact]
+    public void CannotUseBuiltinOffsetOfOnUndeclaredType() => DoesNotCompile(
+        "int m() { return &__builtin_offsetof_instance((undeclared*) 0).x; }",
+        "Cannot resolve type undeclared"
+    );
+
+    [Fact]
+    public void CannotUseBuiltinOffsetOfOnUndeclaredTag() => DoesNotCompile(
+        "int m() { return &__builtin_offsetof_instance((struct undeclared*) 0).x; }",
+        "__builtin_offsetof_instance: struct type \"undeclared\" has no members - is it declared?"
+    );
+
+    // Tests below rely on preprocessor, which is not supported in tests now
+
+    /*
+
+    [Fact]
+    public Task CanUseOffsetOfOnDeclaredStruct() => DoTest(
+        "#include <stddef.h>\ntypedef struct { int x; } a; int m() { return offsetof(a, x); }"
+    );
+
+    [Fact]
+    public Task CanUseOffsetOfOnTaggedStruct() => DoTest(
+        "#include <stddef.h>\nstruct a { int x; }; int m() { return offsetof(struct a, x); }"
+    );
+
+    [Fact]
+    public Task CanUseOffsetOfOnBothDeclaredAndStruct() => DoTest(
+        "#include <stddef.h>\ntypedef struct a_s { int x; } a_t; int m() { return offsetof(a_t, x) + offsetof(struct a_s, x); }"
+    );
+
+    [Fact]
+    public Task CanUseOffsetOfOnDeepMembers() => DoTest(
+        "#include <stddef.h>\ntypedef struct { int x; } a; typedef struct { a a; } b; int m() { return offsetof(b, a.x); }"
+    );
+
+    [Fact]
+    public void CannotUseOffsetOfOnInvalidMembers() => DoesNotCompile(
+        "#include <stddef.h>\ntypedef struct { int x; } a; int m() { return offsetof(a, y); }",
+        "asd"
+    );
+
+    [Fact]
+    public void CannotUseOffsetOfOnPlainType() => DoesNotCompile(
+        "#include <stddef.h>\nint m() { return offsetof(int, x); }",
+        ""
+    );
+
+    [Fact]
+    public void CannotUseOffsetOfOnPointerType() => DoesNotCompile(
+        "#include <stddef.h>\ntypedef struct { int x; } a; int m() { return offsetof(a*, x); }",
+        ""
+    );
+
+    [Fact]
+    public void CannotUseOffsetOfOnUndeclaredType() => DoesNotCompile(
+        "#include <stddef.h>\nint m() { return offsetof(undeclared, x); }",
+        ""
+    );
+
+    [Fact]
+    public void CannotUseOffsetOfOnUndeclaredTag() => DoesNotCompile(
+        "#include <stddef.h>\nint m() { return offsetof(struct undeclared, x); }",
+        ""
+    );
+
+    */
 }

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayAddressOf.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayAddressOf.verified.txt
@@ -7,15 +7,16 @@
   IL_0003: localloc
   IL_0005: stloc.0
   IL_0006: ldloc.0
-  IL_0007: ldc.i4.2
-  IL_0008: conv.i
-  IL_0009: ldc.i4 4
-  IL_000e: mul
-  IL_000f: add
-  IL_0010: conv.u
-  IL_0011: stloc.1
-  IL_0012: ldc.i4.0
-  IL_0013: ret
+  IL_0007: conv.u
+  IL_0008: ldc.i4.4
+  IL_0009: ldc.i4.2
+  IL_000a: mul
+  IL_000b: conv.i
+  IL_000c: add
+  IL_000d: conv.u
+  IL_000e: stloc.1
+  IL_000f: ldc.i4.0
+  IL_0010: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ValidPointerSubtractionTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ValidPointerSubtractionTest.verified.txt
@@ -6,23 +6,25 @@
   IL_0003: localloc
   IL_0005: stloc.0
   IL_0006: ldloc.0
-  IL_0007: ldc.i4.s 10
-  IL_0009: conv.i
-  IL_000a: ldc.i4 4
-  IL_000f: mul
-  IL_0010: add
-  IL_0011: conv.u
-  IL_0012: ldloc.0
-  IL_0013: ldc.i4.1
+  IL_0007: conv.u
+  IL_0008: ldc.i4.4
+  IL_0009: ldc.i4.s 10
+  IL_000b: mul
+  IL_000c: conv.i
+  IL_000d: add
+  IL_000e: conv.u
+  IL_000f: ldloc.0
+  IL_0010: conv.u
+  IL_0011: ldc.i4.4
+  IL_0012: ldc.i4.1
+  IL_0013: mul
   IL_0014: conv.i
-  IL_0015: ldc.i4 4
-  IL_001a: mul
-  IL_001b: add
-  IL_001c: conv.u
-  IL_001d: sub
-  IL_001e: ldc.i4.4
-  IL_001f: div
-  IL_0020: ret
+  IL_0015: add
+  IL_0016: conv.u
+  IL_0017: sub
+  IL_0018: ldc.i4.4
+  IL_0019: div
+  IL_001a: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnBothDeclaredAndStruct.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnBothDeclaredAndStruct.verified.txt
@@ -1,0 +1,15 @@
+﻿System.Int32 <Module>::m()
+  Locals:
+    a_s V_0
+  IL_0000: ldloca V_0
+  IL_0004: conv.u
+  IL_0005: ldflda System.Int32 a_s::x
+  IL_000a: conv.u
+  IL_000b: conv.i4
+  IL_000c: ldloca V_0
+  IL_0010: conv.u
+  IL_0011: ldflda System.Int32 a_s::x
+  IL_0016: conv.u
+  IL_0017: conv.i4
+  IL_0018: add
+  IL_0019: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnDeclaredStruct.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnDeclaredStruct.verified.txt
@@ -1,0 +1,8 @@
+﻿System.Int32 <Module>::m()
+  Locals:
+    <typedef>a V_0
+  IL_0000: ldloca V_0
+  IL_0004: conv.u
+  IL_0005: ldflda System.Int32 <typedef>a::x
+  IL_000a: conv.u
+  IL_000b: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnDeepMembers.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnDeepMembers.verified.txt
@@ -1,0 +1,10 @@
+﻿System.Int32 <Module>::m()
+  Locals:
+    <typedef>b V_0
+  IL_0000: ldloca V_0
+  IL_0004: conv.u
+  IL_0005: ldflda <typedef>a <typedef>b::a
+  IL_000a: conv.u
+  IL_000b: ldflda System.Int32 <typedef>a::x
+  IL_0010: conv.u
+  IL_0011: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnTaggedStruct.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnTaggedStruct.verified.txt
@@ -1,0 +1,8 @@
+﻿System.Int32 <Module>::m()
+  Locals:
+    a V_0
+  IL_0000: ldloca V_0
+  IL_0004: conv.u
+  IL_0005: ldflda System.Int32 a::x
+  IL_000a: conv.u
+  IL_000b: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseOffsetOfInstanceOnDeclaredStruct.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseOffsetOfInstanceOnDeclaredStruct.verified.txt
@@ -1,0 +1,8 @@
+﻿System.Int32 <Module>::m()
+  Locals:
+    <typedef>a V_0
+  IL_0000: ldloca V_0
+  IL_0004: conv.u
+  IL_0005: ldflda System.Int32 <typedef>a::x
+  IL_000a: conv.u
+  IL_000b: ret

--- a/Cesium.CodeGen/Ir/BlockItems/TypeDefBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/TypeDefBlockItem.cs
@@ -33,6 +33,12 @@ internal class TypeDefBlockItem : IBlockItem
 
             type = scope.ResolveType(type);
             scope.AddTypeDefinition(identifier, type);
+
+            if (typeDef.Type is StructType { Identifier: { } tag })
+            {
+                scope.AddTagDefinition(tag, type);
+            }
+
             list.Add(new LocalDeclarationInfo(type, identifier, cliImportMemberName));
         }
 

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -36,6 +36,24 @@ internal class FunctionCallExpression : IExpression
 
     public IExpression Lower(IDeclarationScope scope)
     {
+        if (_function.Identifier == "__builtin_offsetof_instance")
+        {
+            if (_arguments is not [IdentifierExpression typeExpr])
+            {
+                throw new CompilationException($"__builtin_offsetof_instance: invalid arguments");
+            }
+
+            var type = typeExpr.Identifier;
+
+            var resolvedType = scope.ResolveType(new NamedType(type));
+            if (resolvedType is not StructType resolvedStruct)
+            {
+                throw new CompilationException($"Type \"{type}\" is not a struct type.");
+            }
+
+            return new InstanceForOffsetOfExpression(resolvedStruct);
+        }
+
         var functionName = _function.Identifier;
         var callee = scope.GetFunctionInfo(functionName);
         if (callee is null)

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -52,7 +52,7 @@ internal class FunctionCallExpression : IExpression
 
             if (resolvedStruct.Members.Count == 0)
             {
-                throw new CompilationException($"__builtin_offsetof_instance: struct type \"{resolvedType}\" has no members - is it declared?");
+                throw new CompilationException($"__builtin_offsetof_instance: struct type \"{resolvedStruct.Identifier}\" has no members - is it declared?");
             }
 
             return new InstanceForOffsetOfExpression(resolvedStruct);

--- a/Cesium.CodeGen/Ir/Expressions/InstanceForOffsetOfExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/InstanceForOffsetOfExpression.cs
@@ -1,0 +1,49 @@
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Extensions;
+using Cesium.CodeGen.Ir.Expressions.Values;
+using Cesium.CodeGen.Ir.Types;
+using Mono.Cecil.Cil;
+
+namespace Cesium.CodeGen.Ir.Expressions;
+
+internal class InstanceForOffsetOfExpression : IExpression, IValueExpression, IAddressableValue
+{
+    private readonly StructType _resolvedType;
+
+    public InstanceForOffsetOfExpression(StructType resolvedType)
+    {
+        _resolvedType = resolvedType;
+    }
+
+    public IExpression Lower(IDeclarationScope scope) => this;
+
+    public void EmitTo(IEmitScope scope)
+    {
+        var typeRef = _resolvedType.Resolve(scope.Context);
+
+        VariableDefinition var;
+
+        if (scope.Method.Body.Variables.FirstOrDefault(v => v.VariableType.IsEqualTo(typeRef)) is
+            { } existingVar)
+        {
+            var = existingVar;
+        }
+        else
+        {
+            var = new VariableDefinition(typeRef);
+            scope.Method.Body.Variables.Add(var);
+        }
+
+        scope.AddInstruction(OpCodes.Ldloca, var);
+    }
+
+    public IType GetExpressionType(IDeclarationScope scope) => scope.CTypeSystem.NativeInt;
+
+    public IValue Resolve(IDeclarationScope scope) => this;
+
+    public void EmitGetValue(IEmitScope scope) => throw new NotSupportedException();
+
+    public IType GetValueType() => _resolvedType;
+
+    public void EmitGetAddress(IEmitScope scope) => EmitTo(scope);
+}

--- a/Cesium.CodeGen/Ir/Expressions/InstanceForOffsetOfExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/InstanceForOffsetOfExpression.cs
@@ -6,6 +6,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
+/// <summary>Takes an address of an instance of the passed type as part of the offsetof expression.</summary>
 internal class InstanceForOffsetOfExpression : IExpression, IValueExpression, IAddressableValue
 {
     private readonly StructType _resolvedType;

--- a/Cesium.CodeGen/Ir/Expressions/TypeCastExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/TypeCastExpression.cs
@@ -9,13 +9,13 @@ namespace Cesium.CodeGen.Ir.Expressions;
 
 internal sealed class TypeCastExpression : IExpression
 {
-    private IType _targetType;
-    private IExpression _expression;
+    public IType TargetType { get; }
+    public IExpression Expression { get; }
 
     public TypeCastExpression(IType targetType, IExpression expression)
     {
-        _targetType = targetType;
-        _expression = expression;
+        TargetType = targetType;
+        Expression = expression;
     }
 
     public TypeCastExpression(CastExpression castExpression)
@@ -23,51 +23,51 @@ internal sealed class TypeCastExpression : IExpression
         var ls = castExpression.TypeName.AbstractDeclarator is null
             ? Declarations.LocalDeclarationInfo.Of(castExpression.TypeName.SpecifierQualifierList, (Declarator?)null)
             : Declarations.LocalDeclarationInfo.Of(castExpression.TypeName.SpecifierQualifierList, castExpression.TypeName.AbstractDeclarator);
-        _targetType = ls.Type;
-        _expression = ExpressionEx.ToIntermediate(castExpression.Target);
+        TargetType = ls.Type;
+        Expression = ExpressionEx.ToIntermediate(castExpression.Target);
     }
 
     public void EmitTo(IEmitScope scope)
     {
-        _expression.EmitTo(scope);
+        Expression.EmitTo(scope);
 
         var ts = scope.CTypeSystem;
-        if (_targetType.Equals(ts.SignedChar))
+        if (TargetType.Equals(ts.SignedChar))
             Add(OpCodes.Conv_I1);
-        else if (_targetType.Equals(ts.Short))
+        else if (TargetType.Equals(ts.Short))
             Add(OpCodes.Conv_I2);
-        else if (_targetType.Equals(ts.Int))
+        else if (TargetType.Equals(ts.Int))
             Add(OpCodes.Conv_I4);
-        else if (_targetType.Equals(ts.Long))
+        else if (TargetType.Equals(ts.Long))
             Add(OpCodes.Conv_I8);
-        else if (_targetType.Equals(ts.Char))
+        else if (TargetType.Equals(ts.Char))
             Add(OpCodes.Conv_U1);
-        else if (_targetType.Equals(ts.UnsignedShort))
+        else if (TargetType.Equals(ts.UnsignedShort))
             Add(OpCodes.Conv_U2);
-        else if (_targetType.Equals(ts.UnsignedInt))
+        else if (TargetType.Equals(ts.UnsignedInt))
             Add(OpCodes.Conv_U4);
-        else if (_targetType.Equals(ts.UnsignedLong))
+        else if (TargetType.Equals(ts.UnsignedLong))
             Add(OpCodes.Conv_U8);
-        else if (_targetType.Equals(ts.Float))
+        else if (TargetType.Equals(ts.Float))
             Add(OpCodes.Conv_R4);
-        else if (_targetType.Equals(ts.Double))
+        else if (TargetType.Equals(ts.Double))
             Add(OpCodes.Conv_R8);
-        else if (_targetType is PointerType || _targetType.Equals(ts.NativeInt) || _targetType.Equals(ts.NativeUInt))
+        else if (TargetType is PointerType || TargetType.Equals(ts.NativeInt) || TargetType.Equals(ts.NativeUInt))
             Add(OpCodes.Conv_I);
         else
-            throw new AssertException($"Type {_targetType} is not supported.");
+            throw new AssertException($"Type {TargetType} is not supported.");
 
         void Add(OpCode op) => scope.Method.Body.Instructions.Add(Instruction.Create(op));
     }
 
-    public IType GetExpressionType(IDeclarationScope scope) => _targetType;
+    public IType GetExpressionType(IDeclarationScope scope) => TargetType;
 
     public IExpression Lower(IDeclarationScope scope)
     {
-        var resolvedType = scope.ResolveType(_targetType);
+        var resolvedType = scope.ResolveType(TargetType);
 
         return resolvedType is PrimitiveType { Kind: PrimitiveTypeKind.Void }
-            ? new ConsumeExpression(_expression.Lower(scope)).Lower(scope)
-            : new TypeCastExpression(resolvedType, _expression.Lower(scope));
+            ? new ConsumeExpression(Expression.Lower(scope)).Lower(scope)
+            : new TypeCastExpression(resolvedType, Expression.Lower(scope));
     }
 }

--- a/Cesium.CodeGen/Ir/Expressions/UnaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/UnaryOperatorExpression.cs
@@ -28,9 +28,11 @@ internal class UnaryOperatorExpression : IExpression
 
     public IExpression Lower(IDeclarationScope scope)
     {
+        var loweredTarget = _target.Lower(scope);
+
         if (_operator == UnaryOperator.AddressOf)
         {
-            if (_target is not IValueExpression expression)
+            if (loweredTarget is not IValueExpression expression)
                 throw new CompilationException($"Required a value expression to get address, got {_target} instead.");
 
             var value = expression.Resolve(scope);
@@ -40,7 +42,7 @@ internal class UnaryOperatorExpression : IExpression
             return new GetAddressValueExpression(aValue);
         }
 
-        return new UnaryOperatorExpression(_operator, _target.Lower(scope));
+        return new UnaryOperatorExpression(_operator, loweredTarget);
     }
 
     public void EmitTo(IEmitScope scope)

--- a/Cesium.Compiler/stdlib/stddef.h
+++ b/Cesium.Compiler/stdlib/stddef.h
@@ -9,4 +9,4 @@ typedef int                           errno_t;
 typedef size_t rsize_t;
 
 #define NULL ((void*)0)
-#define offsetof(type, member) ((size_t)((char*)&__builtin_offsetof_instance(type).member - (char*)&__builtin_offsetof_instance(type)))
+#define offsetof(type, member) ((size_t)((char*)&__builtin_offsetof_instance((type *)0).member - (char*)&__builtin_offsetof_instance((type *)0)))

--- a/Cesium.Compiler/stdlib/stddef.h
+++ b/Cesium.Compiler/stdlib/stddef.h
@@ -9,3 +9,4 @@ typedef int                           errno_t;
 typedef size_t rsize_t;
 
 #define NULL ((void*)0)
+#define offsetof(type, member) ((size_t)((char*)&__builtin_offsetof_instance(type).member - (char*)&__builtin_offsetof_instance(type)))

--- a/Cesium.IntegrationTests/pointers/pointers_offsetof.c
+++ b/Cesium.IntegrationTests/pointers/pointers_offsetof.c
@@ -1,22 +1,12 @@
 #include <stddef.h>
 
-typedef struct
-{
-    int asd;
-    int fgh;
-} bar_t;
-
-typedef struct foo
-{
-    int bar;
-    bar_t baz;
-    int qux;
-} foo;
+typedef struct { int quux; } qux_t;
+typedef struct { int bar, baz; qux_t qux; } foo_t;
 
 int main(int argc, char* argv[])
 {
-    // return ((size_t) (42));
-    // return offsetof(foo, bar) + offsetof(foo, baz) * offsetof(foo, qux) + 10;
+    foo_t foo;
+    *(int*)((char*) &foo + offsetof(foo_t, qux.quux)) = 42;
 
-    return offsetof(foo, bar) + offsetof(foo, baz.fgh) * offsetof(foo, qux) - 54;
+    return foo.qux.quux;
 }

--- a/Cesium.IntegrationTests/pointers/pointers_offsetof.c
+++ b/Cesium.IntegrationTests/pointers/pointers_offsetof.c
@@ -1,0 +1,22 @@
+#include <stddef.h>
+
+typedef struct
+{
+    int asd;
+    int fgh;
+} bar_t;
+
+typedef struct foo
+{
+    int bar;
+    bar_t baz;
+    int qux;
+} foo;
+
+int main(int argc, char* argv[])
+{
+    // return ((size_t) (42));
+    // return offsetof(foo, bar) + offsetof(foo, baz) * offsetof(foo, qux) + 10;
+
+    return offsetof(foo, bar) + offsetof(foo, baz.fgh) * offsetof(foo, qux) - 54;
+}

--- a/Cesium.sln
+++ b/Cesium.sln
@@ -60,6 +60,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{986C6A13-2
 		docs\tests.md = docs\tests.md
 		docs\type-system.md = docs\type-system.md
 		docs\architecture-sets.md = docs\architecture-sets.md
+		docs\builtins.md = docs\builtins.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cesium.Preprocessor", "Cesium.Preprocessor\Cesium.Preprocessor.csproj", "{0CDF730D-2A2A-437F-B27F-2BB04770C709}"

--- a/Cesium.sln.DotSettings
+++ b/Cesium.sln.DotSettings
@@ -5,4 +5,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=modulekind/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nint/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nuint/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=offsetof/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=runtimeconfig/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ Documentation
 
 - [C17 Language Standard Draft][c17-draft]
 
+- [Contributor Guide][docs.contributing]
 - [Cesium Tests][docs.tests]
 - [Cesium Type System][docs.type-system]
 - [Architecture Sets][docs.architecture-sets]
 - [CLI-Related Language Extensions][docs.language-extensions]
+- [Built-in Functions][docs.builtins]
 - [Exceptions in the Compiler Code][docs.exceptions]
 
 - [License (MIT)][docs.license]
@@ -104,19 +106,6 @@ If you're interested in certain project areas, check the per-area issue labels:
 - [`area:standard-support`][issues.standard-support]: issues related to C17 standard support
 - [`area:stdlib`][issues.stdlib]: issues related to the standard library implementation
 
-Documentation
--------------
-
-- [C17 Language Standard Draft][c17-draft]
-
-- [Contributor Guide][docs.contributing]
-- [Cesium Tests][docs.tests]
-- [Cesium Type System][docs.type-system]
-- [CLI-Related Language Extensions][docs.language-extensions]
-- [Exceptions in the Compiler Code][docs.exceptions]
-
-- [License (MIT)][docs.license]
-
 [andivionian-status-classifier]: https://github.com/ForNeVeR/andivionian-status-classifier#status-enfer-
 [c17-draft]: http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2310.pdf
 [discussions]: https://github.com/ForNeVeR/Cesium/discussions
@@ -127,6 +116,7 @@ Documentation
 [docs.license]: LICENSE.md
 [docs.tests]: docs/tests.md
 [docs.type-system]: docs/type-system.md
+[docs.builtins]: docs/builtins.md
 [issue.c17-standard]: https://github.com/ForNeVeR/Cesium/issues/62
 [issue.lexer]: https://github.com/ForNeVeR/Cesium/issues/76
 [issue.next-milestone]: https://github.com/ForNeVeR/Cesium/issues/61

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -1,0 +1,6 @@
+Built-in Functions
+------------------
+
+As a C implementation, Cesium implements some helper functions for the compiler. These are built-in language constructs.
+
+- `__builtin_offsetof_instance(pointer)`: this function is only concerned about the _type_ of the passed `pointer`. It will find the first variable of same type in the current scope (or emit a new one), and take address of said variable, as part of the `offsetof` macro implementation.


### PR DESCRIPTION
Closes #276.

Replacement for #374 - I decided to make it different PR as the implementation differs largely.

This implementation introduces builtin to obtain ptr to dirty instance of arbitrary struct.
This allows to write macro appropriate to offsetof features that previous implementation was unable to cover.
For example, `offsetof(foo, bar.baz)` now works.

This PR also uncovers discrepancy between default .net struct layout and msvc struct layout - I was forced to use Sequential struct layout for tests to match msvc offsets (related to #355?)

Do not merge: this PR depends on #377 and should be rebased before
Also there's a lot of testing code and dirty places, which requires some tidying.

## TODO[F]
- [x] Fix the review issues
### After merge
- [ ] Open an issue about using preprocessor in codegen tests
- [ ] Open an issue about the single place for builtins