### PR TITLE
Remove not needed function which left after rebase

### DIFF
--- a/Cesium.CodeGen/Contexts/AssemblyContext.cs
+++ b/Cesium.CodeGen/Contexts/AssemblyContext.cs
@@ -37,7 +37,6 @@ public class AssemblyContext
 
         var targetRuntime = compilationOptions.TargetRuntime;
         assembly.CustomAttributes.Add(targetRuntime.GetTargetFrameworkAttribute(module));
-        module.AssemblyReferences.Add(targetRuntime.GetSystemAssemblyReference());
 
         return assemblyContext;
     }


### PR DESCRIPTION
With that function we have two references to System.Runtime when targeting .NET