### PR TITLE
Fix compilation for .NET Framework

### DIFF
--- a/.github/workflows/run-build-and-integration-tests.yml
+++ b/.github/workflows/run-build-and-integration-tests.yml
@@ -18,6 +18,14 @@ jobs:
         environment:
           - ubuntu-latest
           - windows-latest
+        framework:
+          - Net
+        configuration:
+          - Release
+        include:
+          - environment: windows-latest
+            framework: NetFramework
+            configuration: Release
     env:
       DOTNET_NOLOGO: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -30,11 +38,11 @@ jobs:
         uses: ./.github/workflows/perform-common-steps
 
       - name: 🛠 Build Solution 🛠
-        run: dotnet build
+        run: dotnet build --configuration ${{ matrix.configuration }}
 
       - name: 🔃 Setup MSVC Environment 🔃
         uses: ilammy/msvc-dev-cmd@v1
         if: startsWith(runner.os, 'windows')
 
       - name: ☑ Run Integration Tests ☑
-        run: pwsh -c ./Cesium.IntegrationTests/Run-Tests.ps1 -NoBuild
+        run: pwsh -c ./Cesium.IntegrationTests/Run-Tests.ps1 -NoBuild -TargetFramework ${{ matrix.framework }} -Configuration ${{ matrix.configuration }}

--- a/Cesium.CodeGen.Tests/TargetRuntimeTests.cs
+++ b/Cesium.CodeGen.Tests/TargetRuntimeTests.cs
@@ -16,7 +16,6 @@ public class TargetRuntimeTests : CodeGenTestBase
         var frameworkName = (string)targetFrameworkAttribute.ConstructorArguments.Single().Value;
 
         var result = new StringBuilder();
-        result.AppendLine($"CoreLibrary: {assembly.MainModule.TypeSystem.CoreLibrary}");
         result.AppendLine($"TargetFrameworkAttribute.FrameworkName: {frameworkName}");
 
         var verify = Verify(result, GetSettings());

--- a/Cesium.CodeGen.Tests/verified/TargetRuntimeTests.DefaultedFrameworkTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/TargetRuntimeTests.DefaultedFrameworkTest.verified.txt
@@ -1,2 +1,1 @@
-﻿CoreLibrary: System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
-TargetFrameworkAttribute.FrameworkName: .NETCoreApp,Version=v6.0
+﻿TargetFrameworkAttribute.FrameworkName: .NETCoreApp,Version=v6.0

--- a/Cesium.CodeGen.Tests/verified/TargetRuntimeTests.FrameworkTest_targetFramework=MsCorLib_systemAssemblyVersionString=4.0.0.0_frameworkVersionString=4.8.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/TargetRuntimeTests.FrameworkTest_targetFramework=MsCorLib_systemAssemblyVersionString=4.0.0.0_frameworkVersionString=4.8.verified.txt
@@ -1,2 +1,1 @@
-﻿CoreLibrary: System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
-TargetFrameworkAttribute.FrameworkName: .NETFramework,Version=v4.8
+﻿TargetFrameworkAttribute.FrameworkName: .NETFramework,Version=v4.8

--- a/Cesium.CodeGen.Tests/verified/TargetRuntimeTests.FrameworkTest_targetFramework=NetStandard_systemAssemblyVersionString=2.1.0.0_frameworkVersionString=2.1.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/TargetRuntimeTests.FrameworkTest_targetFramework=NetStandard_systemAssemblyVersionString=2.1.0.0_frameworkVersionString=2.1.verified.txt
@@ -1,2 +1,1 @@
-﻿CoreLibrary: System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
-TargetFrameworkAttribute.FrameworkName: .NETStandard,Version=v2.1
+﻿TargetFrameworkAttribute.FrameworkName: .NETStandard,Version=v2.1

--- a/Cesium.CodeGen.Tests/verified/TargetRuntimeTests.FrameworkTest_targetFramework=SystemRuntime_systemAssemblyVersionString=4.2.2.0_frameworkVersionString=6.0.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/TargetRuntimeTests.FrameworkTest_targetFramework=SystemRuntime_systemAssemblyVersionString=4.2.2.0_frameworkVersionString=6.0.verified.txt
@@ -1,2 +1,1 @@
-﻿CoreLibrary: System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
-TargetFrameworkAttribute.FrameworkName: .NETCoreApp,Version=v6.0
+﻿TargetFrameworkAttribute.FrameworkName: .NETCoreApp,Version=v6.0

