### PR TITLE
(#496) Do not try build AOT for macOS

### DIFF
--- a/Cesium.Compiler/Cesium.Compiler.csproj
+++ b/Cesium.Compiler/Cesium.Compiler.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <PublishAot Condition="$(TargetFramework) == 'net7.0'">true</PublishAot>
+        <PublishAot Condition="$(NETCoreSdkRuntimeIdentifier) != 'osx-x64'">true</PublishAot>
         <PublishSingleFile>true</PublishSingleFile>
         <PublishTrimmed>true</PublishTrimmed>
     </PropertyGroup>


### PR DESCRIPTION
Apparently there's a problem with this s on Mac, so for now let's just disable.

Closes #496.