### PR TITLE
Remove extra pointer casts

### DIFF
--- a/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.PointerArrayMemberAssign_arch=Bit32.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.PointerArrayMemberAssign_arch=Bit32.verified.txt
@@ -9,32 +9,26 @@
       IL_0003: localloc
       IL_0005: stloc.0
       IL_0006: ldloc.0
-      IL_0007: conv.u
-      IL_0008: ldc.i4.4
-      IL_0009: ldc.i4.2
-      IL_000a: mul
-      IL_000b: conv.i
-      IL_000c: add
-      IL_000d: ldc.i4.0
-      IL_000e: stind.i
-      IL_000f: ldloc.0
-      IL_0010: conv.u
-      IL_0011: ldc.i4.4
-      IL_0012: ldc.i4.0
-      IL_0013: mul
-      IL_0014: conv.i
-      IL_0015: add
-      IL_0016: ldloc.0
-      IL_0017: conv.u
-      IL_0018: ldc.i4.4
-      IL_0019: ldc.i4.2
-      IL_001a: mul
-      IL_001b: conv.i
-      IL_001c: add
-      IL_001d: ldind.i
-      IL_001e: stind.i
-      IL_001f: ldc.i4.0
-      IL_0020: ret
+      IL_0007: ldc.i4.4
+      IL_0008: ldc.i4.2
+      IL_0009: mul
+      IL_000a: add
+      IL_000b: ldc.i4.0
+      IL_000c: stind.i
+      IL_000d: ldloc.0
+      IL_000e: ldc.i4.4
+      IL_000f: ldc.i4.0
+      IL_0010: mul
+      IL_0011: add
+      IL_0012: ldloc.0
+      IL_0013: ldc.i4.4
+      IL_0014: ldc.i4.2
+      IL_0015: mul
+      IL_0016: add
+      IL_0017: ldind.i
+      IL_0018: stind.i
+      IL_0019: ldc.i4.0
+      IL_001a: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.PointerArrayMemberAssign_arch=Bit64.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.PointerArrayMemberAssign_arch=Bit64.verified.txt
@@ -9,32 +9,26 @@
       IL_0003: localloc
       IL_0005: stloc.0
       IL_0006: ldloc.0
-      IL_0007: conv.u
-      IL_0008: ldc.i4.8
-      IL_0009: ldc.i4.2
-      IL_000a: mul
-      IL_000b: conv.i
-      IL_000c: add
-      IL_000d: ldc.i4.0
-      IL_000e: stind.i
-      IL_000f: ldloc.0
-      IL_0010: conv.u
-      IL_0011: ldc.i4.8
-      IL_0012: ldc.i4.0
-      IL_0013: mul
-      IL_0014: conv.i
-      IL_0015: add
-      IL_0016: ldloc.0
-      IL_0017: conv.u
-      IL_0018: ldc.i4.8
-      IL_0019: ldc.i4.2
-      IL_001a: mul
-      IL_001b: conv.i
-      IL_001c: add
-      IL_001d: ldind.i
-      IL_001e: stind.i
-      IL_001f: ldc.i4.0
-      IL_0020: ret
+      IL_0007: ldc.i4.8
+      IL_0008: ldc.i4.2
+      IL_0009: mul
+      IL_000a: add
+      IL_000b: ldc.i4.0
+      IL_000c: stind.i
+      IL_000d: ldloc.0
+      IL_000e: ldc.i4.8
+      IL_000f: ldc.i4.0
+      IL_0010: mul
+      IL_0011: add
+      IL_0012: ldloc.0
+      IL_0013: ldc.i4.8
+      IL_0014: ldc.i4.2
+      IL_0015: mul
+      IL_0016: add
+      IL_0017: ldind.i
+      IL_0018: stind.i
+      IL_0019: ldc.i4.0
+      IL_001a: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.PointerArrayMemberAssign_arch=Dynamic.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.PointerArrayMemberAssign_arch=Dynamic.verified.txt
@@ -11,32 +11,26 @@
       IL_0009: localloc
       IL_000b: stloc.0
       IL_000c: ldloc.0
-      IL_000d: conv.u
-      IL_000e: sizeof System.Void*
-      IL_0014: ldc.i4.2
-      IL_0015: mul
-      IL_0016: conv.i
-      IL_0017: add
-      IL_0018: ldc.i4.0
-      IL_0019: stind.i
-      IL_001a: ldloc.0
-      IL_001b: conv.u
-      IL_001c: sizeof System.Void*
-      IL_0022: ldc.i4.0
-      IL_0023: mul
-      IL_0024: conv.i
-      IL_0025: add
-      IL_0026: ldloc.0
-      IL_0027: conv.u
-      IL_0028: sizeof System.Void*
-      IL_002e: ldc.i4.2
-      IL_002f: mul
-      IL_0030: conv.i
-      IL_0031: add
-      IL_0032: ldind.i
-      IL_0033: stind.i
-      IL_0034: ldc.i4.0
-      IL_0035: ret
+      IL_000d: sizeof System.Void*
+      IL_0013: ldc.i4.2
+      IL_0014: mul
+      IL_0015: add
+      IL_0016: ldc.i4.0
+      IL_0017: stind.i
+      IL_0018: ldloc.0
+      IL_0019: sizeof System.Void*
+      IL_001f: ldc.i4.0
+      IL_0020: mul
+      IL_0021: add
+      IL_0022: ldloc.0
+      IL_0023: sizeof System.Void*
+      IL_0029: ldc.i4.2
+      IL_002a: mul
+      IL_002b: add
+      IL_002c: ldind.i
+      IL_002d: stind.i
+      IL_002e: ldc.i4.0
+      IL_002f: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Bit32.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Bit32.verified.txt
@@ -1,4 +1,4 @@
-Module: Primary
+﻿Module: Primary
   Type: <Module>
   Methods:
     System.Int32 <Module>::main()
