### PR TITLE
fprintf: correctly process long prefix

### DIFF
--- a/Cesium.IntegrationTests/stdlib/printf.c
+++ b/Cesium.IntegrationTests/stdlib/printf.c
@@ -21,7 +21,7 @@ int main(int argc, char *argv[])
         return -4;
     }
 
-    // TODO: This test is not portable: on Windows, Cesium and MSVC use different sizes for long.
+    // TODO[#586]: This test is not portable: on Windows, Cesium and MSVC use different sizes for long.
     // int maxULongLengthInChars = sizeof(long) == 4 ? 10 : 20;
     // if (printf("%lu\n", -1L) != maxULongLengthInChars + 1) { // + 1 for \n
     //     return -5;

--- a/Cesium.IntegrationTests/stdlib/printf.c
+++ b/Cesium.IntegrationTests/stdlib/printf.c
@@ -21,9 +21,11 @@ int main(int argc, char *argv[])
         return -4;
     }
 
-    if (printf("%lu\n", -1) != 11) {
-        return -5;
-    }
+    // TODO: This test is not portable: on Windows, Cesium and MSVC use different sizes for long.
+    // int maxULongLengthInChars = sizeof(long) == 4 ? 10 : 20;
+    // if (printf("%lu\n", -1L) != maxULongLengthInChars + 1) { // + 1 for \n
+    //     return -5;
+    // }
 
     if (printf("%i\n", -1) != 3) {
         return -6;

--- a/Cesium.Runtime.Tests/StdIoFunctionTests.cs
+++ b/Cesium.Runtime.Tests/StdIoFunctionTests.cs
@@ -7,10 +7,28 @@ public class StdIoFunctionTests
     [Theory]
     [InlineData(9, "0x09")]
     [InlineData(32, "0x20")]
-    public unsafe void FPrintFHex(long input, string expectedResult)
+    public void FPrintFHex(long input, string expectedResult)
     {
-        var format = Encoding.UTF8.GetBytes("0x%02x");
+        var (exitCode, result) = TestFPrintF("0x%02x", input);
+        Assert.Equal(expectedResult, result);
+        Assert.Equal(4, exitCode);
+    }
 
+    [Theory]
+    [InlineData(-1L, "%li", 2, "-1")]
+    [InlineData(-1L, "%lu", 20, "18446744073709551615")]
+    public void FPrintFLong(long input, string format, int expectedExitCode, string expectedResult)
+    {
+        var (exitCode, result) = TestFPrintF(format, input);
+        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedExitCode, exitCode);
+    }
+
+    private static unsafe (int, string) TestFPrintF(string format, long input)
+    {
+        var formatEncoded = Encoding.UTF8.GetBytes(format);
+
+        int exitCode;
         using var buffer = new MemoryStream();
         var handleIndex = StdIoFunctions.Handles.Count;
         try
@@ -24,9 +42,9 @@ public class StdIoFunctionTests
             };
 
             StdIoFunctions.Handles.Add(handle);
-            fixed (byte* formatPtr = format)
+            fixed (byte* formatPtr = formatEncoded)
             {
-                Assert.Equal(4, StdIoFunctions.FPrintF((void*)handleIndex, formatPtr, &input));
+                exitCode = StdIoFunctions.FPrintF((void*)handleIndex, formatPtr, &input);
             }
         }
         finally
@@ -34,7 +52,6 @@ public class StdIoFunctionTests
             StdIoFunctions.Handles.RemoveAt(handleIndex);
         }
 
-        var result = Encoding.UTF8.GetString(buffer.ToArray());
-        Assert.Equal(expectedResult, result);
+        return (exitCode, Encoding.UTF8.GetString(buffer.ToArray()));
     }
 }

--- a/Cesium.Runtime/StdIoFunctions.cs
+++ b/Cesium.Runtime/StdIoFunctions.cs
@@ -298,7 +298,6 @@ public unsafe static class StdIoFunctions
                 case "d":
                 case "ld":
                 case "i":
-                case "li":
                     int intValue = (int)((long*)varargs)[consumedArgs];
                     var intValueString = intValue.ToString();
                     if (alwaysSign && intValue > 0)
@@ -319,16 +318,45 @@ public unsafe static class StdIoFunctions
                     consumedBytes += intValueString.Length;
                     consumedArgs++;
                     break;
-                case "u":
-                case "lu":
+                case "li":
+                    long longValue = ((long*)varargs)[consumedArgs];
+                    var longValueString = longValue.ToString();
+                    if (alwaysSign && longValue > 0)
                     {
-                        uint uintValue = (uint)((long*)varargs)[consumedArgs];
-                        var uintValueString = uintValue.ToString();
-                        streamWriter.Write(uintValueString);
-                        consumedBytes += uintValueString.Length;
-                        consumedArgs++;
-                        break;
+                        streamWriter.Write('+');
                     }
+
+                    if (longValueString.Length < precision)
+                    {
+                        streamWriter.Write(new string('0', precision - longValueString.Length));
+                    }
+
+                    if (precision != 0 || longValue != 0)
+                    {
+                        streamWriter.Write(longValueString);
+                    }
+
+                    consumedBytes += longValueString.Length;
+                    consumedArgs++;
+                    break;
+                case "u":
+                {
+                    uint uintValue = (uint)((long*)varargs)[consumedArgs];
+                    var uintValueString = uintValue.ToString();
+                    streamWriter.Write(uintValueString);
+                    consumedBytes += uintValueString.Length;
+                    consumedArgs++;
+                    break;
+                }
+                case "lu":
+                {
+                    ulong ulongValue = (ulong)((long*)varargs)[consumedArgs];
+                    var ulongValueString = ulongValue.ToString();
+                    streamWriter.Write(ulongValueString);
+                    consumedBytes += ulongValueString.Length;
+                    consumedArgs++;
+                    break;
+                }
                 case "f":
                     {
                         var floatNumber = ((double*)varargs)[consumedArgs];


### PR DESCRIPTION
1. I've updated our handling for `%lu` and `%li` to process argument as `long`, according to the standard.
2. Tests on Mac have started failing recently: it looks like Apple's GCC changed its mind on `long`'s size (?!): before, it was treating `%lu` as a prefix for a `uint32_t`, and now it's `uint64_t`.

   (WTF, seriously.)

As a result, the test is currently not portable, so I'll comment it out and file an issue to fix it in a portable way.

Just another that Cesium programs for now use the same behavior on all the systems and expose `long` as `int64_t`.