### PR TITLE
Small preprocessor update

### DIFF
--- a/Cesium.Parser/CParser.cs
+++ b/Cesium.Parser/CParser.cs
@@ -1,8 +1,6 @@
 using System.Collections.Immutable;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Cesium.Ast;
-using Yoakke.Collections.Values;
 using Yoakke.SynKit.C.Syntax;
 using Yoakke.SynKit.Lexer;
 using Yoakke.SynKit.Parser;
@@ -942,69 +940,6 @@ public partial class CParser
         declarations.Add((Declaration)newDeclaration);
 
     // TODO[#78]: 6.9.2 External object definitions
-
-    // 6.10 Preprocessing directives
-
-    // TODO[#77]:
-    // preprocessing-file:
-    //     group?
-    // group:
-    //     group-part
-    //     group group-part
-    // group-part:
-    //     if-section
-    //     control-line
-    //     text-line
-    //     # non-directive
-    // if-section:
-    //     if-group elif-groups? else-group? endif-line
-    // if-group:
-    //     # if constant-expression new-line group?
-    //     # ifdef identifier new-line group?
-    //     # ifndef identifier new-line group?
-    // elif-groups:
-    //     elif-group
-    //     elif-groups elif-group
-    // elif-group:
-    //     # elif constant-expression new-line group?
-    // else-group:
-    //     # else new-line group?
-    // endif-line:
-    //     # endif new-line
-    // control-line:
-    //     # include pp-tokens new-line
-    //     # define identifier replacement-list new-line
-    //     # define identifier lparen identifier-list? ) replacement-list new-line
-    //     # define identifier lparen ... ) replacement-list new-line
-    //     # define identifier lparen identifier-list , ... ) replacement-list new-line
-    //     # undef identifier new-line
-    //     # line pp-tokens new-line
-    //     # error pp-tokens? new-line
-    //     # pragma pp-tokens? new-line
-    //     # new-line
-    // text-line:
-    //     pp-tokens? new-line
-    // non-directive:
-    //     pp-tokens new-line
-    // lparen:
-    //     a ( character not immediately preceded by white space
-    // replacement-list:
-    //     pp-tokens?
-    // pp-tokens:
-    //     preprocessing-token
-    //     pp-tokens preprocessing-token
-    // new-line:
-    //     the new-line character
-
-    // TODO[#77]: 6.10.1 Conditional inclusion
-    // TODO[#77]: 6.10.2 Source file inclusion
-    // TODO[#77]: 6.10.3 Macro replacement
-    // TODO[#77]: 6.10.4 Line control
-    // TODO[#77]: 6.10.5 Error directive
-    // TODO[#77]: 6.10.6 Pragma directive
-    // TODO[#77]: 6.10.7 Null directive
-    // TODO[#77]: 6.10.8 Predefined macro names
-    // TODO[#77]: 6.10.9 Pragma operator
 
     private ParseResult<(DeclarationSpecifiers, Declarator)> CustomParseSpecifiersAndDeclarator(int offset)
     {

--- a/Cesium.Preprocessor/CPreprocessor.cs
+++ b/Cesium.Preprocessor/CPreprocessor.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using Cesium.Core;
@@ -384,14 +383,9 @@ public record CPreprocessor(string CompilationUnitPath, ILexer<IToken<CPreproces
                 if (identifier == "once")
                 {
                     IncludeContext.RegisterGuardedFileInclude(CompilationUnitPath);
-                    return Array.Empty<IToken<CPreprocessorTokenType>>();
                 }
-                else
-                {
-                    throw new WipException(
-                        77,
-                        $"Preprocessor #pragma directive not supported: {keyword.Kind} {keyword.Text}.");
-                }
+
+                return Array.Empty<IToken<CPreprocessorTokenType>>();
             }
             default:
                 throw new WipException(

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Implementation Dashboard
 ------------------------
 
 - [ ] [C17 standard compatibility][issue.c17-standard]: poor
-    - [ ] [Preprocessor][issue.preprocessor]: about **10%** of all features are supported
+    - [ ] [Preprocessor][issue.preprocessor]: about **30%** of all features are supported
     - [ ] [Lexer][issue.lexer]: mostly works, but needs more tests and validation on its compliance
     - [ ] [Parser][issue.parser]: supports about **25%** of the language syntax
 - [ ] **Compiler**


### PR DESCRIPTION
- Remove no longer needed TODO comments.
- Update the completion percentage in the `README` file.
- Fix the `#pragma` processing to skip unknown pragmas.