### PR TITLE
[sdk]: Possible fix missing/outdated artifacts before compiler packing

### DIFF
--- a/build/Build.Sdk.cs
+++ b/build/Build.Sdk.cs
@@ -14,6 +14,7 @@ public partial class Build
     const string _compilerBundlePackagePrefix = "Cesium.Compiler.Bundle";
 
     Target PublishAllCompilerBundles => _ => _
+        .DependsOn(CompileAll)
         .Executes(() =>
         {
             var compilerProject = Solution.Cesium_Compiler.GetMSBuildProject();
@@ -27,6 +28,7 @@ public partial class Build
         });
 
     Target PublishCompilerBundle => _ => _
+        .DependsOn(CompileAll)
         .Executes(() =>
         {
             PublishCompiler(EffectiveRuntimeId);
@@ -54,6 +56,7 @@ public partial class Build
         });
 
     Target PackSdk => _ => _
+        .DependsOn(CompileAll)
         .Executes(() =>
         {
             var sdkProject = Solution.Cesium_Sdk.GetMSBuildProject();


### PR DESCRIPTION
Not sure about the root cause, but this may probably fix some weird issues when running compiler targets subsequently