@@ -9,23 +9,19 @@ Module: Primary
       IL_0006: localloc
       IL_0008: stloc.0
       IL_0009: ldloc.0
-      IL_000a: conv.u
-      IL_000b: ldc.i4.4
-      IL_000c: ldc.i4 299
-      IL_0011: mul
-      IL_0012: conv.i
-      IL_0013: add
-      IL_0014: ldc.i4.0
-      IL_0015: stind.i
-      IL_0016: ldloc.0
-      IL_0017: conv.u
-      IL_0018: ldc.i4.4
-      IL_0019: ldc.i4 299
-      IL_001e: mul
-      IL_001f: conv.i
-      IL_0020: add
-      IL_0021: ldind.i
-      IL_0022: ret
+      IL_000a: ldc.i4.4
+      IL_000b: ldc.i4 299
+      IL_0010: mul
+      IL_0011: add
+      IL_0012: ldc.i4.0
+      IL_0013: stind.i
+      IL_0014: ldloc.0
+      IL_0015: ldc.i4.4
+      IL_0016: ldc.i4 299
+      IL_001b: mul
+      IL_001c: add
+      IL_001d: ldind.i
+      IL_001e: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Bit64.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Bit64.verified.txt
@@ -1,4 +1,4 @@
-Module: Primary
+﻿Module: Primary
   Type: <Module>
   Methods:
     System.Int32 <Module>::main()
@@ -9,23 +9,19 @@ Module: Primary
       IL_0006: localloc
       IL_0008: stloc.0
       IL_0009: ldloc.0
-      IL_000a: conv.u
-      IL_000b: ldc.i4.8
-      IL_000c: ldc.i4 299
-      IL_0011: mul
-      IL_0012: conv.i
-      IL_0013: add
-      IL_0014: ldc.i4.0
-      IL_0015: stind.i
-      IL_0016: ldloc.0
-      IL_0017: conv.u
-      IL_0018: ldc.i4.8
-      IL_0019: ldc.i4 299
-      IL_001e: mul
-      IL_001f: conv.i
-      IL_0020: add
-      IL_0021: ldind.i
-      IL_0022: ret
+      IL_000a: ldc.i4.8
+      IL_000b: ldc.i4 299
+      IL_0010: mul
+      IL_0011: add
+      IL_0012: ldc.i4.0
+      IL_0013: stind.i
+      IL_0014: ldloc.0
+      IL_0015: ldc.i4.8
+      IL_0016: ldc.i4 299
+      IL_001b: mul
+      IL_001c: add
+      IL_001d: ldind.i
+      IL_001e: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Dynamic.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/ArchitectureDependentCodeTests.StaticArray_arch=Dynamic.verified.txt
@@ -1,4 +1,4 @@
-Module: Primary
+﻿Module: Primary
   Type: <Module>
   Methods:
     System.Int32 <Module>::main()
@@ -11,23 +11,19 @@ Module: Primary
       IL_000d: localloc
       IL_000f: stloc.0
       IL_0010: ldloc.0
-      IL_0011: conv.u
-      IL_0012: sizeof System.Int32*
-      IL_0018: ldc.i4 299
-      IL_001d: mul
-      IL_001e: conv.i
-      IL_001f: add
-      IL_0020: ldc.i4.0
-      IL_0021: stind.i
-      IL_0022: ldloc.0
-      IL_0023: conv.u
-      IL_0024: sizeof System.Int32*
-      IL_002a: ldc.i4 299
-      IL_002f: mul
-      IL_0030: conv.i
-      IL_0031: add
-      IL_0032: ldind.i
-      IL_0033: ret
+      IL_0011: sizeof System.Int32*
+      IL_0017: ldc.i4 299
+      IL_001c: mul
+      IL_001d: add
+      IL_001e: ldc.i4.0
+      IL_001f: stind.i
+      IL_0020: ldloc.0
+      IL_0021: sizeof System.Int32*
+      IL_0027: ldc.i4 299
+      IL_002c: mul
+      IL_002d: add
+      IL_002e: ldind.i
+      IL_002f: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayAddressOf.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayAddressOf.verified.txt
@@ -7,16 +7,13 @@
   IL_0003: localloc
   IL_0005: stloc.0
   IL_0006: ldloc.0
