### PR TITLE
Remove LowerInitializers

### DIFF
--- a/Cesium.CodeGen/Ir/BlockItems/CompoundStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/CompoundStatement.cs
@@ -29,17 +29,7 @@ internal class CompoundStatement : IBlockItem
         var newNestedStatements = new List<IBlockItem>();
         foreach (var blockItem in Statements)
         {
-            if (blockItem is DeclarationBlockItem declaration)
-            {
-                foreach (var splittedBlockItem in declaration.LowerInitializers())
-                {
-                    newNestedStatements.Add(splittedBlockItem.Lower(blockScope));
-                }
-            }
-            else
-            {
-                newNestedStatements.Add(blockItem.Lower(blockScope));
-            }
+            newNestedStatements.Add(blockItem.Lower(blockScope));
         }
 
         return new CompoundStatement(newNestedStatements, blockScope);

--- a/Cesium.CodeGen/Ir/BlockItems/InitializationBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/InitializationBlockItem.cs
@@ -1,0 +1,20 @@
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Ir.Expressions;
+
+namespace Cesium.CodeGen.Ir.BlockItems;
+
+internal record InitializerPart(IExpression? PrimaryInitializer, IExpression? SecondaryInitializer);
+
+internal record InitializationBlockItem(ICollection<InitializerPart> Items) : IBlockItem
+{
+    public IBlockItem Lower(IDeclarationScope scope) => this; // already lowered
+
+    public void EmitTo(IEmitScope scope)
+    {
+        foreach (var (primInt, secInt) in Items)
+        {
+            primInt?.EmitTo(scope);
+            secInt?.EmitTo(scope);
+        }
+    }
+}

--- a/Cesium.CodeGen/Ir/BlockItems/SwitchStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/SwitchStatement.cs
@@ -43,10 +43,7 @@ internal class SwitchStatement : IBlockItem
                         _expression)
                 }));
 
-        foreach (var dbiBlock in dbi.LowerInitializers())
-        {
-            targetStmts.Add(dbiBlock.Lower(switchScope));
-        }
+        targetStmts.Add(dbi.Lower(switchScope));
 
         var idExpr = new IdentifierExpression("$switch_tmp");
 

--- a/Cesium.CodeGen/Ir/Expressions/ConsumeExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/ConsumeExpression.cs
@@ -13,7 +13,7 @@ internal class ConsumeExpression : IExpression
         _expression = expression;
     }
 
-    public IExpression Lower(IDeclarationScope scope) => this;
+    public IExpression Lower(IDeclarationScope scope) => new ConsumeExpression(_expression.Lower(scope));
 
     public IType GetExpressionType(IDeclarationScope scope)
     {
@@ -22,6 +22,13 @@ internal class ConsumeExpression : IExpression
 
     public void EmitTo(IEmitScope scope)
     {
+        if (_expression is SetValueExpression sv)
+        {
+            sv.NoReturn().EmitTo(scope);
+
+            return;
+        }
+
         _expression.EmitTo(scope);
         var processor = scope.Method.Body.GetILProcessor();
         processor.Emit(OpCodes.Pop);

--- a/Cesium.CodeGen/Ir/Expressions/LocalArrayAllocationExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/LocalArrayAllocationExpression.cs
@@ -1,0 +1,16 @@
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Ir.Types;
+
+namespace Cesium.CodeGen.Ir.Expressions;
+
+internal record LocalAllocationExpression(InPlaceArrayType ArrayType) : IExpression
+{
+    public IExpression Lower(IDeclarationScope scope) => this;
+
+    public void EmitTo(IEmitScope scope)
+    {
+        ArrayType.EmitInitializer(scope);
+    }
+
+    public IType GetExpressionType(IDeclarationScope scope) => ArrayType;
+}


### PR DESCRIPTION
WIP: this PR is based on #403, which is not merged now
Look at the last commit

This PR removes LowerInitializers specialization from CompoundStatement and DeclarationBlockItem, latter is now lowered to the new InitializationBlockItem thing, which just emits initializers in a sequence.

New expression - LocalArrayAllocationExpression - is added to replace hacks and specialized emit in DeclarationBlockItem.
LocalArrayAllocationExpression is currently delegates to InPlaceArrayType.EmitInitializer  (this can be changed by just moving that code from I.P.A.T to that expression)

Few hacks less from the CodeGen