--- a/Cesium.CodeGen/Contexts/AssemblyContext.cs
+++ b/Cesium.CodeGen/Contexts/AssemblyContext.cs
@@ -35,7 +35,6 @@ public class AssemblyContext
 
         var targetRuntime = compilationOptions.TargetRuntime;
         assembly.CustomAttributes.Add(targetRuntime.GetTargetFrameworkAttribute(module));
-        module.AssemblyReferences.Add(targetRuntime.GetSystemAssemblyReference());
 
         return assemblyContext;
     }

--- a/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
+++ b/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
@@ -120,7 +120,11 @@ public record TranslationUnitContext(AssemblyContext AssemblyContext, string Nam
 
     private TypeDefinition CreateTranslationUnitLevelType()
     {
-        var type = new TypeDefinition("", $"{Name}<Statics>", TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var type = new TypeDefinition(
+            "",
+            $"{Name}<Statics>",
+            TypeAttributes.Abstract | TypeAttributes.Sealed,
+            Module.TypeSystem.Object);
         Module.Types.Add(type);
         return type;
     }

--- a/Cesium.CodeGen/Extensions/TypeSystemEx.cs
+++ b/Cesium.CodeGen/Extensions/TypeSystemEx.cs
@@ -252,7 +252,15 @@ internal static class TypeSystemEx
 
     public static MethodReference GetArrayCopyToMethod(this TranslationUnitContext context)
     {
-        return context.Module.ImportReference(typeof(byte*[]).GetMethod("CopyTo", new[] { typeof(Array), typeof(int) }));
+        var typeSystem = context.Module.TypeSystem;
+        var arrayRef = context.Module.ImportReference(new TypeReference("System", "Array", context.Module, typeSystem.CoreLibrary));
+        var copyToMethodRef = new MethodReference("CopyTo", typeSystem.Void, arrayRef);
+        copyToMethodRef.HasThis = true;
+        copyToMethodRef.Parameters.Add(new ParameterDefinition(arrayRef));
+        copyToMethodRef.Parameters.Add(new ParameterDefinition(typeSystem.Int32));
+        copyToMethodRef = context.Module.ImportReference(copyToMethodRef);
+
+        return context.Module.ImportReference(copyToMethodRef);
     }
     public static MethodReference GetTargetFrameworkAttributeConstructor(this TranslationUnitContext context)
     {

--- a/Cesium.CodeGen/TargetRuntime.cs
+++ b/Cesium.CodeGen/TargetRuntime.cs
@@ -59,8 +59,10 @@ public record TargetRuntimeDescriptor(
             _ => throw new CompilationException($"Unknown target runtime kind: {Kind}")
         } + $",Version=v{TargetFrameworkVersion}";
 
-        var constructor = typeof(TargetFrameworkAttribute).GetConstructor(new[] { typeof(string) });
-        var constructorRef = module.ImportReference(constructor);
+        var targetFrameworkAttributeRef = module.ImportReference(new TypeReference("System.Runtime.Versioning", "TargetFrameworkAttribute", module, GetSystemAssemblyReference()));
+        var constructorRef = new MethodReference(".ctor", module.TypeSystem.Void, targetFrameworkAttributeRef);
+        constructorRef.Parameters.Add(new ParameterDefinition(module.TypeSystem.String));
+        constructorRef = module.ImportReference(constructorRef);
         return new CustomAttribute(constructorRef)
         {
             ConstructorArguments = { new CustomAttributeArgument(module.TypeSystem.String, frameworkName) }


### PR DESCRIPTION
which was broken for a long time. Because compiler run under TFM net7.0 we canot use `ImportReference(typeof(XXX))` or `ImportReference(typeof(XXX).GetMethod("mymethod"))` since that will bring depedency on S.P.CoreLib to finnal executable, which does not exists in .NET Framework.

Also add another test leg to make sure that it would not regress in the future.

I remove one line in test [/TargetRuntimeTests.cs](https://github.com/ForNeVeR/Cesium/pull/385/files#diff-0b3c15c70dd4a60cb9e5b2a48f0e890eb58fc8dee48810c6f4bc9b20ba043722) because I do not sure what it test since CoreLib is always S.P.CoreLib and after I fix resolving, it always mscorlib due to some Cecil internal stuff.

Also if you run `pwsh -c .\Cesium.IntegrationTests\Run-Tests.ps1 -TestCaseName structs\struct_subscription.c -TargetFramework NetFramework` and open `Cesium.IntegrationTests/bin/out_cs.exe` in ILSpy you would see following

![image](https://user-images.githubusercontent.com/4257079/236663048-87440711-9643-4e56-8ce4-ec805204a524.png)

This does not prevent anything from running, but indicates that we still work with metadata incorrectly.