-  IL_0007: conv.u
-  IL_0008: ldc.i4.4
-  IL_0009: ldc.i4.2
-  IL_000a: mul
-  IL_000b: conv.i
-  IL_000c: add
-  IL_000d: conv.u
-  IL_000e: stloc.1
-  IL_000f: ldc.i4.0
-  IL_0010: ret
+  IL_0007: ldc.i4.4
+  IL_0008: ldc.i4.2
+  IL_0009: mul
+  IL_000a: add
+  IL_000b: stloc.1
+  IL_000c: ldc.i4.0
+  IL_000d: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayAssignment.verified.txt
@@ -6,23 +6,19 @@
   IL_0003: localloc
   IL_0005: stloc.0
   IL_0006: ldloc.0
-  IL_0007: conv.u
-  IL_0008: ldc.i4.4
-  IL_0009: ldc.i4.1
-  IL_000a: mul
-  IL_000b: conv.i
-  IL_000c: add
-  IL_000d: ldc.i4.2
-  IL_000e: stind.i4
-  IL_000f: ldloc.0
-  IL_0010: conv.u
-  IL_0011: ldc.i4.4
-  IL_0012: ldc.i4.1
-  IL_0013: mul
-  IL_0014: conv.i
-  IL_0015: add
-  IL_0016: ldind.i4
-  IL_0017: ret
+  IL_0007: ldc.i4.4
+  IL_0008: ldc.i4.1
+  IL_0009: mul
+  IL_000a: add
+  IL_000b: ldc.i4.2
+  IL_000c: stind.i4
+  IL_000d: ldloc.0
+  IL_000e: ldc.i4.4
+  IL_000f: ldc.i4.1
+  IL_0010: mul
+  IL_0011: add
+  IL_0012: ldind.i4
+  IL_0013: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayElementIndexInComparison.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayElementIndexInComparison.verified.txt
@@ -6,23 +6,21 @@
   IL_0003: localloc
   IL_0005: stloc.0
   IL_0006: ldloc.0
-  IL_0007: conv.u
-  IL_0008: ldc.i4.4
-  IL_0009: ldc.i4.1
-  IL_000a: mul
-  IL_000b: conv.i
-  IL_000c: add
-  IL_000d: ldind.i4
-  IL_000e: ldc.i4.s 13
-  IL_0010: ceq
-  IL_0012: ldc.i4.0
-  IL_0013: ceq
-  IL_0015: brfalse IL_001c
-  IL_001a: ldc.i4.m1
-  IL_001b: ret
-  IL_001c: nop
-  IL_001d: ldc.i4.0
-  IL_001e: ret
+  IL_0007: ldc.i4.4
+  IL_0008: ldc.i4.1
+  IL_0009: mul
+  IL_000a: add
+  IL_000b: ldind.i4
+  IL_000c: ldc.i4.s 13
+  IL_000e: ceq
+  IL_0010: ldc.i4.0
+  IL_0011: ceq
+  IL_0013: brfalse IL_001a
+  IL_0018: ldc.i4.m1
+  IL_0019: ret
+  IL_001a: nop
+  IL_001b: ldc.i4.0
+  IL_001c: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayElementIndexViaVariable.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayElementIndexViaVariable.verified.txt
@@ -14,18 +14,16 @@
   IL_000b: ldc.i4 4
   IL_0010: mul
   IL_0011: add
-  IL_0012: conv.u
-  IL_0013: ldc.i4.4
-  IL_0014: ldc.i4.0
-  IL_0015: ldc.i4.s 10
+  IL_0012: ldc.i4.4
+  IL_0013: ldc.i4.0
+  IL_0014: ldc.i4.s 10
+  IL_0016: mul
   IL_0017: mul
-  IL_0018: mul
-  IL_0019: conv.i
-  IL_001a: add
-  IL_001b: ldc.i4.s 13
-  IL_001d: stind.i4
-  IL_001e: ldc.i4.0
-  IL_001f: ret
+  IL_0018: add
+  IL_0019: ldc.i4.s 13
+  IL_001b: stind.i4
+  IL_001c: ldc.i4.0
+  IL_001d: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayInitialization.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayInitialization.verified.txt
@@ -11,23 +11,19 @@
   IL_0011: conv.u
   IL_0012: call System.Void Cesium.Runtime.RuntimeHelpers::InitializeCompound(System.Void*,System.Void*,System.UInt32)
   IL_0017: ldloc.0
