### PR TITLE
Foolproof comma operator

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenOperatorTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenOperatorTests.cs
@@ -32,6 +32,9 @@ public class CodeGenOperatorTests: CodeGenTestBase
     public Task CommaOperator() => DoTest(@"int main() { int x = (1, 2); }");
 
     [Fact]
+    public Task VoidCommaOperator() => DoTest(@"void a() { } int main() { int x = (a(), 2); }");
+
+    [Fact]
     public Task TertiaryOperator() => DoTest(@"int main() { int x = 1 > 2 ? 1 : 2; }");
 
     [Fact]

--- a/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.VoidCommaOperator.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenOperatorTests.VoidCommaOperator.verified.txt
@@ -1,0 +1,21 @@
+﻿System.Void <Module>::a()
+  IL_0000: ret
+
+System.Int32 <Module>::main()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Void <Module>::a()
+  IL_0005: ldc.i4.2
+  IL_0006: stloc.0
+  IL_0007: ldc.i4.0
+  IL_0008: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen/Ir/Expressions/CommaExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/CommaExpression.cs
@@ -30,7 +30,10 @@ internal class CommaExpression : IExpression
 
         _left.EmitTo(scope);
 
-        bodyProcessor.Emit(OpCodes.Pop);
+        if (_left.GetExpressionType((IDeclarationScope)scope) is not PrimitiveType { Kind: PrimitiveTypeKind.Void })
+        {
+            bodyProcessor.Emit(OpCodes.Pop);
+        }
 
         _right.EmitTo(scope);
     }

--- a/Cesium.IntegrationTests/comma_operator.c
+++ b/Cesium.IntegrationTests/comma_operator.c
@@ -1,4 +1,9 @@
+void voidfn()
+{
+    // do nothing
+}
+
 int main(void)
 {
-    return (1 + 2, 40 + 2);
+    return (1 + 2, voidfn(), 40 + 2);
 }


### PR DESCRIPTION
This PR fixes CommaExpression emit when left expression returns void - there's nothing to pop from the stack in this case