### PR TITLE
(#408) Dedup labels for nested case statements

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenSwitchTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenSwitchTests.cs
@@ -57,6 +57,17 @@ public class CodeGenSwitchTests : CodeGenTestBase
 }");
 
     [Fact]
+    public Task NestedCases() => DoTest(@"int main()
+{
+    int x = 0;
+    switch(x) {
+        case 0: case 1: break;
+        case 2: case 3: case 4: break;
+        case 5: break;
+    };
+}");
+
+    [Fact]
     public Task MultiCasesWithDefault() => DoTest(@"int main()
 {
     int x = 0;

--- a/Cesium.CodeGen.Tests/verified/CodeGenSwitchTests.FallthroughCase.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenSwitchTests.FallthroughCase.verified.txt
@@ -18,15 +18,14 @@
   IL_0017: brfalse IL_0021
   IL_001c: br IL_002d
   IL_0021: nop
-  IL_0022: br IL_002e
+  IL_0022: br IL_002d
   IL_0027: nop
-  IL_0028: br IL_0034
+  IL_0028: br IL_0033
   IL_002d: nop
-  IL_002e: nop
-  IL_002f: br IL_0034
-  IL_0034: nop
-  IL_0035: ldc.i4.0
-  IL_0036: ret
+  IL_002e: br IL_0033
+  IL_0033: nop
+  IL_0034: ldc.i4.0
+  IL_0035: ret
 
 System.Int32 <Module>::<SyntheticEntrypoint>()
   Locals:

--- a/Cesium.CodeGen.Tests/verified/CodeGenSwitchTests.NestedCases.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenSwitchTests.NestedCases.verified.txt
@@ -1,0 +1,64 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Int32 V_0
+    System.Int32 V_1
+  IL_0000: ldc.i4.0
+  IL_0001: stloc.0
+  IL_0002: ldloc.0
+  IL_0003: stloc.1
+  IL_0004: ldloc.1
+  IL_0005: ldc.i4.0
+  IL_0006: ceq
+  IL_0008: brfalse IL_0012
+  IL_000d: br IL_0063
+  IL_0012: nop
+  IL_0013: ldloc.1
+  IL_0014: ldc.i4.1
+  IL_0015: ceq
+  IL_0017: brfalse IL_0021
+  IL_001c: br IL_0063
+  IL_0021: nop
+  IL_0022: ldloc.1
+  IL_0023: ldc.i4.2
+  IL_0024: ceq
+  IL_0026: brfalse IL_0030
+  IL_002b: br IL_0069
+  IL_0030: nop
+  IL_0031: ldloc.1
+  IL_0032: ldc.i4.3
+  IL_0033: ceq
+  IL_0035: brfalse IL_003f
+  IL_003a: br IL_0069
+  IL_003f: nop
+  IL_0040: ldloc.1
+  IL_0041: ldc.i4.4
+  IL_0042: ceq
+  IL_0044: brfalse IL_004e
+  IL_0049: br IL_0069
+  IL_004e: nop
+  IL_004f: ldloc.1
+  IL_0050: ldc.i4.5
+  IL_0051: ceq
+  IL_0053: brfalse IL_005d
+  IL_0058: br IL_006f
+  IL_005d: nop
+  IL_005e: br IL_0075
+  IL_0063: nop
+  IL_0064: br IL_0075
+  IL_0069: nop
+  IL_006a: br IL_0075
+  IL_006f: nop
+  IL_0070: br IL_0075
+  IL_0075: nop
+  IL_0076: ldc.i4.0
+  IL_0077: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret


### PR DESCRIPTION
Closes #408 

Codegen diff for `CodeGenSwitchTests.NestedCases`:

https://www.diffchecker.com/MLuXLwzS/ (left is main, right is PR)