-  IL_0018: conv.u
-  IL_0019: ldc.i4.4
-  IL_001a: ldc.i4.1
-  IL_001b: mul
-  IL_001c: conv.i
-  IL_001d: add
-  IL_001e: ldc.i4.2
-  IL_001f: stind.i4
-  IL_0020: ldloc.0
-  IL_0021: conv.u
-  IL_0022: ldc.i4.4
-  IL_0023: ldc.i4.1
-  IL_0024: mul
-  IL_0025: conv.i
-  IL_0026: add
-  IL_0027: ldind.i4
-  IL_0028: ret
+  IL_0018: ldc.i4.4
+  IL_0019: ldc.i4.1
+  IL_001a: mul
+  IL_001b: add
+  IL_001c: ldc.i4.2
+  IL_001d: stind.i4
+  IL_001e: ldloc.0
+  IL_001f: ldc.i4.4
+  IL_0020: ldc.i4.1
+  IL_0021: mul
+  IL_0022: add
+  IL_0023: ldind.i4
+  IL_0024: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ComplexTypeAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ComplexTypeAssignment.verified.txt
@@ -6,27 +6,21 @@
   IL_0003: localloc
   IL_0005: stloc.0
   IL_0006: ldloc.0
-  IL_0007: conv.u
-  IL_0008: ldc.i4.4
-  IL_0009: ldc.i4.2
-  IL_000a: ldc.i4.1
-  IL_000b: sub
-  IL_000c: mul
-  IL_000d: conv.i
-  IL_000e: add
-  IL_000f: conv.u
-  IL_0010: ldc.i4.s 42
-  IL_0012: stfld System.Int32 <typedef>foo::x
-  IL_0017: ldloc.0
-  IL_0018: conv.u
-  IL_0019: ldc.i4.4
-  IL_001a: ldc.i4.1
-  IL_001b: mul
-  IL_001c: conv.i
-  IL_001d: add
-  IL_001e: conv.u
-  IL_001f: ldfld System.Int32 <typedef>foo::x
-  IL_0024: ret
+  IL_0007: ldc.i4.4
+  IL_0008: ldc.i4.2
+  IL_0009: ldc.i4.1
+  IL_000a: sub
+  IL_000b: mul
+  IL_000c: add
+  IL_000d: ldc.i4.s 42
+  IL_000f: stfld System.Int32 <typedef>foo::x
+  IL_0014: ldloc.0
+  IL_0015: ldc.i4.4
+  IL_0016: ldc.i4.1
+  IL_0017: mul
+  IL_0018: add
+  IL_0019: ldfld System.Int32 <typedef>foo::x
+  IL_001e: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalArrayAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalArrayAssignment.verified.txt
@@ -7,23 +7,19 @@
 
 System.Int32 <Module>::main()
   IL_0000: ldsflda System.Int32* <Module>::a
-  IL_0005: conv.u
-  IL_0006: ldc.i4.4
-  IL_0007: ldc.i4.1
-  IL_0008: mul
-  IL_0009: conv.i
-  IL_000a: add
-  IL_000b: ldc.i4.2
-  IL_000c: stind.i4
-  IL_000d: ldsflda System.Int32* <Module>::a
-  IL_0012: conv.u
-  IL_0013: ldc.i4.4
-  IL_0014: ldc.i4.1
-  IL_0015: mul
-  IL_0016: conv.i
-  IL_0017: add
-  IL_0018: ldind.i4
-  IL_0019: ret
+  IL_0005: ldc.i4.4
+  IL_0006: ldc.i4.1
+  IL_0007: mul
+  IL_0008: add
+  IL_0009: ldc.i4.2
+  IL_000a: stind.i4
+  IL_000b: ldsflda System.Int32* <Module>::a
+  IL_0010: ldc.i4.4
+  IL_0011: ldc.i4.1
+  IL_0012: mul
+  IL_0013: add
+  IL_0014: ldind.i4
+  IL_0015: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalArrayInitialization.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalArrayInitialization.verified.txt
@@ -12,23 +12,19 @@
 
 System.Int32 <Module>::main()
   IL_0000: ldsflda System.Int32* <Module>::a
-  IL_0005: conv.u
-  IL_0006: ldc.i4.4
-  IL_0007: ldc.i4.1
-  IL_0008: mul
-  IL_0009: conv.i
-  IL_000a: add
-  IL_000b: ldc.i4.2
-  IL_000c: stind.i4
-  IL_000d: ldsflda System.Int32* <Module>::a
-  IL_0012: conv.u
-  IL_0013: ldc.i4.4
-  IL_0014: ldc.i4.1
-  IL_0015: mul
-  IL_0016: conv.i
-  IL_0017: add
-  IL_0018: ldind.i4
-  IL_0019: ret
+  IL_0005: ldc.i4.4
+  IL_0006: ldc.i4.1
+  IL_0007: mul
+  IL_0008: add
+  IL_0009: ldc.i4.2
+  IL_000a: stind.i4
+  IL_000b: ldsflda System.Int32* <Module>::a
+  IL_0010: ldc.i4.4
+  IL_0011: ldc.i4.1
+  IL_0012: mul
+  IL_0013: add
+  IL_0014: ldind.i4
+  IL_0015: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalMultidimensionalArrayAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalMultidimensionalArrayAssignment.verified.txt
@@ -12,32 +12,28 @@ System.Int32 <Module>::main()
   IL_0007: ldc.i4 4
   IL_000c: mul
   IL_000d: add
