### PR TITLE
#422 Added support for array initialization without size

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenArrayTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenArrayTests.cs
@@ -99,4 +99,24 @@ int main() {
     a[1] = 2;
     return a[1];
  }");
+
+    [Fact]
+    public Task GlobalArrayInitializationWithoutSize() => DoTest(@"
+    int ints1[3] = { 1, 2, 3 };
+    int ints2[] = { 1, 2, 1 };
+
+    int main() {
+    return ints1[0] + ints2[2];
+}");
+
+    [Fact]
+    public Task ArrayInitializationWithoutSize() => DoTest(@"int main() {
+    int ints1[3] = { 1, 2, 3 };
+    int ints2[] = { 1, 2, 1 };
+    return ints1[0] + ints2[2];
+}");
+
+    [Fact]
+    public Task ArrayParameterPassing() => DoTest(@"
+int foo(int ints[]) { return ints[0]; }");
 }

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayInitializationWithoutSize.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayInitializationWithoutSize.verified.txt
@@ -1,0 +1,46 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32* V_0
+    System.Int32* V_1
+  IL_0000: ldc.i4.s 12
+  IL_0002: conv.u
+  IL_0003: localloc
+  IL_0005: stloc.0
+  IL_0006: ldsflda <ConstantPool>/<ConstantPoolItemType12> <ConstantPool>::ConstDataBuffer0
+  IL_000b: ldloc V_0
+  IL_000f: ldc.i4.s 12
+  IL_0011: conv.u
+  IL_0012: call System.Void Cesium.Runtime.RuntimeHelpers::InitializeCompound(System.Void*,System.Void*,System.UInt32)
+  IL_0017: ldc.i4.s 12
+  IL_0019: conv.u
+  IL_001a: localloc
+  IL_001c: stloc.1
+  IL_001d: ldsflda <ConstantPool>/<ConstantPoolItemType12> <ConstantPool>::ConstDataBuffer1
+  IL_0022: ldloc V_1
+  IL_0026: ldc.i4.s 12
+  IL_0028: conv.u
+  IL_0029: call System.Void Cesium.Runtime.RuntimeHelpers::InitializeCompound(System.Void*,System.Void*,System.UInt32)
+  IL_002e: ldloc.0
+  IL_002f: ldc.i4.4
+  IL_0030: ldc.i4.0
+  IL_0031: mul
+  IL_0032: add
+  IL_0033: ldind.i4
+  IL_0034: ldloc.1
+  IL_0035: ldc.i4.4
+  IL_0036: ldc.i4.2
+  IL_0037: mul
+  IL_0038: add
+  IL_0039: ldind.i4
+  IL_003a: add
+  IL_003b: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayParameterPassing.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayParameterPassing.verified.txt
@@ -1,0 +1,8 @@
+﻿System.Int32 <Module>::foo(System.Int32* ints)
+  IL_0000: ldarg.0
+  IL_0001: ldc.i4.4
+  IL_0002: ldc.i4.0
+  IL_0003: mul
+  IL_0004: add
+  IL_0005: ldind.i4
+  IL_0006: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalArrayInitializationWithoutSize.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.GlobalArrayInitializationWithoutSize.verified.txt
@@ -1,0 +1,46 @@
+﻿System.Void <Module>::.cctor()
+  IL_0000: ldc.i4.s 12
+  IL_0002: conv.u
+  IL_0003: call System.Void* Cesium.Runtime.RuntimeHelpers::AllocateGlobalField(System.UInt32)
+  IL_0008: stsfld System.Int32* <Module>::ints1
+  IL_000d: ldsflda <ConstantPool>/<ConstantPoolItemType12> <ConstantPool>::ConstDataBuffer0
+  IL_0012: ldsflda System.Int32* <Module>::ints1
+  IL_0017: ldc.i4.s 12
+  IL_0019: conv.u
+  IL_001a: call System.Void Cesium.Runtime.RuntimeHelpers::InitializeCompound(System.Void*,System.Void*,System.UInt32)
+  IL_001f: ldc.i4.s 12
+  IL_0021: conv.u
+  IL_0022: call System.Void* Cesium.Runtime.RuntimeHelpers::AllocateGlobalField(System.UInt32)
+  IL_0027: stsfld System.Int32* <Module>::ints2
+  IL_002c: ldsflda <ConstantPool>/<ConstantPoolItemType12> <ConstantPool>::ConstDataBuffer1
+  IL_0031: ldsflda System.Int32* <Module>::ints2
+  IL_0036: ldc.i4.s 12
+  IL_0038: conv.u
+  IL_0039: call System.Void Cesium.Runtime.RuntimeHelpers::InitializeCompound(System.Void*,System.Void*,System.UInt32)
+  IL_003e: ret
+
+System.Int32 <Module>::main()
+  IL_0000: ldsflda System.Int32* <Module>::ints1
+  IL_0005: ldc.i4.4
+  IL_0006: ldc.i4.0
+  IL_0007: mul
+  IL_0008: add
+  IL_0009: ldind.i4
+  IL_000a: ldsflda System.Int32* <Module>::ints2
+  IL_000f: ldc.i4.4
+  IL_0010: ldc.i4.2
+  IL_0011: mul
+  IL_0012: add
+  IL_0013: ldind.i4
+  IL_0014: add
+  IL_0015: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen/Ir/Declarations/ScopedDeclarationInfo.cs
+++ b/Cesium.CodeGen/Ir/Declarations/ScopedDeclarationInfo.cs
@@ -92,7 +92,7 @@ internal interface IScopedDeclarationInfo
         InitDeclarator initDeclarator)
     {
         var (declarator, initializer) = initDeclarator;
-        var declarationInfo = LocalDeclarationInfo.Of(specifiers, declarator);
+        var declarationInfo = LocalDeclarationInfo.Of(specifiers, declarator, initializer);
         var (type, _, _) = declarationInfo;
         var expression = ConvertInitializer(type, initializer);
         return new InitializableDeclarationInfo(declarationInfo, expression);

--- a/Cesium.IntegrationTests/array/array_initialization.c
+++ b/Cesium.IntegrationTests/array/array_initialization.c
@@ -52,6 +52,16 @@ int testGlobalIntArray() {
     return 1;
 }
 
+//int testNoSizeSpecified() {
+//    char a[] = { 99, 0, 22, 17, 2, 0, };
+//
+//    if (sizeof(a) != 6) {
+//        return 0;
+//    }
+//
+//    return 1;
+//}
+
 int main(int argc, char *argv[])
 {
     if (!testIntArray()) {
@@ -69,6 +79,10 @@ int main(int argc, char *argv[])
     if (!testGlobalIntArray()) {
         return -4;
     }
+
+    //if (!testNoSizeSpecified()) {
+    //    return -5;
+    //}
 
     return 42;
 }

--- a/Cesium.IntegrationTests/array/array_initialization.c
+++ b/Cesium.IntegrationTests/array/array_initialization.c
@@ -52,16 +52,6 @@ int testGlobalIntArray() {
     return 1;
 }
 
-//int testNoSizeSpecified() {
-//    char a[] = { 99, 0, 22, 17, 2, 0, };
-//
-//    if (sizeof(a) != 6) {
-//        return 0;
-//    }
-//
-//    return 1;
-//}
-
 int main(int argc, char *argv[])
 {
     if (!testIntArray()) {
@@ -79,10 +69,6 @@ int main(int argc, char *argv[])
     if (!testGlobalIntArray()) {
         return -4;
     }
-
-    //if (!testNoSizeSpecified()) {
-    //    return -5;
-    //}
 
     return 42;
 }


### PR DESCRIPTION
I think this should fix #422, I am not sure if I took the right approach, but it is working.
I wanted to add an integration test to make this work, but it seems that sizeof(array) is not working, any ideas on how to test this feature?

One of my changes is close to TODO #126, but I didn't know what to do with it, since it is working in both scenarios mentioned in that issue.