### PR TITLE
What's wrong with System.Text.Json?

### DIFF
--- a/Cesium.Test.Framework/ParserTestBase.cs
+++ b/Cesium.Test.Framework/ParserTestBase.cs
@@ -13,5 +13,7 @@ public abstract class ParserTestBase : VerifyTestBase
         TypeNameHandling = TypeNameHandling.Objects
     };
 
-    protected static string JsonSerialize(object value) => JsonConvert.SerializeObject(value, SerializerOptions);
+    protected static string JsonSerialize(object value) =>
+        System.Text.Json.JsonSerializer.Serialize(value);
+    //JsonConvert.SerializeObject(value, SerializerOptions);
 }


### PR DESCRIPTION
This PR demonstrates that all the tests are broken after conversion to System.Text.Json.

STJ is bad and we won't use it.