### PR TITLE
Improve Main function signature equivalency

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
@@ -77,6 +77,9 @@ int main()
     [Fact] public Task VoidParameterMain() => DoTest("int main(void){}");
     [Fact] public Task PointerReceivingFunction() => DoTest("void foo(int *ptr){}");
     [Fact] public Task StandardMain() => DoTest("int main(int argc, char *argv[]){}");
+    [Fact] public Task PointerPointerMain() => DoTest("int main(int argc, char **argv){}");
+    [Fact] public Task ConstConstMain() => DoTest("int main(int argc, const char * const *argv){}");
+    [Fact] public Task ConstArgcMain() => DoTest("int main(const int argc, char* argv[]){}");
     [Fact, NoVerify] public void NonstandardMainDoesNotCompile1() => DoesNotCompile("void main(){}", "Invalid return type");
     [Fact, NoVerify] public void NonstandardMainDoesNotCompile2() => DoesNotCompile("int main(int c){}", "Invalid parameter");
     [Fact, NoVerify]

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ConstArgcMain.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ConstArgcMain.verified.txt
@@ -1,0 +1,43 @@
+﻿System.Int32 <Module>::main(System.Int32 argc, System.Byte** argv)
+  IL_0000: ldc.i4.0
+  IL_0001: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>(System.String[] args)
+  Locals:
+    System.Int32 V_0
+    System.Byte*[] V_1
+    System.Byte*[] V_2
+    System.Byte*[] (pinned) V_3
+    System.Int32 V_4
+  IL_0000: ldarg.0
+  IL_0001: ldlen
+  IL_0002: ldc.i4.1
+  IL_0003: add
+  IL_0004: stloc.0
+  IL_0005: ldarg.0
+  IL_0006: call System.Byte*[] Cesium.Runtime.RuntimeHelpers::ArgsToArgv(System.String[])
+  IL_000b: stloc.1
+  IL_000c: ldloc.1
+  IL_000d: ldlen
+  IL_000e: newarr System.Byte*
+  IL_0013: stloc.2
+  IL_0014: ldloc.1
+  IL_0015: ldloc.2
+  IL_0016: ldc.i4.0
+  IL_0017: call System.Void System.Array::CopyTo(System.Array,System.Int32)
+  IL_001c: ldloc.0
+  IL_001d: ldloc.2
+  IL_001e: stloc.3
+  IL_001f: ldloc.3
+  IL_0020: ldc.i4.0
+  IL_0021: ldelema System.Byte*
+  IL_0026: call System.Int32 <Module>::main(System.Int32,System.Byte**)
+  IL_002b: stloc.s V_4
+  IL_002d: ldnull
+  IL_002e: stloc.3
+  IL_002f: ldloc.1
+  IL_0030: call System.Void Cesium.Runtime.RuntimeHelpers::FreeArgv(System.Byte*[])
+  IL_0035: ldloc.s V_4
+  IL_0037: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_003c: ldloc.s V_4
+  IL_003e: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ConstConstMain.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.ConstConstMain.verified.txt
@@ -1,0 +1,43 @@
+﻿System.Int32 <Module>::main(System.Int32 argc, System.Byte** argv)
+  IL_0000: ldc.i4.0
+  IL_0001: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>(System.String[] args)
+  Locals:
+    System.Int32 V_0
+    System.Byte*[] V_1
+    System.Byte*[] V_2
+    System.Byte*[] (pinned) V_3
+    System.Int32 V_4
+  IL_0000: ldarg.0
+  IL_0001: ldlen
+  IL_0002: ldc.i4.1
+  IL_0003: add
+  IL_0004: stloc.0
+  IL_0005: ldarg.0
+  IL_0006: call System.Byte*[] Cesium.Runtime.RuntimeHelpers::ArgsToArgv(System.String[])
+  IL_000b: stloc.1
+  IL_000c: ldloc.1
+  IL_000d: ldlen
+  IL_000e: newarr System.Byte*
+  IL_0013: stloc.2
+  IL_0014: ldloc.1
+  IL_0015: ldloc.2
+  IL_0016: ldc.i4.0
+  IL_0017: call System.Void System.Array::CopyTo(System.Array,System.Int32)
+  IL_001c: ldloc.0
+  IL_001d: ldloc.2
+  IL_001e: stloc.3
+  IL_001f: ldloc.3
+  IL_0020: ldc.i4.0
+  IL_0021: ldelema System.Byte*
+  IL_0026: call System.Int32 <Module>::main(System.Int32,System.Byte**)
+  IL_002b: stloc.s V_4
+  IL_002d: ldnull
+  IL_002e: stloc.3
+  IL_002f: ldloc.1
+  IL_0030: call System.Void Cesium.Runtime.RuntimeHelpers::FreeArgv(System.Byte*[])
+  IL_0035: ldloc.s V_4
+  IL_0037: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_003c: ldloc.s V_4
+  IL_003e: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.PointerPointerMain.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.PointerPointerMain.verified.txt
@@ -1,0 +1,43 @@
+﻿System.Int32 <Module>::main(System.Int32 argc, System.Byte** argv)
+  IL_0000: ldc.i4.0
+  IL_0001: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>(System.String[] args)
+  Locals:
+    System.Int32 V_0
+    System.Byte*[] V_1
+    System.Byte*[] V_2
+    System.Byte*[] (pinned) V_3
+    System.Int32 V_4
+  IL_0000: ldarg.0
+  IL_0001: ldlen
+  IL_0002: ldc.i4.1
+  IL_0003: add
+  IL_0004: stloc.0
+  IL_0005: ldarg.0
+  IL_0006: call System.Byte*[] Cesium.Runtime.RuntimeHelpers::ArgsToArgv(System.String[])
+  IL_000b: stloc.1
+  IL_000c: ldloc.1
+  IL_000d: ldlen
+  IL_000e: newarr System.Byte*
+  IL_0013: stloc.2
+  IL_0014: ldloc.1
+  IL_0015: ldloc.2
+  IL_0016: ldc.i4.0
+  IL_0017: call System.Void System.Array::CopyTo(System.Array,System.Int32)
+  IL_001c: ldloc.0
+  IL_001d: ldloc.2
+  IL_001e: stloc.3
+  IL_001f: ldloc.3
+  IL_0020: ldc.i4.0
+  IL_0021: ldelema System.Byte*
+  IL_0026: call System.Int32 <Module>::main(System.Int32,System.Byte**)
+  IL_002b: stloc.s V_4
+  IL_002d: ldnull
+  IL_002e: stloc.3
+  IL_002f: ldloc.1
+  IL_0030: call System.Void Cesium.Runtime.RuntimeHelpers::FreeArgv(System.Byte*[])
+  IL_0035: ldloc.s V_4
+  IL_0037: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_003c: ldloc.s V_4
+  IL_003e: ret

--- a/Cesium.CodeGen/Ir/BlockItems/FunctionDefinition.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/FunctionDefinition.cs
@@ -125,12 +125,16 @@ internal sealed class FunctionDefinition : IBlockItem
         bool isValid = true;
 
         var argc = parameterList[0];
-        if (argc.Type is not PrimitiveType { Kind: PrimitiveTypeKind.Int }) isValid = false;
+        if (argc.Type is not PrimitiveType { Kind: PrimitiveTypeKind.Int } // int argc
+            and not ConstType { Base: PrimitiveType { Kind: PrimitiveTypeKind.Int } /* const int argc */ }) isValid = false;
 
         var argv = parameterList[1];
-        if (argv.Type is not PointerType
+        if (argv.Type is not PointerType // char** or char*[]
             {
                 Base: PointerType { Base: PrimitiveType { Kind: PrimitiveTypeKind.Char } }
+            } and not PointerType // [opt const] char * const *
+            {
+                Base: PointerType { Base: ConstType { Base: PrimitiveType { Kind: PrimitiveTypeKind.Char } } }
             }) isValid = false;
 
         if (!isValid)


### PR DESCRIPTION
Now main functions using const int argc or const char * cosnt * argv or char * cont * argv are valid.
Issue #66