### PR TITLE
`sealed` internal classes

### DIFF
--- a/Cesium.CodeGen/Ir/BlockItems/CaseStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/CaseStatement.cs
@@ -3,7 +3,7 @@ using Cesium.CodeGen.Ir.Expressions;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class CaseStatement : IBlockItem
+internal sealed class CaseStatement : IBlockItem
 {
     public CaseStatement(Ast.CaseStatement statement)
     {

--- a/Cesium.CodeGen/Ir/BlockItems/ContinueStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ContinueStatement.cs
@@ -1,5 +1,5 @@
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class ContinueStatement : IBlockItem
+internal sealed class ContinueStatement : IBlockItem
 {
 }

--- a/Cesium.CodeGen/Ir/BlockItems/DeclarationBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/DeclarationBlockItem.cs
@@ -2,7 +2,7 @@ using Cesium.CodeGen.Ir.Declarations;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class DeclarationBlockItem : IBlockItem
+internal sealed class DeclarationBlockItem : IBlockItem
 {
     public ScopedIdentifierDeclaration Declaration { get; }
 

--- a/Cesium.CodeGen/Ir/BlockItems/DoWhileStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/DoWhileStatement.cs
@@ -3,7 +3,7 @@ using Cesium.CodeGen.Ir.Expressions;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class DoWhileStatement : IBlockItem
+internal sealed class DoWhileStatement : IBlockItem
 {
     public IExpression TestExpression { get; }
     public IBlockItem Body { get; }

--- a/Cesium.CodeGen/Ir/BlockItems/ExpressionStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ExpressionStatement.cs
@@ -3,7 +3,7 @@ using Cesium.CodeGen.Ir.Expressions;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class ExpressionStatement : IBlockItem
+internal sealed class ExpressionStatement : IBlockItem
 {
     public IExpression? Expression { get; }
 

--- a/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ForStatement.cs
@@ -4,7 +4,7 @@ using Cesium.Core;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class ForStatement : IBlockItem
+internal sealed class ForStatement : IBlockItem
 {
     public IBlockItem? InitDeclaration { get; }
     public IExpression? InitExpression { get; }

--- a/Cesium.CodeGen/Ir/BlockItems/FunctionDeclaration.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/FunctionDeclaration.cs
@@ -3,7 +3,7 @@ using Cesium.CodeGen.Ir.Types;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class FunctionDeclaration : IBlockItem
+internal sealed class FunctionDeclaration : IBlockItem
 {
     public string Identifier { get; }
     public StorageClass StorageClass { get; }

--- a/Cesium.CodeGen/Ir/BlockItems/FunctionDefinition.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/FunctionDefinition.cs
@@ -14,7 +14,7 @@ using PointerType = Cesium.CodeGen.Ir.Types.PointerType;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class FunctionDefinition : IBlockItem
+internal sealed class FunctionDefinition : IBlockItem
 {
     private const string MainFunctionName = "main";
 
@@ -139,7 +139,7 @@ internal class FunctionDefinition : IBlockItem
         return GenerateSyntheticEntryPointStrArray(context, userEntrypoint);
     }
 
-    private MethodDefinition GenerateSyntheticEntryPointStrArray(
+    private static MethodDefinition GenerateSyntheticEntryPointStrArray(
         TranslationUnitContext context,
         MethodReference userEntrypoint)
     {
@@ -232,7 +232,7 @@ internal class FunctionDefinition : IBlockItem
         return syntheticEntrypoint;
     }
 
-    private MethodDefinition GenerateSyntheticEntryPointSimple(
+    private static MethodDefinition GenerateSyntheticEntryPointSimple(
         TranslationUnitContext context,
         MethodReference userEntrypoint)
     {

--- a/Cesium.CodeGen/Ir/BlockItems/GoToStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/GoToStatement.cs
@@ -1,6 +1,6 @@
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class GoToStatement : IBlockItem
+internal sealed class GoToStatement : IBlockItem
 {
     public string Identifier { get; }
 

--- a/Cesium.CodeGen/Ir/BlockItems/ReturnStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/ReturnStatement.cs
@@ -3,7 +3,7 @@ using Cesium.CodeGen.Ir.Expressions;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class ReturnStatement : IBlockItem
+internal sealed class ReturnStatement : IBlockItem
 {
     public IExpression? Expression { get; }
 

--- a/Cesium.CodeGen/Ir/BlockItems/SwitchStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/SwitchStatement.cs
@@ -3,7 +3,7 @@ using Cesium.CodeGen.Ir.Expressions;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class SwitchStatement : IBlockItem
+internal sealed class SwitchStatement : IBlockItem
 {
     public IExpression Expression { get; }
     public IBlockItem Body { get; }

--- a/Cesium.CodeGen/Ir/BlockItems/TagBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/TagBlockItem.cs
@@ -2,7 +2,7 @@ using Cesium.CodeGen.Ir.Declarations;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class TagBlockItem : IBlockItem
+internal sealed class TagBlockItem : IBlockItem
 {
     public ICollection<LocalDeclarationInfo> Types { get; }
 

--- a/Cesium.CodeGen/Ir/BlockItems/TypeDefBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/TypeDefBlockItem.cs
@@ -2,7 +2,7 @@ using Cesium.CodeGen.Ir.Declarations;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class TypeDefBlockItem : IBlockItem
+internal sealed class TypeDefBlockItem : IBlockItem
 {
     public ICollection<LocalDeclarationInfo> Types { get; }
 

--- a/Cesium.CodeGen/Ir/BlockItems/WhileStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/WhileStatement.cs
@@ -3,7 +3,7 @@ using Cesium.CodeGen.Ir.Expressions;
 
 namespace Cesium.CodeGen.Ir.BlockItems;
 
-internal class WhileStatement : IBlockItem
+internal sealed class WhileStatement : IBlockItem
 {
     public IExpression TestExpression { get; }
     public IBlockItem Body { get; }

--- a/Cesium.CodeGen/Ir/ControlFlow/ControlFlowChecker.cs
+++ b/Cesium.CodeGen/Ir/ControlFlow/ControlFlowChecker.cs
@@ -8,7 +8,7 @@ using QuikGraph;
 
 namespace Cesium.CodeGen.Ir.ControlFlow;
 
-internal class ControlFlowChecker
+internal sealed class ControlFlowChecker
 {
     // we don't want structural equality here
     class CodeBlockVertex
@@ -74,7 +74,7 @@ internal class ControlFlowChecker
                 var compoundVtx = new CodeBlockVertex(compound);
                 graph.AddVertex(compoundVtx);
 
-                List<CodeBlockVertex> unboundVertices = new List<CodeBlockVertex>
+                List<CodeBlockVertex> unboundVertices = new()
                 {
                     compoundVtx
                 };
@@ -131,7 +131,7 @@ internal class ControlFlowChecker
         graph.AddVertex(start);
         graph.AddVertex(terminator);
 
-        List<CodeBlockVertex> unboundVertices = new List<CodeBlockVertex>
+        List<CodeBlockVertex> unboundVertices = new()
         {
             start
         };
@@ -159,13 +159,11 @@ internal class ControlFlowChecker
             {
                 var label = graph.Vertices.First(x =>
                 {
-                    switch (x.BlockItem)
+                    return x.BlockItem switch
                     {
-                        case LabelStatement { Identifier: { } id } when id == goTo.Identifier:
-                            return true;
-                        default:
-                            return false;
-                    }
+                        LabelStatement { Identifier: { } id } when id == goTo.Identifier => true,
+                        _ => false,
+                    };
                 });
 
                 graph.AddEdge(new CodeBlockEdge(vtx, label));

--- a/Cesium.CodeGen/Ir/Expressions/AssignmentExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/AssignmentExpression.cs
@@ -21,7 +21,7 @@ public enum AssignmentOperator
     BitwiseXorAndAssign, // ^=
 }
 
-internal class AssignmentExpression : IExpression
+internal sealed class AssignmentExpression : IExpression
 {
     public IValueExpression Left { get; }
     public IExpression Right{ get; }

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BinaryOperatorExpression.cs
@@ -7,7 +7,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.BinaryOperators;
 
-internal class BinaryOperatorExpression : IExpression
+internal sealed class BinaryOperatorExpression : IExpression
 {
     public IExpression Left { get; }
     public BinaryOperator Operator { get; }

--- a/Cesium.CodeGen/Ir/Expressions/CommaExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/CommaExpression.cs
@@ -5,7 +5,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class CommaExpression : IExpression
+internal sealed class CommaExpression : IExpression
 {
     private readonly IExpression _left;
     private readonly IExpression _right;

--- a/Cesium.CodeGen/Ir/Expressions/ConditionalExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/ConditionalExpression.cs
@@ -6,7 +6,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class ConditionalExpression : IExpression
+internal sealed class ConditionalExpression : IExpression
 {
     private readonly IExpression _condition;
     private readonly IExpression _trueExpression;

--- a/Cesium.CodeGen/Ir/Expressions/ConstantLiteralExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/ConstantLiteralExpression.cs
@@ -8,7 +8,7 @@ using Yoakke.SynKit.C.Syntax;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class ConstantLiteralExpression : IExpression
+internal sealed class ConstantLiteralExpression : IExpression
 {
     public static ConstantLiteralExpression OfInt32(int value) => new(new IntegerConstant(value));
 

--- a/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/CharConstant.cs
@@ -5,7 +5,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Constants;
 
-internal class CharConstant : IConstant
+internal sealed class CharConstant : IConstant
 {
     private readonly byte _value;
 

--- a/Cesium.CodeGen/Ir/Expressions/Constants/FloatingPointConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/FloatingPointConstant.cs
@@ -4,7 +4,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Constants;
 
-internal class FloatingPointConstant : IConstant
+internal sealed class FloatingPointConstant : IConstant
 {
     private readonly double _value;
     private readonly bool _isFloat;

--- a/Cesium.CodeGen/Ir/Expressions/Constants/IntegerConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/IntegerConstant.cs
@@ -6,7 +6,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Constants;
 
-internal class IntegerConstant : IConstant
+internal sealed class IntegerConstant : IConstant
 {
     public IntegerConstant(string value)
     {

--- a/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Constants/StringConstant.cs
@@ -4,7 +4,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Constants;
 
-internal class StringConstant : IConstant
+internal sealed class StringConstant : IConstant
 {
     private readonly string _value;
     public StringConstant(string value)

--- a/Cesium.CodeGen/Ir/Expressions/ConsumeExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/ConsumeExpression.cs
@@ -4,7 +4,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class ConsumeExpression : IExpression
+internal sealed class ConsumeExpression : IExpression
 {
     private readonly IExpression _expression;
 

--- a/Cesium.CodeGen/Ir/Expressions/GetValueExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/GetValueExpression.cs
@@ -4,7 +4,7 @@ using Cesium.CodeGen.Ir.Types;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class GetValueExpression : IExpression, IValueExpression
+internal sealed class GetValueExpression : IExpression, IValueExpression
 {
     private readonly IValue _value;
 

--- a/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IdentifierExpression.cs
@@ -7,7 +7,7 @@ using Yoakke.SynKit.C.Syntax;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class IdentifierExpression : IExpression, IValueExpression
+internal sealed class IdentifierExpression : IExpression, IValueExpression
 {
     public string Identifier { get; }
 

--- a/Cesium.CodeGen/Ir/Expressions/IdentifierSizeOfOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IdentifierSizeOfOperatorExpression.cs
@@ -5,7 +5,7 @@ using Cesium.Core;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class IdentifierSizeOfOperatorExpression : IExpression
+internal sealed class IdentifierSizeOfOperatorExpression : IExpression
 {
     private readonly IdentifierExpression _identifier;
 

--- a/Cesium.CodeGen/Ir/Expressions/IndirectFunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IndirectFunctionCallExpression.cs
@@ -6,7 +6,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class IndirectFunctionCallExpression : FunctionCallExpressionBase
+internal sealed class IndirectFunctionCallExpression : FunctionCallExpressionBase
 {
     private readonly IReadOnlyList<IExpression> _arguments;
     private readonly IExpression _callee;

--- a/Cesium.CodeGen/Ir/Expressions/IndirectionExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IndirectionExpression.cs
@@ -6,7 +6,7 @@ using Cesium.Core;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class IndirectionExpression : IExpression, IValueExpression
+internal sealed class IndirectionExpression : IExpression, IValueExpression
 {
     private readonly IExpression _target;
 

--- a/Cesium.CodeGen/Ir/Expressions/InstanceForOffsetOfExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/InstanceForOffsetOfExpression.cs
@@ -7,7 +7,7 @@ using Mono.Cecil.Cil;
 namespace Cesium.CodeGen.Ir.Expressions;
 
 /// <summary>Takes an address of an instance of the passed type as part of the offsetof expression.</summary>
-internal class InstanceForOffsetOfExpression : IExpression, IValueExpression, IAddressableValue
+internal sealed class InstanceForOffsetOfExpression : IExpression, IValueExpression, IAddressableValue
 {
     private readonly StructType _resolvedType;
 

--- a/Cesium.CodeGen/Ir/Expressions/MemberAccessExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/MemberAccessExpression.cs
@@ -6,7 +6,7 @@ using Cesium.Core;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class MemberAccessExpression : IExpression, IValueExpression
+internal sealed class MemberAccessExpression : IExpression, IValueExpression
 {
     private readonly IExpression _target;
     private readonly IdentifierExpression _memberIdentifier;

--- a/Cesium.CodeGen/Ir/Expressions/PointerMemberAccessExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/PointerMemberAccessExpression.cs
@@ -6,7 +6,7 @@ using Cesium.Core;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class PointerMemberAccessExpression : IExpression, IValueExpression
+internal sealed class PointerMemberAccessExpression : IExpression, IValueExpression
 {
     private readonly IExpression _target;
     private readonly IdentifierExpression _memberIdentifier;

--- a/Cesium.CodeGen/Ir/Expressions/PostfixIncrementDecrementExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/PostfixIncrementDecrementExpression.cs
@@ -9,7 +9,7 @@ using Yoakke.SynKit.Lexer;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class PostfixIncrementDecrementExpression : IExpression
+internal sealed class PostfixIncrementDecrementExpression : IExpression
 {
     private readonly IExpression _target;
     private readonly BinaryOperator _operator;

--- a/Cesium.CodeGen/Ir/Expressions/PrefixIncrementDecrementExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/PrefixIncrementDecrementExpression.cs
@@ -9,7 +9,7 @@ using Yoakke.SynKit.Lexer;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class PrefixIncrementDecrementExpression : IExpression
+internal sealed class PrefixIncrementDecrementExpression : IExpression
 {
     private readonly IExpression _target;
     private readonly BinaryOperator _operator;

--- a/Cesium.CodeGen/Ir/Expressions/SetValueExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SetValueExpression.cs
@@ -4,7 +4,7 @@ using Cesium.CodeGen.Ir.Types;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class SetValueExpression : IExpression
+internal sealed class SetValueExpression : IExpression
 {
     private readonly ILValue _value;
     private readonly IExpression _expression;

--- a/Cesium.CodeGen/Ir/Expressions/SizeOfOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SizeOfOperatorExpression.cs
@@ -5,7 +5,7 @@ using Cesium.Core;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class SizeOfOperatorExpression : IExpression
+internal sealed class SizeOfOperatorExpression : IExpression
 {
     private readonly IType _type;
 

--- a/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
@@ -8,7 +8,7 @@ using Cesium.Core;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class SubscriptingExpression : IValueExpression
+internal sealed class SubscriptingExpression : IValueExpression
 {
     private readonly IExpression _expression;
     private readonly IExpression _index;

--- a/Cesium.CodeGen/Ir/Expressions/TypeCastOrNamedFunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/TypeCastOrNamedFunctionCallExpression.cs
@@ -5,7 +5,7 @@ using Cesium.Core;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class TypeCastOrNamedFunctionCallExpression : IExpression
+internal sealed class TypeCastOrNamedFunctionCallExpression : IExpression
 {
     private readonly string _typeOrFunctionName;
     private readonly IReadOnlyList<IExpression> _arguments;

--- a/Cesium.CodeGen/Ir/Expressions/TypeNameSizeOfOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/TypeNameSizeOfOperatorExpression.cs
@@ -6,7 +6,7 @@ using Cesium.Core;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class TypeNameSizeOfOperatorExpression : IExpression
+internal sealed class TypeNameSizeOfOperatorExpression : IExpression
 {
     private readonly IType _type;
 

--- a/Cesium.CodeGen/Ir/Expressions/UnaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/UnaryOperatorExpression.cs
@@ -8,7 +8,7 @@ using Mono.Cecil.Rocks;
 
 namespace Cesium.CodeGen.Ir.Expressions;
 
-internal class UnaryOperatorExpression : IExpression
+internal sealed class UnaryOperatorExpression : IExpression
 {
     public UnaryOperator Operator { get; }
     public IExpression Target { get; }

--- a/Cesium.CodeGen/Ir/Expressions/Values/FunctionValue.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/FunctionValue.cs
@@ -7,7 +7,7 @@ using Mono.Cecil;
 namespace Cesium.CodeGen.Ir.Expressions.Values;
 
 /// <summary>This is a value representing a function type directly, not a function pointer.</summary>
-internal class FunctionValue : IAddressableValue
+internal sealed class FunctionValue : IAddressableValue
 {
     private readonly MethodReference _methodReference;
     private readonly Contexts.Meta.FunctionInfo _functionInfo;

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueArrayElement.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueArrayElement.cs
@@ -5,7 +5,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Values;
 
-internal class LValueArrayElement : ILValue
+internal sealed class LValueArrayElement : ILValue
 {
     private readonly IValue _array;
     private readonly IExpression _index;

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueField.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueField.cs
@@ -6,7 +6,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Values;
 
-internal class LValueField : ILValue
+internal sealed class LValueField : ILValue
 {
     private readonly IExpression _expression;
     private readonly StructType _structType;

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueGlobalVariable.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueGlobalVariable.cs
@@ -6,7 +6,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Values
 {
-    internal class LValueGlobalVariable : ILValue
+    internal sealed class LValueGlobalVariable : ILValue
     {
         private readonly IType _type;
         private readonly string _name;

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueIndirection.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueIndirection.cs
@@ -5,7 +5,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Values;
 
-internal class LValueIndirection : ILValue
+internal sealed class LValueIndirection : ILValue
 {
     private readonly IExpression _pointerExpression;
     private readonly PointerType _pointerType;

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueLocalVariable.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueLocalVariable.cs
@@ -5,7 +5,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Values;
 
-internal class LValueLocalVariable : ILValue
+internal sealed class LValueLocalVariable : ILValue
 {
     private readonly IType _variableType;
     private readonly string _name;

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueParameter.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueParameter.cs
@@ -6,7 +6,7 @@ using Mono.Cecil.Cil;
 
 namespace Cesium.CodeGen.Ir.Expressions.Values;
 
-internal class LValueParameter : ILValue
+internal sealed class LValueParameter : ILValue
 {
     private readonly ParameterInfo _parameterInfo;
     private ParameterDefinition? _definition;

--- a/Cesium.CodeGen/Ir/Types/CTypeSystem.cs
+++ b/Cesium.CodeGen/Ir/Types/CTypeSystem.cs
@@ -3,7 +3,7 @@ using Cesium.Core;
 
 namespace Cesium.CodeGen.Ir.Types;
 
-internal class CTypeSystem
+internal sealed class CTypeSystem
 {
     public IType Void { get; } = new PrimitiveType(PrimitiveTypeKind.Void);
     public IType Bool { get; } = new PrimitiveType(PrimitiveTypeKind.Int); // TODO[#179]: Figure out the right type.

--- a/Cesium.CodeGen/Ir/Types/EnumType.cs
+++ b/Cesium.CodeGen/Ir/Types/EnumType.cs
@@ -4,7 +4,7 @@ using Mono.Cecil;
 
 namespace Cesium.CodeGen.Ir.Types;
 
-internal class EnumType : IType
+internal sealed class EnumType : IType
 {
     public EnumType(IReadOnlyList<InitializableDeclarationInfo> members, string? identifier)
     {

--- a/Cesium.CodeGen/Ir/Types/StructType.cs
+++ b/Cesium.CodeGen/Ir/Types/StructType.cs
@@ -7,7 +7,7 @@ using Mono.Cecil;
 
 namespace Cesium.CodeGen.Ir.Types;
 
-internal class StructType : IGeneratedType
+internal sealed class StructType : IGeneratedType
 {
     public StructType(IReadOnlyList<LocalDeclarationInfo> members, string? identifier)
     {

--- a/Cesium.Compiler.Tests/MockCompilerReporter.cs
+++ b/Cesium.Compiler.Tests/MockCompilerReporter.cs
@@ -2,7 +2,7 @@ using Cesium.CodeGen;
 
 namespace Cesium.Compiler.Tests;
 
-internal class MockCompilerReporter : ICompilerReporter
+internal sealed class MockCompilerReporter : ICompilerReporter
 {
     public List<string> Errors { get; set; } = new();
     public List<string> InformationMessages { get; set; } = new();

--- a/Cesium.Preprocessor/BinaryExpression.cs
+++ b/Cesium.Preprocessor/BinaryExpression.cs
@@ -2,7 +2,7 @@ using Cesium.Core;
 
 namespace Cesium.Preprocessor;
 
-internal class BinaryExpression : IPreprocessorExpression
+internal sealed class BinaryExpression : IPreprocessorExpression
 {
     public BinaryExpression(IPreprocessorExpression first, CPreprocessorOperator @operator, IPreprocessorExpression second)
     {
@@ -19,26 +19,17 @@ internal class BinaryExpression : IPreprocessorExpression
     {
         string? firstValue = First.EvaluateExpression(context);
         string? secondValue = Second.EvaluateExpression(context);
-        switch(Operator)
+        return Operator switch
         {
-            case CPreprocessorOperator.Equals:
-                return firstValue == secondValue ? "1" : "0";
-            case CPreprocessorOperator.NotEquals:
-                return firstValue != secondValue ? "1" : "0";
-            case CPreprocessorOperator.LessOrEqual:
-                return (firstValue ?? "").CompareTo(secondValue ?? "") <= 0 ? "1" : "0";
-            case CPreprocessorOperator.GreaterOrEqual:
-                return (firstValue ?? "").CompareTo(secondValue ?? "") >= 0 ? "1" : "0";
-            case CPreprocessorOperator.LessThan:
-                return (firstValue ?? "").CompareTo(secondValue ?? "") < 0 ? "1" : "0";
-            case CPreprocessorOperator.GreaterThan:
-                return (firstValue ?? "").CompareTo(secondValue ?? "") > 0 ? "1" : "0";
-            case CPreprocessorOperator.LogicalAnd:
-                return (firstValue.AsBoolean() && secondValue.AsBoolean()) ? "1" : "0";
-            case CPreprocessorOperator.LogicalOr:
-                return (firstValue.AsBoolean() || secondValue.AsBoolean()) ? "1" : "0";
-            default:
-                throw new CompilationException($"Operator {Operator} cannot be used in the preprocessor directives");
-        }
+            CPreprocessorOperator.Equals => firstValue == secondValue ? "1" : "0",
+            CPreprocessorOperator.NotEquals => firstValue != secondValue ? "1" : "0",
+            CPreprocessorOperator.LessOrEqual => (firstValue ?? "").CompareTo(secondValue ?? "") <= 0 ? "1" : "0",
+            CPreprocessorOperator.GreaterOrEqual => (firstValue ?? "").CompareTo(secondValue ?? "") >= 0 ? "1" : "0",
+            CPreprocessorOperator.LessThan => (firstValue ?? "").CompareTo(secondValue ?? "") < 0 ? "1" : "0",
+            CPreprocessorOperator.GreaterThan => (firstValue ?? "").CompareTo(secondValue ?? "") > 0 ? "1" : "0",
+            CPreprocessorOperator.LogicalAnd => (firstValue.AsBoolean() && secondValue.AsBoolean()) ? "1" : "0",
+            CPreprocessorOperator.LogicalOr => (firstValue.AsBoolean() || secondValue.AsBoolean()) ? "1" : "0",
+            _ => throw new CompilationException($"Operator {Operator} cannot be used in the preprocessor directives"),
+        };
     }
 }

--- a/Cesium.Preprocessor/DefinedExpression.cs
+++ b/Cesium.Preprocessor/DefinedExpression.cs
@@ -1,6 +1,6 @@
 namespace Cesium.Preprocessor;
 
-internal class DefinedExpression : IPreprocessorExpression
+internal sealed class DefinedExpression : IPreprocessorExpression
 {
     public DefinedExpression(string identifer)
     {

--- a/Cesium.Preprocessor/IdentifierExpression.cs
+++ b/Cesium.Preprocessor/IdentifierExpression.cs
@@ -3,7 +3,7 @@ using Yoakke.SynKit.Lexer;
 
 namespace Cesium.Preprocessor;
 
-internal class IdentifierExpression : IPreprocessorExpression
+internal sealed class IdentifierExpression : IPreprocessorExpression
 {
     public IdentifierExpression(string identifer)
     {

--- a/Cesium.Preprocessor/UnaryExpression.cs
+++ b/Cesium.Preprocessor/UnaryExpression.cs
@@ -2,7 +2,7 @@ using Cesium.Core;
 
 namespace Cesium.Preprocessor;
 
-internal class UnaryExpression : IPreprocessorExpression
+internal sealed class UnaryExpression : IPreprocessorExpression
 {
     public UnaryExpression(CPreprocessorOperator @operator, IPreprocessorExpression expression)
     {
@@ -16,12 +16,10 @@ internal class UnaryExpression : IPreprocessorExpression
     public string? EvaluateExpression(IMacroContext context)
     {
         string? expressionValue = Expression.EvaluateExpression(context);
-        switch(Operator)
+        return Operator switch
         {
-            case CPreprocessorOperator.Negation:
-                return !expressionValue.AsBoolean() ? "1" : "0";
-            default:
-                throw new CompilationException($"Operator {Operator} cannot be used in the preprocessor directives");
-        }
+            CPreprocessorOperator.Negation => !expressionValue.AsBoolean() ? "1" : "0",
+            _ => throw new CompilationException($"Operator {Operator} cannot be used in the preprocessor directives"),
+        };
     }
 }


### PR DESCRIPTION
Along the way, some small improvements were also made, like turning some `switch` statements into `switch` expressions, and simplifying calls to constructors