### PR TITLE
Resolved Issue #489 : Made FunctionInfo immutable

### DIFF
--- a/Cesium.CodeGen/Contexts/Meta/FunctionInfo.cs
+++ b/Cesium.CodeGen/Contexts/Meta/FunctionInfo.cs
@@ -5,55 +5,53 @@ using Cesium.CodeGen.Ir.Types;
 using Cesium.Core;
 using Mono.Cecil;
 
-namespace Cesium.CodeGen.Contexts.Meta;
-
-// TODO[#489]: This is confusing, make immutable.
-internal record FunctionInfo(
-    ParametersInfo? Parameters,
-    IType ReturnType,
-    StorageClass StorageClass,
-    bool IsDefined,
-    MethodReference? MethodReference = null)
+namespace Cesium.CodeGen.Contexts.Meta
 {
-    public ParametersInfo? Parameters { get; set; } = Parameters;
-    public StorageClass StorageClass { get; set; } = StorageClass;
-    public bool IsDefined { get; set; } = IsDefined;
-    public string? CliImportMember { get; set; }
-
-    public void VerifySignatureEquality(string name, ParametersInfo? parameters, IType returnType)
+    
+    internal record FunctionInfo(
+        ParametersInfo? Parameters,
+        IType ReturnType,
+        StorageClass StorageClass,
+        bool IsDefined,
+        MethodReference? MethodReference = null)
     {
-        if (!returnType.Equals(ReturnType))
-            throw new CompilationException(
-                $"Incorrect return type for function {name} declared as {ReturnType}: {returnType}.");
+        public string? CliImportMember { get; init; }
 
-        var declaredWithVarargs = Parameters?.IsVarArg == true;
-        var definedWithVarargs = parameters?.IsVarArg == true;
-        if (declaredWithVarargs && !definedWithVarargs)
-            throw new CompilationException(
-                $"Function {name} declared with varargs but defined without varargs.");
-
-        if (!declaredWithVarargs && definedWithVarargs)
-            throw new CompilationException(
-                $"Function {name} declared without varargs but defined with varargs.");
-
-        if (declaredWithVarargs != definedWithVarargs)
-            throw new CompilationException(
-                $"Var arg declarations does not matched for functionn {name}.");
-
-        var actualCount = parameters?.Parameters.Count ?? 0;
-        var declaredCount = Parameters?.Parameters.Count ?? 0;
-        if (actualCount != declaredCount)
-            throw new CompilationException(
-                $"Incorrect parameter count for function {name}: declared with {declaredCount} parameters, defined" +
-                $"with {actualCount}.");
-
-        var actualParams = parameters?.Parameters ?? Array.Empty<ParameterInfo>();
-        var declaredParams = Parameters?.Parameters ?? Array.Empty<ParameterInfo>();
-        foreach (var (a, b) in actualParams.Zip(declaredParams))
+        public void VerifySignatureEquality(string name, ParametersInfo? parameters, IType returnType)
         {
-            if (!a.Type.IsEqualTo(b.Type))
+            if (!returnType.Equals(ReturnType))
                 throw new CompilationException(
-                    $"Incorrect type for parameter {a.Name}: declared as {b.Type}, defined as {a.Type}.");
+                    $"Incorrect return type for function {name} declared as {ReturnType}: {returnType}.");
+
+            var declaredWithVarargs = Parameters?.IsVarArg == true;
+            var definedWithVarargs = parameters?.IsVarArg == true;
+            if (declaredWithVarargs && !definedWithVarargs)
+                throw new CompilationException(
+                    $"Function {name} declared with varargs but defined without varargs.");
+
+            if (!declaredWithVarargs && definedWithVarargs)
+                throw new CompilationException(
+                    $"Function {name} declared without varargs but defined with varargs.");
+
+            if (declaredWithVarargs != definedWithVarargs)
+                throw new CompilationException(
+                    $"Var arg declarations do not match for function {name}.");
+
+            var actualCount = parameters?.Parameters.Count ?? 0;
+            var declaredCount = Parameters?.Parameters.Count ?? 0;
+            if (actualCount != declaredCount)
+                throw new CompilationException(
+                    $"Incorrect parameter count for function {name}: declared with {declaredCount} parameters, defined" +
+                    $" with {actualCount}.");
+
+            var actualParams = parameters?.Parameters ?? Array.Empty<ParameterInfo>();
+            var declaredParams = Parameters?.Parameters ?? Array.Empty<ParameterInfo>();
+            foreach (var (a, b) in actualParams.Zip(declaredParams))
+            {
+                if (!a.Type.IsEqualTo(b.Type))
+                    throw new CompilationException(
+                        $"Incorrect type for parameter {a.Name}: declared as {b.Type}, defined as {a.Type}.");
+            }
         }
     }
 }


### PR DESCRIPTION
Changes made:
[x] Removed the setters from properties like Parameters, StorageClass, and IsDefined.
[x] Initialized the CliImportMember property using init instead of in the constructor. This makes it immutable after construction.
[x] Remove TODO[#489] from the code.

Signed-off-by: @lightlessdays