### PR TITLE
Tests: add a workaround for https://github.com/dotnet/sdk/issues/34653

### DIFF
--- a/Cesium.IntegrationTests/Cesium.IntegrationTests.csproj
+++ b/Cesium.IntegrationTests/Cesium.IntegrationTests.csproj
@@ -21,4 +21,8 @@
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"/>
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\Cesium.Test.Framework\Cesium.Test.Framework.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/Cesium.IntegrationTests/IntegrationTestContext.cs
+++ b/Cesium.IntegrationTests/IntegrationTestContext.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Cesium.Test.Framework;
 using JetBrains.Annotations;
 using NeoSmart.AsyncLock;
 using Xunit.Abstractions;
@@ -72,11 +73,7 @@ public class IntegrationTestContext : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        await ExecUtil.RunToSuccess(null, "dotnet", SolutionRootPath, new[]
-        {
-            "build-server",
-            "shutdown"
-        });
+        await DotNetCliHelper.ShutdownBuildServer();
     }
 
     private static string GetSolutionRoot()
@@ -97,20 +94,12 @@ public class IntegrationTestContext : IAsyncDisposable
     private async Task BuildRuntime(ITestOutputHelper output)
     {
         var runtimeProjectFile = Path.Combine(SolutionRootPath, "Cesium.Runtime/Cesium.Runtime.csproj");
-        await BuildDotNetProject(output, runtimeProjectFile);
+        await DotNetCliHelper.BuildDotNetProject(output, BuildConfiguration, runtimeProjectFile);
     }
 
     private async Task BuildCompiler(ITestOutputHelper output)
     {
         var compilerProjectFile = Path.Combine(SolutionRootPath, "Cesium.Compiler/Cesium.Compiler.csproj");
-        await BuildDotNetProject(output, compilerProjectFile);
+        await DotNetCliHelper.BuildDotNetProject(output, BuildConfiguration, compilerProjectFile);
     }
-
-    private Task BuildDotNetProject(ITestOutputHelper output, string projectFilePath) =>
-        ExecUtil.RunToSuccess(output, "dotnet", Path.GetDirectoryName(projectFilePath)!, new[]
-        {
-            "build",
-            "--configuration", BuildConfiguration,
-            projectFilePath
-        });
 }

--- a/Cesium.IntegrationTests/IntegrationTestRunner.cs
+++ b/Cesium.IntegrationTests/IntegrationTestRunner.cs
@@ -1,4 +1,4 @@
-using Xunit;
+using Cesium.Test.Framework;
 using Xunit.Abstractions;
 
 namespace Cesium.IntegrationTests;
@@ -76,7 +76,7 @@ public class IntegrationTestRunner : IClassFixture<IntegrationTestContext>, IAsy
                 targetFramework);
             var managedResult = await (targetFramework switch
             {
-                TargetFramework.Net => ExecUtil.Run(_output, "dotnet", outRootPath, new[] { managedExecutable }),
+                TargetFramework.Net => DotNetCliHelper.RunDotNetDll(_output, outRootPath, managedExecutable),
                 TargetFramework.NetFramework => ExecUtil.Run(_output, managedExecutable, outRootPath,
                     Array.Empty<string>()),
                 _ => throw new ArgumentOutOfRangeException(nameof(targetFramework), targetFramework, null)
@@ -204,7 +204,7 @@ public class IntegrationTestRunner : IClassFixture<IntegrationTestContext>, IAsy
             });
         }
 
-        await ExecUtil.RunToSuccess(_output, "dotnet", objDirPath, args.ToArray());
+        await DotNetCliHelper.RunToSuccess(_output, "dotnet", objDirPath, args.ToArray());
 
         return executableFilePath;
     }

--- a/Cesium.IntegrationTests/WindowsEnvUtil.cs
+++ b/Cesium.IntegrationTests/WindowsEnvUtil.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Versioning;
+using Cesium.Test.Framework;
 using Microsoft.Win32;
 using Xunit.Abstractions;
 

--- a/Cesium.Test.Framework/Cesium.Test.Framework.csproj
+++ b/Cesium.Test.Framework/Cesium.Test.Framework.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="MedallionShell" Version="1.6.2" />
       <PackageReference Include="Verify.Xunit" Version="16.3.5" />
       <PackageReference Include="Yoakke.SynKit.C.Syntax" Version="2023.5.30-5.54.38-nightly" />
       <PackageReference Include="Yoakke.SynKit.Lexer" Version="2023.5.30-5.54.38-nightly" />

--- a/Cesium.Test.Framework/DotNetCliHelper.cs
+++ b/Cesium.Test.Framework/DotNetCliHelper.cs
@@ -1,0 +1,44 @@
+using Medallion.Shell;
+using Xunit.Abstractions;
+
+namespace Cesium.Test.Framework;
+
+/// <summary>Utils to properly run commands like <c>dotnet build</c> and such.</summary>
+public static class DotNetCliHelper
+{
+    public static async Task ShutdownBuildServer()
+    {
+        await RunToSuccess(null, "dotnet", Environment.CurrentDirectory, new[]
+        {
+            "build-server",
+            "shutdown"
+        });
+    }
+
+    public static async Task BuildDotNetProject(ITestOutputHelper output, string configuration, string projectFilePath)
+    {
+        await RunToSuccess(output, "dotnet", Path.GetDirectoryName(projectFilePath)!, new[]
+        {
+            "build",
+            "--configuration", configuration,
+            projectFilePath
+        });
+    }
+
+    public static Task<CommandResult> RunDotNetDll(
+        ITestOutputHelper output,
+        string workingDirectoryPath,
+        string dllPath) =>
+        ExecUtil.Run(output, "dotnet", workingDirectoryPath, new[] { dllPath });
+
+    public static Task RunToSuccess(
+        ITestOutputHelper? output,
+        string executable,
+        string workingDirectory,
+        string[] args) => ExecUtil.RunToSuccess(output, executable, workingDirectory, args,
+        new Dictionary<string, string>
+        {
+            // Work around https://github.com/dotnet/sdk/issues/34653
+            ["MSBUILDENSURESTDOUTFORTASKPROCESSES"] = "0"
+        });
+}

--- a/Cesium.sln.DotSettings
+++ b/Cesium.sln.DotSettings
@@ -6,6 +6,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=corelib/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Initializable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=modulekind/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=MSBUILDENSURESTDOUTFORTASKPROCESSES/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nint/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nuint/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=offsetof/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
For more stable testing, we have to pass `MSBUILDENSURESTDOUTFORTASKPROCESSES = 0` to any dotnet build processes.

See https://github.com/dotnet/sdk/issues/34653 for details.

## TODO
- [x] After merge don't forget to also port this to #356