### PR TITLE
 String literal concatenation

### DIFF
--- a/Cesium.Ast/Expressions.cs
+++ b/Cesium.Ast/Expressions.cs
@@ -6,6 +6,9 @@ namespace Cesium.Ast;
 
 public abstract record Expression;
 
+// 6.4.5 String literals
+public record StringLiteralListExpression(ImmutableArray<IToken<CTokenType>> ConstantList) : Expression;
+
 // 6.5.1 Primary expressions
 public record IdentifierExpression(string Identifier) : Expression;
 public record ConstantLiteralExpression(IToken<CTokenType> Constant) : Expression;

--- a/Cesium.CodeGen/Extensions/ExpressionEx.cs
+++ b/Cesium.CodeGen/Extensions/ExpressionEx.cs
@@ -10,6 +10,7 @@ internal static class ExpressionEx
     public static IExpression ToIntermediate(this Ast.Expression ex) => ex switch
     {
         Ast.IdentifierExpression e => new IdentifierExpression(e),
+        Ast.StringLiteralListExpression e => new StringLiteralListExpression(e),
         Ast.ConstantLiteralExpression { Constant.Kind: CTokenType.Identifier } e => new IdentifierExpression(e),
         Ast.ConstantLiteralExpression e => new ConstantLiteralExpression(e),
         Ast.ParenExpression e => ToIntermediate(e.Contents),

--- a/Cesium.CodeGen/Ir/Expressions/StringLiteralListExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/StringLiteralListExpression.cs
@@ -1,0 +1,51 @@
+using System.Globalization;
+using System.Reflection.Metadata;
+using System.Text;
+using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Ir.Expressions.Constants;
+using Cesium.CodeGen.Ir.Types;
+using Cesium.Core;
+using Cesium.Parser;
+using Yoakke.SynKit.C.Syntax;
+
+namespace Cesium.CodeGen.Ir.Expressions;
+
+internal class StringLiteralListExpression : IExpression
+{
+    public static StringLiteralListExpression OfInt32(int value) => new(new IntegerConstant(value));
+
+    internal StringLiteralListExpression(IConstant constant)
+    {
+        Constant = constant;
+    }
+
+    public StringLiteralListExpression(Ast.StringLiteralListExpression expression)
+        : this(GetConstant(expression))
+    {
+    }
+
+    internal IConstant Constant { get; }
+
+    public IExpression Lower(IDeclarationScope scope) => this;
+
+    public void EmitTo(IEmitScope scope) => Constant.EmitTo(scope);
+
+    public IType GetExpressionType(IDeclarationScope scope) => Constant.GetConstantType(scope);
+
+    public override string ToString() => $"{nameof(StringLiteralListExpression)}: {Constant}";
+
+    private static IConstant GetConstant(Ast.StringLiteralListExpression expression)
+    {
+        StringBuilder builder = new();
+        foreach (var constant in expression.ConstantList)
+        {
+            builder.Append(constant.Kind switch
+            {
+                CTokenType.StringLiteral => constant.UnwrapStringLiteral(),
+                _ => throw new AssertException($"Not a string literal: {constant.Kind}.")
+            });
+        }
+
+        return new StringConstant(builder.ToString());
+    }
+}

--- a/Cesium.IntegrationTests/strings/string_literals.c
+++ b/Cesium.IntegrationTests/strings/string_literals.c
@@ -1,0 +1,23 @@
+#include <string.h>
+
+const char* a = "a " "b" " c";
+int testConcatenation() {
+    const char* b = "a b c";
+
+    int result = strncmp(a, b, 5);
+
+    if (result != 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+int main(int argc, char* argv[])
+{
+    if (!testConcatenation()) {
+        return -1;
+    }
+
+    return 42;
+}

--- a/Cesium.Parser/CParser.cs
+++ b/Cesium.Parser/CParser.cs
@@ -20,6 +20,7 @@ using SpecifierQualifierList = ImmutableArray<ISpecifierQualifierListItem>;
 using StructDeclarationList = ImmutableArray<StructDeclaration>;
 using StructDeclaratorList = ImmutableArray<StructDeclarator>;
 using TypeQualifierList = ImmutableArray<TypeQualifier>;
+using LiteralExpressionList = ImmutableArray<IToken<CTokenType>>;
 
 /// <remarks>See the section 6 of the C17 standard.</remarks>
 [Parser(typeof(CTokenType))]
@@ -32,6 +33,20 @@ public partial class CParser
     [Rule("constant: enumeration_constant")]
     [Rule("constant: CharLiteral")]
     private static ICToken MakeConstant(ICToken constant) => constant;
+
+    // 6.4.5 String literals
+
+    // TODO:
+    // string_literal:
+    //      encoding-prefix? " s-char-sequence? "
+    [Rule("string_literal: StringLiteral")]
+    private static LiteralExpressionList MakeStringLiteral(ICToken stringLiteral) => ImmutableArray.Create(stringLiteral);
+
+
+    [Rule("string_literal: string_literal StringLiteral")]
+    private static LiteralExpressionList MakeStringLiteral(
+        LiteralExpressionList prev,
+        ICToken stringLiteral) => prev.Add(stringLiteral);
 
     // 6.4.4.3 Enumeration constants
     [Rule("enumeration_constant: Identifier")]
@@ -71,6 +86,10 @@ public partial class CParser
     [Rule("primary_expression: StringLiteral")]
     private static Expression MakeStringLiteralExpression(ICToken stringLiteral) =>
         new ConstantLiteralExpression(stringLiteral);
+
+    [Rule("primary_expression: string_literal")]
+    private static Expression MakeStringLiteralListExpression(LiteralExpressionList literalExpressionList) =>
+        new StringLiteralListExpression(literalExpressionList);
 
     [Rule("primary_expression: '(' expression ')'")]
     private static Expression MakeParens(IToken _, Expression expression, IToken __) => new ParenExpression(expression);


### PR DESCRIPTION
Closes #446. It is a simple solution that works for now. However, it doesn't support the _encoding-prefix_ yet, but this is a good start.
Please let me know if I am missing something here.

> Semantics
5. In translation phase 6, the multibyte character sequences specified by any sequence of adjacent character and identically-prefixed string literal tokens are concatenated into a single multibyte character sequence. 