### PR TITLE
Improved cli-interop

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenNetInteropTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenNetInteropTests.cs
@@ -170,4 +170,22 @@ int main(void)
    return Func(&myFunc) - 1;
 }
 """);
+
+    [Theory]
+    [InlineData(TargetArchitectureSet.Dynamic)]
+    [InlineData(TargetArchitectureSet.Wide)]
+    public Task TestEquivalentTypeAttribute(TargetArchitectureSet architecture) => DoTest(architecture,
+@"using Cesium.Runtime;
+public static unsafe class Test
+{
+    public static int Func(UTF8String str) => (int)str.Length;
+}",
+@"
+__cli_import(""Test::Func"")
+int Func(char*);
+
+int main(void)
+{
+    return Func(""Hi"") - 2;
+}");
 }

--- a/Cesium.CodeGen.Tests/verified/CodeGenNetInteropTests.TestEquivalentTypeAttribute_architecture=Dynamic.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenNetInteropTests.TestEquivalentTypeAttribute_architecture=Dynamic.verified.txt
@@ -1,0 +1,29 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::main()
+      IL_0000: ldsflda <ConstantPool>/<ConstantPoolItemType3> <ConstantPool>::ConstDataBuffer0
+      IL_0005: call Cesium.Runtime.UTF8String Cesium.Runtime.UTF8String::op_Implicit(System.Byte*)
+      IL_000a: call System.Int32 Test::Func(Cesium.Runtime.UTF8String)
+      IL_000f: ldc.i4.2
+      IL_0010: sub
+      IL_0011: ret
+
+    System.Int32 <Module>::<SyntheticEntrypoint>()
+      Locals:
+        System.Int32 V_0
+      IL_0000: call System.Int32 <Module>::main()
+      IL_0005: stloc.s V_0
+      IL_0007: ldloc.s V_0
+      IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+      IL_000e: ldloc.s V_0
+      IL_0010: ret
+
+  Type: <ConstantPool>
+  Nested types:
+    Type: <ConstantPool>/<ConstantPoolItemType3>
+    Pack: 1
+    Size: 3
+  Fields:
+    <ConstantPool>/<ConstantPoolItemType3> <ConstantPool>::ConstDataBuffer0
+      Init with (UTF-8 x 3 bytes): "Hi"

--- a/Cesium.CodeGen.Tests/verified/CodeGenNetInteropTests.TestEquivalentTypeAttribute_architecture=Wide.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenNetInteropTests.TestEquivalentTypeAttribute_architecture=Wide.verified.txt
@@ -1,0 +1,29 @@
+﻿Module: Primary
+  Type: <Module>
+  Methods:
+    System.Int32 <Module>::main()
+      IL_0000: ldsflda <ConstantPool>/<ConstantPoolItemType3> <ConstantPool>::ConstDataBuffer0
+      IL_0005: call Cesium.Runtime.UTF8String Cesium.Runtime.UTF8String::op_Implicit(System.Byte*)
+      IL_000a: call System.Int32 Test::Func(Cesium.Runtime.UTF8String)
+      IL_000f: ldc.i4.2
+      IL_0010: sub
+      IL_0011: ret
+
+    System.Int32 <Module>::<SyntheticEntrypoint>()
+      Locals:
+        System.Int32 V_0
+      IL_0000: call System.Int32 <Module>::main()
+      IL_0005: stloc.s V_0
+      IL_0007: ldloc.s V_0
+      IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+      IL_000e: ldloc.s V_0
+      IL_0010: ret
+
+  Type: <ConstantPool>
+  Nested types:
+    Type: <ConstantPool>/<ConstantPoolItemType3>
+    Pack: 1
+    Size: 3
+  Fields:
+    <ConstantPool>/<ConstantPoolItemType3> <ConstantPool>::ConstDataBuffer0
+      Init with (UTF-8 x 3 bytes): "Hi"

--- a/Cesium.CodeGen/Extensions/TypeSystemEx.cs
+++ b/Cesium.CodeGen/Extensions/TypeSystemEx.cs
@@ -13,6 +13,7 @@ internal static class TypeSystemEx
     public const string CPtrFullTypeName = "Cesium.Runtime.CPtr`1";
     public const string VoidPtrFullTypeName = "Cesium.Runtime.VoidPtr";
     public const string FuncPtrFullTypeName = "Cesium.Runtime.FuncPtr`1";
+    public const string EquivalentTypeAttributeName = "Cesium.Runtime.Attributes.EquivalentTypeAttribute";
 
     public static MethodReference MethodLookup(
         this TranslationUnitContext context,
@@ -158,6 +159,21 @@ internal static class TypeSystemEx
         if (type2.FullName.Equals(VoidPtrFullTypeName))
         {
             return type1 is PointerType pt && pt.ElementType.IsEqualTo(typeSystem.Void);
+        }
+
+        var resolvedType2 = type2.Resolve();
+        if (resolvedType2.HasCustomAttributes)
+        {
+            // check for EquivalentTypeAttribute
+            foreach(var attr in resolvedType2.CustomAttributes)
+            {
+                if (!attr.AttributeType.FullName.Equals(EquivalentTypeAttributeName))
+                    continue;
+
+                var eqType = (TypeReference)attr.ConstructorArguments[0].Value;
+                if (type1.FullName == eqType.FullName)
+                    return true;
+            }
         }
 
         if (type2 is not GenericInstanceType type2Instance) return false;

--- a/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/FunctionCallExpression.cs
@@ -124,11 +124,12 @@ internal sealed class FunctionCallExpression : FunctionCallExpressionBase
         if (_callee == null)
             throw new AssertException("Should be lowered");
 
-        EmitArgumentList(scope, _callee.Parameters, _arguments);
-
         var functionName = _function.Identifier;
         var callee = _callee ?? throw new CompilationException($"Function \"{functionName}\" was not lowered.");
         var methodReference = callee.MethodReference ?? throw new CompilationException($"Function \"{functionName}\" was not found.");
+
+        EmitArgumentList(scope, _callee.Parameters, _arguments, methodReference);
+
         scope.Method.Body.Instructions.Add(Instruction.Create(OpCodes.Call, methodReference));
     }
 

--- a/Cesium.Runtime.Tests/PtrTests.cs
+++ b/Cesium.Runtime.Tests/PtrTests.cs
@@ -9,7 +9,7 @@ public unsafe class PtrTests
         Assert.Equal(0x1234L, (long)v.AsPtr());
         Assert.Equal(0x1234L, (long)v.AsPtr<byte>());
 
-        Assert.Equal(sizeof(long), sizeof(VoidPtr));
+        Assert.Equal(sizeof(IntPtr), sizeof(VoidPtr));
     }
 
     [Fact]
@@ -20,7 +20,7 @@ public unsafe class PtrTests
         Assert.Equal((IntPtr)0x2345, t.AsIntPtr());
         Assert.Equal(0x2345L, (long)t.AsPtr<byte>());
 
-        Assert.Equal(sizeof(long), sizeof(CPtr<int>));
+        Assert.Equal(sizeof(IntPtr), sizeof(CPtr<int>));
     }
 
     [Fact]
@@ -28,6 +28,15 @@ public unsafe class PtrTests
     {
         var a = new FuncPtr<Action>((void*)0x1234);
         Assert.Equal(0x1234L, (long)a.AsPtr());
-        Assert.Equal(sizeof(long), sizeof(FuncPtr<Action>));
+        Assert.Equal(sizeof(IntPtr), sizeof(FuncPtr<Action>));
+
+        FuncPtr<Func<int>> funcPtr = (Func<int>)SomeAnonFunc;
+        var func = SomeAnonFunc;
+        Assert.Equal(funcPtr.AsDelegate()(), func());
+
+        funcPtr = (delegate*<int>)&SomeAnonFunc;
+        Assert.Equal(funcPtr.AsDelegate()(), func());
+
+        static int SomeAnonFunc() => 5;
     }
 }

--- a/Cesium.Runtime.Tests/PtrTests.cs
+++ b/Cesium.Runtime.Tests/PtrTests.cs
@@ -9,7 +9,7 @@ public unsafe class PtrTests
         Assert.Equal(0x1234L, (long)v.AsPtr());
         Assert.Equal(0x1234L, (long)v.AsPtr<byte>());
 
-        Assert.Equal(sizeof(IntPtr), sizeof(VoidPtr));
+        Assert.Equal(sizeof(long), sizeof(VoidPtr));
     }
 
     [Fact]
@@ -20,7 +20,7 @@ public unsafe class PtrTests
         Assert.Equal((IntPtr)0x2345, t.AsIntPtr());
         Assert.Equal(0x2345L, (long)t.AsPtr<byte>());
 
-        Assert.Equal(sizeof(IntPtr), sizeof(CPtr<int>));
+        Assert.Equal(sizeof(long), sizeof(CPtr<int>));
     }
 
     [Fact]

--- a/Cesium.Runtime.Tests/StringTests.cs
+++ b/Cesium.Runtime.Tests/StringTests.cs
@@ -6,6 +6,8 @@ public unsafe class StringTests
     [Fact]
     public void ComplexTest()
     {
+        Assert.Equal(sizeof(long), sizeof(UTF8String));
+
         UTF8String someString = (byte*)Marshal.StringToHGlobalAnsi("Hello world!\0");
 
         Assert.Equal("Hello world!".Length, (int)someString.Length);

--- a/Cesium.Runtime.Tests/StringTests.cs
+++ b/Cesium.Runtime.Tests/StringTests.cs
@@ -1,0 +1,26 @@
+using System.Runtime.InteropServices;
+
+namespace Cesium.Runtime.Tests;
+public unsafe class StringTests
+{
+    [Fact]
+    public void ComplexTest()
+    {
+        UTF8String someString = (byte*)Marshal.StringToHGlobalAnsi("Hello world!\0");
+
+        Assert.Equal("Hello world!".Length, (int)someString.Length);
+        Assert.Equal("Hello world!".Length + 1, (int)someString.NullTerminatedLength);
+        Assert.Equal("Hello world!", someString.ToString());
+
+        UTF8String someMemory = stackalloc byte[(int)someString.NullTerminatedLength];
+        someString.CopyTo(someMemory);
+        Assert.Equal(someString.ToString(), someMemory.ToString());
+
+        UTF8String someOtherMemory = stackalloc byte[(int)someString.NullTerminatedLength];
+        someString.CopyTo(someOtherMemory, 5);
+        someOtherMemory[6] = (byte)'\0';
+        Assert.Equal("Hello", someOtherMemory.ToString());
+
+        Assert.Equal((byte)'o', someString.At(4)[0]);
+    }
+}

--- a/Cesium.Runtime/Attributes/EquivalentTypeAttribute.cs
+++ b/Cesium.Runtime/Attributes/EquivalentTypeAttribute.cs
@@ -1,0 +1,7 @@
+namespace Cesium.Runtime.Attributes;
+
+[AttributeUsage(AttributeTargets.Struct)]
+public class EquivalentTypeAttribute(Type equivalentType) : Attribute
+{
+    public Type EquivalentType { get; } = equivalentType;
+}

--- a/Cesium.Runtime/FuncPtr.cs
+++ b/Cesium.Runtime/FuncPtr.cs
@@ -12,14 +12,9 @@ public readonly unsafe struct FuncPtr<TDelegate> where TDelegate : MulticastDele
         _value = (IntPtr)ptr;
     }
 
-    public FuncPtr(IntPtr ptr)
-    {
-        _value = ptr;
-    }
-
     public static implicit operator TDelegate(FuncPtr<TDelegate> funcPtr) => (TDelegate)Activator.CreateInstance(typeof(TDelegate), [null, funcPtr._value])!;
     public static implicit operator FuncPtr<TDelegate>(TDelegate @delegate) => @delegate.Method.MethodHandle.GetFunctionPointer();
-    public static implicit operator FuncPtr<TDelegate>(IntPtr funcPtr) => new(funcPtr);
+    public static implicit operator FuncPtr<TDelegate>(IntPtr funcPtr) => new((void*)funcPtr);
     public static implicit operator FuncPtr<TDelegate>(void* funcPtr) => new(funcPtr);
 
     public TDelegate AsDelegate() => this;

--- a/Cesium.Runtime/FuncPtr.cs
+++ b/Cesium.Runtime/FuncPtr.cs
@@ -5,14 +5,14 @@ namespace Cesium.Runtime;
 /// <summary>A class encapsulating a C function pointer.</summary>
 public readonly unsafe struct FuncPtr<TDelegate> where TDelegate : MulticastDelegate // TODO[#487]: Think about vararg and empty parameter list encoding.
 {
-    private readonly IntPtr _value;
+    private readonly long _value;
 
     public FuncPtr(void* ptr)
     {
-        _value = (IntPtr)ptr;
+        _value = (long)ptr;
     }
 
-    public static implicit operator TDelegate(FuncPtr<TDelegate> funcPtr) => (TDelegate)Activator.CreateInstance(typeof(TDelegate), [null, funcPtr._value])!;
+    public static implicit operator TDelegate(FuncPtr<TDelegate> funcPtr) => (TDelegate)Activator.CreateInstance(typeof(TDelegate), [null, (IntPtr)funcPtr._value])!;
     public static implicit operator FuncPtr<TDelegate>(TDelegate @delegate) => @delegate.Method.MethodHandle.GetFunctionPointer();
     public static implicit operator FuncPtr<TDelegate>(IntPtr funcPtr) => new((void*)funcPtr);
     public static implicit operator FuncPtr<TDelegate>(void* funcPtr) => new(funcPtr);

--- a/Cesium.Runtime/FuncPtr.cs
+++ b/Cesium.Runtime/FuncPtr.cs
@@ -1,14 +1,28 @@
+using System.Runtime.InteropServices;
+
 namespace Cesium.Runtime;
 
 /// <summary>A class encapsulating a C function pointer.</summary>
-public readonly unsafe struct FuncPtr<TDelegate> where TDelegate : Delegate // TODO[#487]: Think about vararg and empty parameter list encoding.
+public readonly unsafe struct FuncPtr<TDelegate> where TDelegate : MulticastDelegate // TODO[#487]: Think about vararg and empty parameter list encoding.
 {
-    private readonly long _value;
+    private readonly IntPtr _value;
 
     public FuncPtr(void* ptr)
     {
-        _value = (long)ptr;
+        _value = (IntPtr)ptr;
     }
+
+    public FuncPtr(IntPtr ptr)
+    {
+        _value = ptr;
+    }
+
+    public static implicit operator TDelegate(FuncPtr<TDelegate> funcPtr) => (TDelegate)Activator.CreateInstance(typeof(TDelegate), [null, funcPtr._value])!;
+    public static implicit operator FuncPtr<TDelegate>(TDelegate @delegate) => @delegate.Method.MethodHandle.GetFunctionPointer();
+    public static implicit operator FuncPtr<TDelegate>(IntPtr funcPtr) => new(funcPtr);
+    public static implicit operator FuncPtr<TDelegate>(void* funcPtr) => new(funcPtr);
+
+    public TDelegate AsDelegate() => this;
 
     public void* AsPtr() => (void*)_value;
 }

--- a/Cesium.Runtime/StringFunctions.cs
+++ b/Cesium.Runtime/StringFunctions.cs
@@ -12,81 +12,32 @@ namespace Cesium.Runtime;
 /// </summary>
 public static unsafe class StringFunctions
 {
-    public static nuint StrLen(byte* str)
-    {
-#if NETSTANDARD
-        if (str == null)
-        {
-            return 0;
-        }
+    public static nuint StrLen(UTF8String str) => str.Length;
 
-        Encoding encoding = Encoding.UTF8;
-        int byteLength = 0;
-        byte* search = str;
-        while (*search != '\0')
-        {
-            byteLength++;
-            search++;
-        }
-
-        int stringLength = encoding.GetCharCount(str, byteLength);
-        return (uint)stringLength;
-#else
-        return (uint)(Marshal.PtrToStringUTF8((nint)str)?.Length ?? 0);
-#endif
-    }
-    public static byte* StrCpy(byte* dest, byte* src)
+    public static byte* StrCpy(UTF8String dest, UTF8String src)
     {
-        if (dest == null)
-        {
+        if (!dest)
             return null;
-        }
 
-        var result = dest;
-        if (src == null)
-        {
+        if (!src)
             return dest;
-        }
 
-        byte* search = src;
-        while (*search != '\0')
-        {
-            *dest = *search;
-            search++;
-            dest++;
-        }
+        src.CopyTo(dest);
 
-        *dest = 0;
-        return result;
+        return dest;
     }
-    public static byte* StrNCpy(byte* dest, byte* src, nuint count)
+
+    public static byte* StrNCpy(UTF8String dest, UTF8String src, nuint count)
     {
-        if (dest == null)
-        {
+        if (!dest)
             return null;
-        }
 
-        var result = dest;
-        if (src == null)
-        {
+        if (!src)
             return dest;
-        }
 
-        uint counter = 0;
-        byte* search = src;
-        while (*search != '\0')
-        {
-            *dest = *search;
-            search++;
-            dest++;
-            counter++;
-            if (counter == count)
-            {
-                break;
-            }
-        }
+        src.CopyTo(dest, count);
 
-        return result;
+        return dest;
     }
     public static byte* StrCat(byte* dest, byte* src)
     {
@@ -184,24 +135,12 @@ public static unsafe class StringFunctions
 
         return dest;
     }
-    public static byte* StrChr(byte* str, int ch)
+    public static byte* StrChr(UTF8String str, int ch)
     {
-        if (str == null)
-        {
+        if (!str)
             return null;
-        }
 
-        while (*str != 0)
-        {
-            if (*str == ch)
-            {
-                return str;
-            }
-
-            str++;
-        }
-
-        return null;
+        return str.FindEntry((byte)ch);
     }
 
     public static int StrCmp(byte* lhs, byte* rhs)

--- a/Cesium.Runtime/UTF8String.cs
+++ b/Cesium.Runtime/UTF8String.cs
@@ -1,0 +1,139 @@
+using Cesium.Runtime.Attributes;
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Cesium.Runtime;
+
+/// <summary>
+/// A useful wrapper over UTF8 strings.
+/// </summary>
+[EquivalentType(typeof(byte*))]
+[StructLayout(LayoutKind.Sequential)]
+public unsafe readonly struct UTF8String
+{
+    public readonly static UTF8String NullString = new UTF8String((byte*)0);
+
+    private readonly byte* _value;
+
+    public UTF8String(byte* text) => _value = text;
+
+    public byte this[int index]
+    {
+        get => _value[index];
+        set => _value[index] = value;
+    }
+
+    public byte this[nuint index]
+    {
+        get => _value[index];
+        set => _value[index] = value;
+    }
+
+    /// <summary>
+    /// String length
+    /// </summary>
+    public nuint Length
+    {
+        get
+        {
+            nuint length = 0;
+            while (_value[length] != 0) length++;
+            return length;
+        }
+    }
+
+    /// <summary>
+    /// String length including '\0'
+    /// </summary>
+    public nuint NullTerminatedLength
+    {
+        get
+        {
+            nuint length = 0;
+            while (_value[length] != 0) length++;
+            return length + 1;
+        }
+    }
+
+#if !NETSTANDARD
+    /// <summary>
+    /// Creates a Span for the full length of the string
+    /// </summary>
+    public Span<byte> Span => new(_value, (int)Length);
+
+    /// <summary>
+    /// Creates Span(ptr, int.MaxValue)
+    /// </summary>
+    public Span<byte> UncheckedSpan => new(_value, int.MaxValue);
+#endif
+
+    /// <summary>
+    /// Copies the contents of a string for its entire length to another string
+    /// </summary>
+    /// <param name="dest">Destination</param>
+    public void CopyTo(UTF8String dest)
+    {
+        var len = NullTerminatedLength;
+
+#if NETSTANDARD
+        for(nuint i = 0; i < len; i++)
+            dest[i] = _value[i];
+#else
+        UncheckedSpan.Slice(0, (int)len).CopyTo(dest.UncheckedSpan);
+#endif
+    }
+
+    /// <summary>
+    /// Copies "count" bytes of a string to another string
+    /// </summary>
+    /// <param name="dest">Destination</param>
+    /// <param name="count">How many bytes to copy</param>
+    public void CopyTo(UTF8String dest, nuint count)
+    {
+        var len = Math.Min(NullTerminatedLength, count);
+
+#if NETSTANDARD
+        for (nuint i = 0; i < len; i++)
+            dest[i] = _value[i];
+#else
+        UncheckedSpan.Slice(0, (int)len).CopyTo(dest.UncheckedSpan);
+#endif
+    }
+
+    /// <summary>
+    /// Looks for a literal in a string
+    /// </summary>
+    /// <param name="ch">ASCII literal</param>
+    /// <returns>Pointer to the literal</returns>
+    public UTF8String FindEntry(byte ch)
+    {
+#if NETSTANDARD
+        var len = Length;
+        for (nuint i = 0; i < len; i++)
+            if (this[i] == ch)
+                return At(i);
+        return NullString;
+#else
+        var index = Span.IndexOf(ch);
+        if (index == -1) return NullString;
+        return (byte*)Unsafe.AsPointer(ref Unsafe.AddByteOffset(ref Unsafe.AsRef<byte>(_value), (nuint)index));
+#endif
+    }
+
+    public UTF8String At(int index) => new UTF8String(_value + index);
+    public UTF8String At(nuint index) => new UTF8String(_value + index);
+
+    public override string ToString() => new string((sbyte*)_value);
+
+    public static bool operator !(UTF8String str) => (nuint)str._value == 0;
+
+    public static implicit operator byte*(UTF8String str) => str._value;
+    public static implicit operator IntPtr(UTF8String str) => (IntPtr)str._value;
+
+    public static implicit operator UTF8String(byte* p) => new UTF8String(p);
+    public static implicit operator UTF8String(sbyte* p) => new UTF8String((byte*)p);
+    public static implicit operator UTF8String(IntPtr p) => new UTF8String((byte*)p);
+    public static implicit operator UTF8String(CPtr<byte> p) => new UTF8String(p.AsPtr());
+    public static implicit operator UTF8String(CPtr<sbyte> p) => new UTF8String((byte*)p.AsPtr());
+}

--- a/Cesium.Runtime/VoidPtr.cs
+++ b/Cesium.Runtime/VoidPtr.cs
@@ -3,14 +3,14 @@ namespace Cesium.Runtime;
 /// <summary>A class encapsulating an opaque pointer (aka <code>void*</code> in C).</summary>
 public readonly unsafe struct VoidPtr
 {
-    private readonly IntPtr _value;
+    private readonly long _value;
 
-    private VoidPtr(IntPtr value)
+    private VoidPtr(long value)
     {
         _value = value;
     }
 
-    public static implicit operator VoidPtr(void* ptr) => new((IntPtr)ptr);
+    public static implicit operator VoidPtr(void* ptr) => new((long)ptr);
     public void* AsPtr() => (void*)_value;
     public TResult* AsPtr<TResult>() where TResult : unmanaged => (TResult*)_value;
     public IntPtr AsIntPtr() => (IntPtr)AsPtr();
@@ -21,14 +21,14 @@ public readonly unsafe struct VoidPtr
 /// <typeparam name="T">Type this pointer may be resolved to.</typeparam>
 public readonly unsafe struct CPtr<T> where T : unmanaged
 {
-    private readonly IntPtr _value;
+    private readonly long _value;
 
-    private CPtr(IntPtr value)
+    private CPtr(long value)
     {
         _value = value;
     }
 
-    public static implicit operator CPtr<T>(T* ptr) => new((IntPtr)ptr);
+    public static implicit operator CPtr<T>(T* ptr) => new((long)ptr);
     public T* AsPtr() => (T*)_value;
     public TResult* AsPtr<TResult>() where TResult : unmanaged => (TResult*)_value;
     public IntPtr AsIntPtr() => (IntPtr)AsPtr();

--- a/Cesium.Runtime/VoidPtr.cs
+++ b/Cesium.Runtime/VoidPtr.cs
@@ -3,14 +3,14 @@ namespace Cesium.Runtime;
 /// <summary>A class encapsulating an opaque pointer (aka <code>void*</code> in C).</summary>
 public readonly unsafe struct VoidPtr
 {
-    private readonly long _value;
+    private readonly IntPtr _value;
 
-    private VoidPtr(long value)
+    private VoidPtr(IntPtr value)
     {
         _value = value;
     }
 
-    public static implicit operator VoidPtr(void* ptr) => new((long)ptr);
+    public static implicit operator VoidPtr(void* ptr) => new((IntPtr)ptr);
     public void* AsPtr() => (void*)_value;
     public TResult* AsPtr<TResult>() where TResult : unmanaged => (TResult*)_value;
     public IntPtr AsIntPtr() => (IntPtr)AsPtr();
@@ -21,14 +21,14 @@ public readonly unsafe struct VoidPtr
 /// <typeparam name="T">Type this pointer may be resolved to.</typeparam>
 public readonly unsafe struct CPtr<T> where T : unmanaged
 {
-    private readonly long _value;
+    private readonly IntPtr _value;
 
-    private CPtr(long value)
+    private CPtr(IntPtr value)
     {
         _value = value;
     }
 
-    public static implicit operator CPtr<T>(T* ptr) => new((long)ptr);
+    public static implicit operator CPtr<T>(T* ptr) => new((IntPtr)ptr);
     public T* AsPtr() => (T*)_value;
     public TResult* AsPtr<TResult>() where TResult : unmanaged => (TResult*)_value;
     public IntPtr AsIntPtr() => (IntPtr)AsPtr();


### PR DESCRIPTION
A FuncPtr can now be turned into a corresponding Delegate and also a Delegate can be turned into a FuncPtr.
You can also use UTF8String instead of byte*. This is more convenient and it contains the fastest implementations of some methods for the corresponding .Net versions.