### PR TITLE
Improved unescape

### DIFF
--- a/Cesium.CodeGen/Cesium.CodeGen.csproj
+++ b/Cesium.CodeGen/Cesium.CodeGen.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/Cesium.Parser/Cesium.Parser.csproj
+++ b/Cesium.Parser/Cesium.Parser.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
+        <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Cesium.Parser/TokenExtensions.cs
+++ b/Cesium.Parser/TokenExtensions.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text;
 using Cesium.Core;
 using Yoakke.SynKit.C.Syntax;
@@ -7,143 +8,158 @@ namespace Cesium.Parser;
 
 public static class TokenExtensions
 {
-    public static string UnwrapStringLiteral(this IToken<CTokenType> token)
+    public unsafe static string UnwrapStringLiteral(this IToken<CTokenType> token)
     {
         if (token.Kind != CTokenType.StringLiteral)
             throw new ParseException($"Non-string literal token: {token.Kind} {token.Text}");
 
-        var result = token.Text[1..^1];
+        var result = token.Text[1..^1]; // allocates new sliced string
 
-        // simple escape sequences
-        var builder = new StringBuilder(result.Length);
-        for (int i = 0; i < result.Length; ++i)
+        if (result.IndexOf('\\') == -1) // no \ no fun no unescape
+            return result;
+
+        fixed (char* p = result)
         {
-            if (result.ElementAt(i) == '\\' && i < result.Length - 1)
+            var span = new Span<char>(p, result.Length + 1); // create a span for string. Also +1 for \0
+            int eaten = 0;
+            while (true) // loop
             {
-                char currentChar = result.ElementAt(i + 1);
-                switch (currentChar)
+                var i = span.IndexOf('\\'); // SIMD search \. Blazing fast.
+                if (i == -1) break; // break if there is no more \
+
+                int shift = 1; // how many characters we're gonna skip
+
+                switch (span[i + 1])
                 {
-                    case '\'':
-                    case '\"':
-                    case '?':
-                    case '\\':
-                        builder.Append(currentChar);
-                        break;
-                    case 'a':
-                        builder.Append('\a');
-                        break;
-                    case 'b':
-                        builder.Append('\b');
-                        break;
-                    case 'f':
-                        builder.Append('\f');
-                        break;
-                    case 'n':
-                        builder.Append('\n');
-                        break;
-                    case 'r':
-                        builder.Append('\r');
-                        break;
-                    case 't':
-                        builder.Append('\t');
-                        break;
-                    case 'v':
-                        builder.Append('\v');
-                        break;
-                    case '0':
+                    // Simple escape sequences
+                    case '"': span[i] = '"'; break;
+                    case '?': span[i] = '?'; break;
+                    case '\'': span[i] = '\''; break;
+                    case '\\': span[i] = '\\'; break;
+                    case 'a': span[i] = '\a'; break;
+                    case 'b': span[i] = '\b'; break;
+                    case 'f': span[i] = '\f'; break;
+                    case 'n': span[i] = '\n'; break;
+                    case 'r': span[i] = '\r'; break;
+                    case 't': span[i] = '\t'; break;
+                    case 'v': span[i] = '\v'; break;
+                    // Numeric escape sequences
+                    case '0': // arbitrary octal value '\nnn'
                         {
-                            int counter = 2;
-                            int octalNumber = 0;
-                            if (result.Length <= i + counter)
+                            if (span.Length <= i + 2 || span[i + 2] == '\0') // \0 check for 2nd..n iters.
                             {
-                                builder.Append('\0');
+                                span[i] = '\0';
                                 break;
                             }
 
-                            char current = result.ElementAt(i + counter);
+                            int number = 0;
+                            var c = span[i + shift + 1]; // get next char after 0
                             do
                             {
-                                octalNumber = octalNumber * 8 + (current - '0');
-                                counter++;
-                                if (result.Length <= i + counter)
-                                    break;
-                                current = result.ElementAt(i + counter);
+                                number = number * 8 + (c - '0');
+                                shift++;
+                                c = span[i + shift + 1];
                             }
-                            while (current >= '0' && current <= '7');
-                            i += counter - 1;
-                            builder.Append(char.ConvertFromUtf32(octalNumber));
+                            while (char.IsBetween(c, '0', '7'));
+                            span[i] = (char)number;
                             break;
                         }
                     case 'x':
-                    case 'X':
+                    case 'X': // \Xn... arbitrary hexadecimal value
                         {
-                            int counter = 2;
-                            int octalNumber = 0;
-                            if (result.Length <= i + counter)
+                            if (span.Length <= i + 2 || span[i + 2] == '\0') // \0 check for 2nd..n iters.
                             {
-                                builder.Append('\\');
-                                builder.Append(currentChar);
+                                shift = 0;
                                 break;
                             }
 
-                            char current = result.ElementAt(i + counter);
+                            int number = 0;
+                            var c = span[i + 1 + shift]; // shift == 1, so i + 2 points at next char after '\' 'X'
                             do
                             {
-                                int digit = Char.IsAsciiDigit(current) ? current - '0' : (char.ToUpperInvariant(current) - 'A') + 10;
-                                octalNumber = octalNumber * 16 + digit;
-                                counter++;
-                                if (result.Length <= i + counter)
-                                    break;
-                                current = result.ElementAt(i + counter);
+                                int digit = char.IsAsciiDigit(c) ? c - '0' : (char.ToUpperInvariant(c) - 'A') + 10;
+                                number = number * 16 + digit;
+                                shift++;
+                                c = span[i + 1 + shift];
                             }
-                            while (Char.IsAsciiDigit(current) || (current >= 'A' && current <= 'F') || (current >= 'a' && current <= 'f'));
-                            i += counter - 1;
-                            builder.Append((char)octalNumber);
+                            while (char.IsAsciiDigit(c) || char.IsBetween(c, 'a', 'f') || char.IsBetween(c, 'A', 'F'));
+                            span[i] = (char)number;
                             break;
                         }
-                    case 'u':
-                    case 'U':
+                    // Universal character names
+                    case 'u': // \unnnn
+                    case 'U': // \Unnnnnnnn 
                         {
-                            int counter = 2;
-                            int octalNumber = 0;
-                            if (result.Length <= i + counter)
+                            int counter = span[i + 1] == 'U' ? 8 : 4;
+                            if (span.Length <= i + counter) // no free chars no fun
                             {
-                                builder.Append('\\');
-                                builder.Append(currentChar);
+                                shift = 0;
                                 break;
                             }
 
-                            char current = result.ElementAt(i + counter);
-                            do
+                            int number = 0;
+                            for (int n = 0; n < counter; n++)
                             {
-                                int digit = Char.IsAsciiDigit(current) ? current - '0' : (char.ToUpperInvariant(current) - 'A') + 10;
-                                octalNumber = octalNumber * 16 + digit;
-                                counter++;
-                                if (result.Length <= i + counter)
-                                    break;
-                                current = result.ElementAt(i + counter);
+                                var c = span[i + 2 + n]; // i + 2 points at next char after '\', 'U',
+                                // in theory, we should throw an error.
+                                if (!(char.IsAsciiDigit(c) || char.IsBetween(c, 'a', 'f') || char.IsBetween(c, 'A', 'F'))) break;
+                                int digit = char.IsAsciiDigit(c) ? c - '0' : (char.ToUpperInvariant(c) - 'A') + 10;
+                                number = number * 16 + digit;
+                                shift++;
                             }
-                            while (Char.IsAsciiDigit(current) || (current >= 'A' && current <= 'F') || (current >= 'a' && current <= 'f'));
-                            i += counter - 1;
-                            builder.Append(char.ConvertFromUtf32(octalNumber));
+                            // char.ConvertFromUtf32(number) allocates string :(
+                            //                create span  from     pointer    to our number  represented as ref byte
+                            var spanCodeSeq = new Span<byte>(Unsafe.AsPointer(ref Unsafe.As<int, byte>(ref number)), 4);
+                            // get utf16 chars from utf32 bytes seq without allocations yeeeah
+                            if (!Encoding.UTF32.TryGetChars(spanCodeSeq, span.Slice(i), out int written)) throw new Exception("Bad UTF32 sequence!");
+                            // if we writted one char, so just do nothing
+                            // if we writted two chars, so just skip one char
+                            i += written - 1;
+                            shift -= written - 1;
                             break;
                         }
                     default:
+                        // from orig method:
                         // TODO[#295]: maybe smarter handling of this edge case with errors/warnings
-                        builder.Append('\\');
-                        --i; // don't skip next
+                        // builder.Append('\\');
+                        // --i; // don't skip next
+                        // mmm, idk when that might happen
                         break;
                 }
 
-                ++i; // skip next
-            }
-            else
-            {
-                builder.Append(result.ElementAt(i));
-            }
-        }
-        result = builder.ToString();
+                if (shift == 0)
+                {
+                    span = span.Slice(1); // skip 1 char
+                    continue;
+                }
 
-        return result;
+                // ex:
+                // before
+                // span[i] = '\'  span[i+1] = 'n' span[i+2] = 'h'
+                // after
+                // shift = 1
+                // span[i] = '\n' span[i+1] = 'n' span[i+2] = 'h'
+                // it is required to shift all subsequent chars by (1..shift) to the left
+                // result slice slice copy
+                // span[i] = '\n' span[i+1] = 'h' span[i+2] = (previous span)[i+3]
+                var start = i + shift;
+                var source = span.Slice(start + 1); // next from consumed chars
+                var destination = span.Slice(i + 1); // next from span[i] = '\n'
+                // If copy properly in chunks, rather than continuously copying the WHOLE unchecked string, unescape will be even faster
+                source.CopyTo(destination); // <--- copies the WHOLE unchecked string. bad. bad. but also SIMDed, so it's still very fast
+                span = destination; // next iter
+                eaten += shift;
+            }
+
+            // oh wait
+            // before: "kek \\n\\n\\n kek"    len 17
+            // after   "kek \n\n\n kek\0\0\0" len 17
+            // create copy & alocate it again
+            // we can change the length of an existing string, but GC always *bonk* for it
+            result = new ReadOnlySpan<char>(p, result.Length - eaten).ToString(); // alocate x2 ><
+            // after:  "kek \n\n\n kek" len 14
+
+            return result;
+        }
     }
 }