-  IL_000e: conv.u
-  IL_000f: ldc.i4.4
-  IL_0010: ldc.i4.2
-  IL_0011: ldc.i4.s 10
+  IL_000e: ldc.i4.4
+  IL_000f: ldc.i4.2
+  IL_0010: ldc.i4.s 10
+  IL_0012: mul
   IL_0013: mul
-  IL_0014: mul
-  IL_0015: conv.i
-  IL_0016: add
-  IL_0017: ldc.i4.2
-  IL_0018: stind.i4
-  IL_0019: ldsfld System.Int32* <Module>::a
-  IL_001e: ldc.i4.1
-  IL_001f: conv.i
-  IL_0020: ldc.i4 4
-  IL_0025: mul
-  IL_0026: add
-  IL_0027: conv.u
-  IL_0028: ldc.i4.4
-  IL_0029: ldc.i4.2
-  IL_002a: ldc.i4.s 10
-  IL_002c: mul
-  IL_002d: mul
-  IL_002e: conv.i
-  IL_002f: add
-  IL_0030: ldind.i4
-  IL_0031: ret
+  IL_0014: add
+  IL_0015: ldc.i4.2
+  IL_0016: stind.i4
+  IL_0017: ldsfld System.Int32* <Module>::a
+  IL_001c: ldc.i4.1
+  IL_001d: conv.i
+  IL_001e: ldc.i4 4
+  IL_0023: mul
+  IL_0024: add
+  IL_0025: ldc.i4.4
+  IL_0026: ldc.i4.2
+  IL_0027: ldc.i4.s 10
+  IL_0029: mul
+  IL_002a: mul
+  IL_002b: add
+  IL_002c: ldind.i4
+  IL_002d: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.MultidimensionalArrayAssignment.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.MultidimensionalArrayAssignment.verified.txt
@@ -11,32 +11,28 @@
   IL_000c: ldc.i4 4
   IL_0011: mul
   IL_0012: add
-  IL_0013: conv.u
-  IL_0014: ldc.i4.4
-  IL_0015: ldc.i4.2
-  IL_0016: ldc.i4.s 10
+  IL_0013: ldc.i4.4
+  IL_0014: ldc.i4.2
+  IL_0015: ldc.i4.s 10
+  IL_0017: mul
   IL_0018: mul
-  IL_0019: mul
-  IL_001a: conv.i
-  IL_001b: add
-  IL_001c: ldc.i4.2
-  IL_001d: stind.i4
-  IL_001e: ldloc.0
-  IL_001f: ldc.i4.1
-  IL_0020: conv.i
-  IL_0021: ldc.i4 4
-  IL_0026: mul
-  IL_0027: add
-  IL_0028: conv.u
-  IL_0029: ldc.i4.4
-  IL_002a: ldc.i4.2
-  IL_002b: ldc.i4.s 10
-  IL_002d: mul
-  IL_002e: mul
-  IL_002f: conv.i
-  IL_0030: add
-  IL_0031: ldind.i4
-  IL_0032: ret
+  IL_0019: add
+  IL_001a: ldc.i4.2
+  IL_001b: stind.i4
+  IL_001c: ldloc.0
+  IL_001d: ldc.i4.1
+  IL_001e: conv.i
+  IL_001f: ldc.i4 4
+  IL_0024: mul
+  IL_0025: add
+  IL_0026: ldc.i4.4
+  IL_0027: ldc.i4.2
+  IL_0028: ldc.i4.s 10
+  IL_002a: mul
+  IL_002b: mul
+  IL_002c: add
+  IL_002d: ldind.i4
+  IL_002e: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FunctionPointerCallTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.FunctionPointerCallTest.verified.txt
@@ -6,12 +6,11 @@ System.Int32 <Module>::main()
   Locals:
     method System.Int32 *(System.Int32) V_0
   IL_0000: ldftn System.Int32 <Module>::foo(System.Int32)
-  IL_0006: conv.u
-  IL_0007: stloc.0
-  IL_0008: ldc.i4.s 123
-  IL_000a: ldloc.0
-  IL_000b: calli System.Int32(System.Int32)
-  IL_0010: ret
+  IL_0006: stloc.0
+  IL_0007: ldc.i4.s 123
+  IL_0009: ldloc.0
+  IL_000a: calli System.Int32(System.Int32)
+  IL_000f: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.MultiDeclarationWithStruct.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.MultiDeclarationWithStruct.verified.txt
@@ -2,11 +2,10 @@
   Locals:
     <typedef>foo V_0
   IL_0000: ldloca.s V_0
-  IL_0002: conv.u
-  IL_0003: ldc.i4.0
-  IL_0004: stfld System.Int32 <typedef>foo::x
-  IL_0009: ldc.i4.0
-  IL_000a: ret
+  IL_0002: ldc.i4.0
+  IL_0003: stfld System.Int32 <typedef>foo::x
+  IL_0008: ldc.i4.0
+  IL_0009: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.StructArraySubscriptionTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.StructArraySubscriptionTest.verified.txt
@@ -8,25 +8,19 @@
   IL_000a: localloc
   IL_000c: stloc.0
   IL_000d: ldloc.0
