### PR TITLE
(#441) Docs: update references to the C23 standard

### DIFF
--- a/Cesium.Parser/CParser.cs
+++ b/Cesium.Parser/CParser.cs
@@ -22,7 +22,7 @@ using StructDeclaratorList = ImmutableArray<StructDeclarator>;
 using TypeQualifierList = ImmutableArray<TypeQualifier>;
 using LiteralExpressionList = ImmutableArray<IToken<CTokenType>>;
 
-/// <remarks>See the section 6 of the C17 standard.</remarks>
+/// <remarks>See the section 6 of the C23 standard.</remarks>
 [Parser(typeof(CTokenType))]
 [SuppressMessage("ReSharper", "UnusedParameter.Local")] // parser parameters are mandatory even if unused
 public partial class CParser

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Unfortunately, not yet. You won't be able to use Cesium for anything useful toda
 
 ### Sneak Peek
 
-Currently, Cesium is able to compile a "Hello, world" C17 example to a .NET assembly:
+Currently, Cesium is able to compile a "Hello, world" C23 example to a .NET assembly:
 
 ```c
 #include <stdio.h>
@@ -33,7 +33,7 @@ The next milestone is [#61: sha1collisiondetection][issue.next-milestone], which
 Documentation
 -------------
 
-- [C17 Language Standard Draft][c17-draft]
+- [C23 Language Standard Draft][c23-draft]
 
 - [Contributor Guide][docs.contributing]
 - [Cesium Tests][docs.tests]
@@ -81,7 +81,7 @@ $ mono ./out.exe # run with Mono
 Implementation Dashboard
 ------------------------
 
-- [ ] [C17 standard compatibility][issue.c17-standard]: poor
+- [ ] [C23 standard compatibility][issue.c23-standard]: poor
     - [ ] [Preprocessor][issue.preprocessor]: about **30%** of all features are supported
     - [ ] [Lexer][issue.lexer]: mostly works, but needs more tests and validation on its compliance
     - [ ] [Parser][issue.parser]: supports about **25%** of the language syntax
@@ -104,11 +104,11 @@ If you're interested in certain project areas, check the per-area issue labels:
 - [`area:compiler`][issues.compiler]: issues related to the Cesium compiler, type checker, and code analyzer
 - [`area:parser`][issues.parser]: issues related to C parsing
 - [`area:sdk`][issues.sdk]: issues related to the Cesium .NET SDK
-- [`area:standard-support`][issues.standard-support]: issues related to C17 standard support
+- [`area:standard-support`][issues.standard-support]: issues related to C23 standard support
 - [`area:stdlib`][issues.stdlib]: issues related to the standard library implementation
 
 [andivionian-status-classifier]: https://github.com/ForNeVeR/andivionian-status-classifier#status-enfer-
-[c17-draft]: http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2310.pdf
+[c23-draft]: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3096.pdf
 [discussions]: https://github.com/ForNeVeR/Cesium/discussions
 [docs.architecture-sets]: docs/architecture-sets.md
 [docs.contributing]: CONTRIBUTING.md
@@ -118,7 +118,7 @@ If you're interested in certain project areas, check the per-area issue labels:
 [docs.tests]: docs/tests.md
 [docs.type-system]: docs/type-system.md
 [docs.builtins]: docs/builtins.md
-[issue.c17-standard]: https://github.com/ForNeVeR/Cesium/issues/62
+[issue.c23-standard]: https://github.com/ForNeVeR/Cesium/issues/62
 [issue.lexer]: https://github.com/ForNeVeR/Cesium/issues/76
 [issue.next-milestone]: https://github.com/ForNeVeR/Cesium/issues/61
 [issue.parser]: https://github.com/ForNeVeR/Cesium/issues/78


### PR DESCRIPTION
Closes #441.

All the issues have been updated to C23 (with adding and removing the new items where appropriate). Cesium will target C23 from now on.