### PR DESCRIPTION
Refactored unescape. It is now 11 times faster than the previous one.
Bumped Net7 up to Net8, because UTF32.TryGetChars is only available in Net8.
Now there are only two bottlenecks:
```csharp
var result = token.Text[1..^1]; // allocates new sliced string
```
and
```csharp
result = new ReadOnlySpan<char>(p, result.Length - eaten).ToString(); // alocate x2 ><
```
Benchmark results, input string `string s = "\"\\'hello, world\\\"\\?\\\\test\\b\\f\\n\\r42\\t\\v \\02 \\024 \\007 \\077 \\x06 \\x28 \\u2200 \\U0001f34c \"";`:
```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.22000.2538/21H2/SunValley)
Intel Core i7-7700K CPU 4.20GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK 8.0.200
  [Host]     : .NET 8.0.2 (8.0.224.6711), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.2 (8.0.224.6711), X64 RyuJIT AVX2
```
| Method | Mean       | Error    | StdDev   | Ratio         | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------- |-----------:|---------:|---------:|--------------:|--------:|-------:|----------:|------------:|
| New |   545.2 ns |  2.86 ns |  2.39 ns | 11.32x faster |   0.13x | 0.1450 |     608 B |  6.68x less |
| Old | 6,175.4 ns | 78.12 ns | 73.08 ns |      baseline |         | 0.9689 |    4064 B |             |