-  IL_000e: conv.u
-  IL_000f: sizeof <typedef>foo
-  IL_0015: ldc.i4.1
-  IL_0016: mul
-  IL_0017: conv.i
-  IL_0018: add
-  IL_0019: conv.u
-  IL_001a: ldc.i4.s 42
-  IL_001c: stfld System.Int32 <typedef>foo::x
-  IL_0021: ldloc.0
-  IL_0022: conv.u
-  IL_0023: sizeof <typedef>foo
-  IL_0029: ldc.i4.1
-  IL_002a: mul
-  IL_002b: conv.i
-  IL_002c: add
-  IL_002d: conv.u
-  IL_002e: ldfld System.Int32 <typedef>foo::x
-  IL_0033: ret
+  IL_000e: sizeof <typedef>foo
+  IL_0014: ldc.i4.1
+  IL_0015: mul
+  IL_0016: add
+  IL_0017: ldc.i4.s 42
+  IL_0019: stfld System.Int32 <typedef>foo::x
+  IL_001e: ldloc.0
+  IL_001f: sizeof <typedef>foo
+  IL_0025: ldc.i4.1
+  IL_0026: mul
+  IL_0027: add
+  IL_0028: ldfld System.Int32 <typedef>foo::x
+  IL_002d: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.StructSubscriptionTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.StructSubscriptionTest.verified.txt
@@ -2,27 +2,21 @@
   Locals:
     <typedef>foo V_0
   IL_0000: ldloca.s V_0
-  IL_0002: conv.u
-  IL_0003: ldflda <typedef>foo/<SyntheticBuffer>fixedArr <typedef>foo::fixedArr
-  IL_0008: conv.u
-  IL_0009: ldc.i4.4
-  IL_000a: ldc.i4.3
-  IL_000b: mul
-  IL_000c: conv.i
-  IL_000d: add
-  IL_000e: ldc.i4.0
-  IL_000f: stind.i4
-  IL_0010: ldloca.s V_0
-  IL_0012: conv.u
-  IL_0013: ldflda <typedef>foo/<SyntheticBuffer>fixedArr <typedef>foo::fixedArr
-  IL_0018: conv.u
-  IL_0019: ldc.i4.4
-  IL_001a: ldc.i4.3
-  IL_001b: mul
-  IL_001c: conv.i
-  IL_001d: add
-  IL_001e: ldind.i4
-  IL_001f: ret
+  IL_0002: ldflda <typedef>foo/<SyntheticBuffer>fixedArr <typedef>foo::fixedArr
+  IL_0007: ldc.i4.4
+  IL_0008: ldc.i4.3
+  IL_0009: mul
+  IL_000a: add
+  IL_000b: ldc.i4.0
+  IL_000c: stind.i4
+  IL_000d: ldloca.s V_0
+  IL_000f: ldflda <typedef>foo/<SyntheticBuffer>fixedArr <typedef>foo::fixedArr
+  IL_0014: ldc.i4.4
+  IL_0015: ldc.i4.3
+  IL_0016: mul
+  IL_0017: add
+  IL_0018: ldind.i4
+  IL_0019: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ValidPointerSubtractionTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ValidPointerSubtractionTest.verified.txt
@@ -6,25 +6,19 @@
   IL_0003: localloc
   IL_0005: stloc.0
   IL_0006: ldloc.0
-  IL_0007: conv.u
-  IL_0008: ldc.i4.4
-  IL_0009: ldc.i4.s 10
-  IL_000b: mul
-  IL_000c: conv.i
-  IL_000d: add
-  IL_000e: conv.u
-  IL_000f: ldloc.0
-  IL_0010: conv.u
-  IL_0011: ldc.i4.4
-  IL_0012: ldc.i4.1
-  IL_0013: mul
-  IL_0014: conv.i
-  IL_0015: add
-  IL_0016: conv.u
-  IL_0017: sub
-  IL_0018: ldc.i4.4
-  IL_0019: div
-  IL_001a: ret
+  IL_0007: ldc.i4.4
+  IL_0008: ldc.i4.s 10
+  IL_000a: mul
+  IL_000b: add
+  IL_000c: ldloc.0
+  IL_000d: ldc.i4.4
+  IL_000e: ldc.i4.1
+  IL_000f: mul
+  IL_0010: add
+  IL_0011: sub
+  IL_0012: ldc.i4.4
+  IL_0013: div
+  IL_0014: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.AddToPointerFromLeft.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.AddToPointerFromLeft.verified.txt
@@ -2,8 +2,7 @@
   IL_0000: ldc.i4.4
   IL_0001: ldc.i4.1
   IL_0002: mul
-  IL_0003: conv.i
-  IL_0004: ldarg.0
-  IL_0005: add
-  IL_0006: starg.s x
-  IL_0008: ret
+  IL_0003: ldarg.0
+  IL_0004: add
+  IL_0005: starg.s x
+  IL_0007: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.AddToPointerFromRight.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.AddToPointerFromRight.verified.txt
@@ -3,7 +3,6 @@
   IL_0001: ldc.i4.4
   IL_0002: ldc.i4.1
   IL_0003: mul
