### PR TITLE
Fix SetValueExpression emitting

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenOperatorTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenOperatorTests.cs
@@ -36,4 +36,13 @@ public class CodeGenOperatorTests: CodeGenTestBase
 
     [Fact]
     public Task TertiaryOperatorWithoutAssignment() => DoTest(@"int main() { 1 > 2 ? 1 : 2; }");
+
+    [Fact]
+    public Task CompoundAssignment() => DoTest(@"int main() { int i = 0; i += 1; }");
+
+    [Fact]
+    public Task CompoundAssignmentAsValue() => DoTest(@"int main() { int i = 0; i = i += 1; }");
+
+    [Fact]
+    public Task IncrementAsValue() => DoTest(@"int main() { int i = 0; i = i++; }");
 }

--- a/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.CompoundAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.CompoundAssignment.verified.txt
@@ -1,0 +1,21 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32 V_0
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.0
+  IL_0002: ldloc.0
+  IL_0003: ldc.i4.1
+  IL_0004: add
+  IL_0005: stloc.0
+  IL_0006: ldc.i4.0
+  IL_0007: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.CompoundAssignmentAsValue.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.CompoundAssignmentAsValue.verified.txt
@@ -1,0 +1,23 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32 V_0
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.0
+  IL_0002: ldloc.0
+  IL_0003: ldc.i4.1
+  IL_0004: add
+  IL_0005: stloc.0
+  IL_0006: ldloc.0
+  IL_0007: stloc.0
+  IL_0008: ldc.i4.0
+  IL_0009: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.IncrementAsValue.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.IncrementAsValue.verified.txt
@@ -1,0 +1,23 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32 V_0
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.0
+  IL_0002: ldloc.0
+  IL_0003: ldc.i4.1
+  IL_0004: add
+  IL_0005: stloc.0
+  IL_0006: ldloc.0
+  IL_0007: stloc.0
+  IL_0008: ldc.i4.0
+  IL_0009: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen/Ir/BlockItems/ExpressionStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ExpressionStatement.cs
@@ -18,9 +18,12 @@ internal class ExpressionStatement : IBlockItem
 
     public IBlockItem Lower(IDeclarationScope scope)
     {
-        IExpression? loweredExpression = _expression?.Lower(scope);
+        var loweredExpression = _expression?.Lower(scope);
+
+        if (loweredExpression is SetValueExpression setValue)
+            return new ExpressionStatement(setValue.NoReturn());
+
         if (loweredExpression is not null
-            && loweredExpression is not SetValueExpression
             && !loweredExpression.GetExpressionType(scope).IsEqualTo(scope.CTypeSystem.Void))
         {
             loweredExpression = new ConsumeExpression(loweredExpression);

--- a/Cesium.CodeGen/Ir/Expressions/SetValueExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SetValueExpression.cs
@@ -8,16 +8,28 @@ internal class SetValueExpression : IExpression
 {
     private readonly ILValue _value;
     private readonly IExpression _expression;
+    private readonly bool _doReturn;
 
-    public SetValueExpression(ILValue value, IExpression expression)
+    public SetValueExpression(ILValue value, IExpression expression, bool doReturn = true)
     {
         _value = value;
         _expression = expression;
+        _doReturn = doReturn;
     }
 
     public IExpression Lower(IDeclarationScope scope) => this;
 
-    public void EmitTo(IEmitScope scope) => _value.EmitSetValue(scope, _expression);
+    public void EmitTo(IEmitScope scope)
+    {
+        _value.EmitSetValue(scope, _expression);
 
-    public IType GetExpressionType(IDeclarationScope scope) => _value.GetValueType();
+        if (_doReturn)
+            _value.EmitGetValue(scope);
+    }
+
+    public IType GetExpressionType(IDeclarationScope scope) => _doReturn
+        ? _value.GetValueType()
+        : new PrimitiveType(PrimitiveTypeKind.Void);
+
+    public IExpression NoReturn() => new SetValueExpression(_value, _expression, false);
 }

--- a/Cesium.IntegrationTests/switch/duff_device.c
+++ b/Cesium.IntegrationTests/switch/duff_device.c
@@ -3,11 +3,7 @@ int main()
     int j = 0;
     int c = 42;
 
-    // TODO[#411] assignments are broken as expressions currently
-    // switch(c&3) while((c-=4)>=0) {
-    switch(c&3) while(c >= 4) {
-        c -= 4;
-
+    switch(c&3) while((c-=4)>=0) {
         j++; case 3:
         j++; case 2:
         j++; case 1:

--- a/Cesium.IntegrationTests/switch/no_side_effects.c
+++ b/Cesium.IntegrationTests/switch/no_side_effects.c
@@ -2,7 +2,6 @@ int main(int argc, char *argv[])
 {
     int i = 0;
 
-    // TODO[#409]: bad SetValueExpression results in unbalanced stack
     switch (++i)
     {
         case 0:

--- a/Cesium.IntegrationTests/value_assignments.c
+++ b/Cesium.IntegrationTests/value_assignments.c
@@ -1,0 +1,8 @@
+int main()
+{
+    int i = 0;
+
+    int j = i++;
+
+    return i += 41;
+}


### PR DESCRIPTION
SetValueExpression has invalid type - type is always equal to type of value to set, but actual emitted code always leave empty stack, so SetValueExpression cannot be used as value and when it is used compiler produces invalid IL.

This PR fixes that - compound assignments now work correctly
This allows `while (i += 1)` and `while (i++)` to be compiled correctly

Fun fact - this code will result in 1 in `i`

```
var i = 0;
i += i += 1;
```

(there's no sequence points, so who cares, but this it worth noting)

- Closes #409.
- Closes #411.