-  IL_0004: conv.i
-  IL_0005: add
-  IL_0006: starg.s x
-  IL_0008: ret
+  IL_0004: add
+  IL_0005: starg.s x
+  IL_0007: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.AddressOfTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.AddressOfTest.verified.txt
@@ -3,10 +3,9 @@
     System.Int32* V_0
     System.Int32 V_1
   IL_0000: ldloca.s V_1
-  IL_0002: conv.u
-  IL_0003: stloc.0
-  IL_0004: ldc.i4.0
-  IL_0005: ret
+  IL_0002: stloc.0
+  IL_0003: ldc.i4.0
+  IL_0004: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnBothDeclaredAndStruct.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnBothDeclaredAndStruct.verified.txt
@@ -2,14 +2,10 @@
   Locals:
     a_s V_0
   IL_0000: ldloca V_0
-  IL_0004: conv.u
-  IL_0005: ldflda System.Int32 a_s::x
-  IL_000a: conv.u
-  IL_000b: conv.i4
-  IL_000c: ldloca V_0
-  IL_0010: conv.u
-  IL_0011: ldflda System.Int32 a_s::x
-  IL_0016: conv.u
-  IL_0017: conv.i4
-  IL_0018: add
-  IL_0019: ret
+  IL_0004: ldflda System.Int32 a_s::x
+  IL_0009: conv.i4
+  IL_000a: ldloca V_0
+  IL_000e: ldflda System.Int32 a_s::x
+  IL_0013: conv.i4
+  IL_0014: add
+  IL_0015: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnDeclaredStruct.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnDeclaredStruct.verified.txt
@@ -2,7 +2,5 @@
   Locals:
     <typedef>a V_0
   IL_0000: ldloca V_0
-  IL_0004: conv.u
-  IL_0005: ldflda System.Int32 <typedef>a::x
-  IL_000a: conv.u
-  IL_000b: ret
+  IL_0004: ldflda System.Int32 <typedef>a::x
+  IL_0009: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnDeepMembers.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnDeepMembers.verified.txt
@@ -2,9 +2,6 @@
   Locals:
     <typedef>b V_0
   IL_0000: ldloca V_0
-  IL_0004: conv.u
-  IL_0005: ldflda <typedef>a <typedef>b::a
-  IL_000a: conv.u
-  IL_000b: ldflda System.Int32 <typedef>a::x
-  IL_0010: conv.u
-  IL_0011: ret
+  IL_0004: ldflda <typedef>a <typedef>b::a
+  IL_0009: ldflda System.Int32 <typedef>a::x
+  IL_000e: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnTaggedStruct.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.CanUseBuiltinOffsetOfOnTaggedStruct.verified.txt
@@ -2,7 +2,5 @@
   Locals:
     a V_0
   IL_0000: ldloca V_0
-  IL_0004: conv.u
-  IL_0005: ldflda System.Int32 a::x
-  IL_000a: conv.u
-  IL_000b: ret
+  IL_0004: ldflda System.Int32 a::x
+  IL_0009: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.IndexOverPointer.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.IndexOverPointer.verified.txt
@@ -5,8 +5,7 @@
   IL_0001: ldc.i4.4
   IL_0002: ldc.i4.1
   IL_0003: mul
-  IL_0004: conv.i
-  IL_0005: add
-  IL_0006: ldind.i4
-  IL_0007: stloc.0
-  IL_0008: ret
+  IL_0004: add
+  IL_0005: ldind.i4
+  IL_0006: stloc.0
+  IL_0007: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.FunctionPointer.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.FunctionPointer.verified.txt
@@ -8,10 +8,9 @@
       Locals:
         method System.Int32 *(System.Int32) V_0
       IL_0000: ldftn System.Void <Module>::foo(System.Int32)
-      IL_0006: conv.u
-      IL_0007: stloc.0
-      IL_0008: ldc.i4.0
-      IL_0009: ret
+      IL_0006: stloc.0
+      IL_0007: ldc.i4.0
+      IL_0008: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessGet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessGet.verified.txt
@@ -5,9 +5,8 @@
       Locals:
         <typedef>foo V_0
       IL_0000: ldloca.s V_0
-      IL_0002: conv.u
-      IL_0003: ldfld System.Int32 <typedef>foo::x
-      IL_0008: ret
+      IL_0002: ldfld System.Int32 <typedef>foo::x
+      IL_0007: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessSet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAddressWithPointerMemberAccessSet.verified.txt
@@ -5,11 +5,10 @@
       Locals:
         <typedef>foo V_0
       IL_0000: ldloca.s V_0
-      IL_0002: conv.u
-      IL_0003: ldc.i4.s 42
-      IL_0005: stfld System.Int32 <typedef>foo::x
-      IL_000a: ldc.i4.0
-      IL_000b: ret
+      IL_0002: ldc.i4.s 42
+      IL_0004: stfld System.Int32 <typedef>foo::x
+      IL_0009: ldc.i4.0
+      IL_000a: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAndTypeDefHasSeparateNamespaces.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructAndTypeDefHasSeparateNamespaces.verified.txt
@@ -6,15 +6,13 @@
         tagFoo V_0
         <typedef>Foo V_1
       IL_0000: ldloca.s V_0
-      IL_0002: conv.u
-      IL_0003: ldc.i4.0
-      IL_0004: stfld System.Int32 tagFoo::A
-      IL_0009: ldloca.s V_1
-      IL_000b: conv.u
-      IL_000c: ldc.i4.0
-      IL_000d: stfld System.Int32 <typedef>Foo::B
-      IL_0012: ldc.i4.0
-      IL_0013: ret
+      IL_0002: ldc.i4.0
+      IL_0003: stfld System.Int32 tagFoo::A
+      IL_0008: ldloca.s V_1
+      IL_000a: ldc.i4.0
+      IL_000b: stfld System.Int32 <typedef>Foo::B
+      IL_0010: ldc.i4.0
+      IL_0011: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithMemberAccessGet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithMemberAccessGet.verified.txt
@@ -5,9 +5,8 @@
       Locals:
         <typedef>foo V_0
       IL_0000: ldloca.s V_0
-      IL_0002: conv.u
-      IL_0003: ldfld System.Int32 <typedef>foo::x
-      IL_0008: ret
+      IL_0002: ldfld System.Int32 <typedef>foo::x
+      IL_0007: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithMemberAccessSet.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructUsageWithMemberAccessSet.verified.txt
@@ -5,11 +5,10 @@
       Locals:
         <typedef>foo V_0
       IL_0000: ldloca.s V_0
-      IL_0002: conv.u
-      IL_0003: ldc.i4.s 42
-      IL_0005: stfld System.Int32 <typedef>foo::x
-      IL_000a: ldc.i4.0
-      IL_000b: ret
+      IL_0002: ldc.i4.s 42
+      IL_0004: stfld System.Int32 <typedef>foo::x
+      IL_0009: ldc.i4.0
+      IL_000a: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.TypeDefStructUsage.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.TypeDefStructUsage.verified.txt
@@ -5,11 +5,10 @@
       Locals:
         <typedef>foo V_0
       IL_0000: ldloca.s V_0
-      IL_0002: conv.u
-      IL_0003: ldc.i4.0
-      IL_0004: stfld System.Int32 <typedef>foo::x
-      IL_0009: ldc.i4.0
-      IL_000a: ret
+      IL_0002: ldc.i4.0
+      IL_0003: stfld System.Int32 <typedef>foo::x
+      IL_0008: ldc.i4.0
+      IL_0009: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
       Locals:

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BinaryOperatorExpression.cs
@@ -101,12 +101,11 @@ internal class BinaryOperatorExpression : IExpression
                 throw new CompilationException($"Operator {Operator} is not supported for pointer/value operands");
             }
 
-            right = new TypeCastExpression(
-                scope.CTypeSystem.NativeInt,
-                new BinaryOperatorExpression(
-                    leftPointerType.Base.GetSizeInBytesExpression(scope.ArchitectureSet),
-                    BinaryOperator.Multiply,
-                    right));
+            right = new BinaryOperatorExpression(
+                leftPointerType.Base.GetSizeInBytesExpression(scope.ArchitectureSet),
+                BinaryOperator.Multiply,
+                right
+            );
 
             return new BinaryOperatorExpression(left, Operator, right);
         }
@@ -119,12 +118,11 @@ internal class BinaryOperatorExpression : IExpression
                 throw new CompilationException($"Operator {Operator} is not supported for value/pointer operands");
             }
 
-            left = new TypeCastExpression(
-                scope.CTypeSystem.NativeInt,
-                new BinaryOperatorExpression(
-                    rightPointerType.Base.GetSizeInBytesExpression(scope.ArchitectureSet),
-                    BinaryOperator.Multiply,
-                    left));
+            left = new BinaryOperatorExpression(
+                rightPointerType.Base.GetSizeInBytesExpression(scope.ArchitectureSet),
+                BinaryOperator.Multiply,
+                left
+            );
 
             return new BinaryOperatorExpression(left, Operator, right);
         }

--- a/Cesium.CodeGen/Ir/Expressions/GetAddressValueExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/GetAddressValueExpression.cs
@@ -20,7 +20,6 @@ internal class GetAddressValueExpression : IExpression
     public void EmitTo(IEmitScope scope)
     {
         _value.EmitGetAddress(scope);
-        scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Conv_U));
     }
 
     public IType GetExpressionType(IDeclarationScope scope)


### PR DESCRIPTION
This PR removes a huge amount of conv.u/conv.i casts around pointers - they are redundant and it does not matter if they're signed or not. The only available arithmetic operations for pointers are only addition and subtraction - the sign (and any sign extension too) does not matter for them.