### PR TITLE
Fix bug with codegeneration with forward declaration

### DIFF
--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.MegaUnionDefinition.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.MegaUnionDefinition.verified.txt
@@ -5,17 +5,17 @@
       Locals:
         <typedef>foo V_0
       IL_0000: ldloca.s V_0
-      IL_0002: ldflda _Union__ <typedef>foo::_Union__
-      IL_0007: ldflda _Union_Int_x1_Float_x2__ _Union__::_Union_Int_x1_Float_x2__
-      IL_000c: ldflda _Union_Int_x2_Float_f2__ _Union_Int_x1_Float_x2__::_Union_Int_x2_Float_f2__
-      IL_0011: ldflda _Union_Int_x3_Float_f3__ _Union_Int_x2_Float_f2__::_Union_Int_x3_Float_f3__
-      IL_0016: ldflda _Union_Int_x4_Float_f4 _Union_Int_x3_Float_f3__::_Union_Int_x4_Float_f4
+      IL_0002: ldflda <typedef>_Union__ <typedef>foo::_Union__
+      IL_0007: ldflda <typedef>_Union_Int_x1_Float_x2__ <typedef>_Union__::_Union_Int_x1_Float_x2__
+      IL_000c: ldflda <typedef>_Union_Int_x2_Float_f2__ <typedef>_Union_Int_x1_Float_x2__::_Union_Int_x2_Float_f2__
+      IL_0011: ldflda <typedef>_Union_Int_x3_Float_f3__ <typedef>_Union_Int_x2_Float_f2__::_Union_Int_x3_Float_f3__
+      IL_0016: ldflda <typedef>_Union_Int_x4_Float_f4 <typedef>_Union_Int_x3_Float_f3__::_Union_Int_x4_Float_f4
       IL_001b: ldc.r4 5.2
-      IL_0020: stfld System.Single _Union_Int_x4_Float_f4::f4
+      IL_0020: stfld System.Single <typedef>_Union_Int_x4_Float_f4::f4
       IL_0025: ldloca.s V_0
-      IL_0027: ldflda _Union__ <typedef>foo::_Union__
-      IL_002c: ldflda _Union_Int_x1_Float_x2__ _Union__::_Union_Int_x1_Float_x2__
-      IL_0031: ldfld System.Single _Union_Int_x1_Float_x2__::x2
+      IL_0027: ldflda <typedef>_Union__ <typedef>foo::_Union__
+      IL_002c: ldflda <typedef>_Union_Int_x1_Float_x2__ <typedef>_Union__::_Union_Int_x1_Float_x2__
+      IL_0031: ldfld System.Single <typedef>_Union_Int_x1_Float_x2__::x2
       IL_0036: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
@@ -30,31 +30,31 @@
 
   Type: <typedef>foo
   Fields:
-    _Union__ <typedef>foo::_Union__
+    <typedef>_Union__ <typedef>foo::_Union__
 
-  Type: _Union_Int_x4_Float_f4
+  Type: <typedef>_Union__
   Fields:
-    System.Int32 _Union_Int_x4_Float_f4::x4
-    System.Single _Union_Int_x4_Float_f4::f4
+    <typedef>_Union_Int_x1_Float_x2__ <typedef>_Union__::_Union_Int_x1_Float_x2__
 
-  Type: _Union_Int_x3_Float_f3__
+  Type: <typedef>_Union_Int_x1_Float_x2__
   Fields:
-    System.Int32 _Union_Int_x3_Float_f3__::x3
-    System.Single _Union_Int_x3_Float_f3__::f3
-    _Union_Int_x4_Float_f4 _Union_Int_x3_Float_f3__::_Union_Int_x4_Float_f4
+    System.Int32 <typedef>_Union_Int_x1_Float_x2__::x1
+    System.Single <typedef>_Union_Int_x1_Float_x2__::x2
+    <typedef>_Union_Int_x2_Float_f2__ <typedef>_Union_Int_x1_Float_x2__::_Union_Int_x2_Float_f2__
 
-  Type: _Union_Int_x2_Float_f2__
+  Type: <typedef>_Union_Int_x2_Float_f2__
   Fields:
-    System.Int32 _Union_Int_x2_Float_f2__::x2
-    System.Single _Union_Int_x2_Float_f2__::f2
-    _Union_Int_x3_Float_f3__ _Union_Int_x2_Float_f2__::_Union_Int_x3_Float_f3__
+    System.Int32 <typedef>_Union_Int_x2_Float_f2__::x2
+    System.Single <typedef>_Union_Int_x2_Float_f2__::f2
+    <typedef>_Union_Int_x3_Float_f3__ <typedef>_Union_Int_x2_Float_f2__::_Union_Int_x3_Float_f3__
 
-  Type: _Union_Int_x1_Float_x2__
+  Type: <typedef>_Union_Int_x3_Float_f3__
   Fields:
-    System.Int32 _Union_Int_x1_Float_x2__::x1
-    System.Single _Union_Int_x1_Float_x2__::x2
-    _Union_Int_x2_Float_f2__ _Union_Int_x1_Float_x2__::_Union_Int_x2_Float_f2__
+    System.Int32 <typedef>_Union_Int_x3_Float_f3__::x3
+    System.Single <typedef>_Union_Int_x3_Float_f3__::f3
+    <typedef>_Union_Int_x4_Float_f4 <typedef>_Union_Int_x3_Float_f3__::_Union_Int_x4_Float_f4
 
-  Type: _Union__
+  Type: <typedef>_Union_Int_x4_Float_f4
   Fields:
-    _Union_Int_x1_Float_x2__ _Union__::_Union_Int_x1_Float_x2__
+    System.Int32 <typedef>_Union_Int_x4_Float_f4::x4
+    System.Single <typedef>_Union_Int_x4_Float_f4::f4

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.MultipleFieldStructWithUnionDefinition.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.MultipleFieldStructWithUnionDefinition.verified.txt
@@ -4,9 +4,9 @@
   Type: <typedef>foo
   Fields:
     System.Int64 <typedef>foo::l
-    _Union_Int_x_Float_f <typedef>foo::_Union_Int_x_Float_f
+    <typedef>_Union_Int_x_Float_f <typedef>foo::_Union_Int_x_Float_f
 
-  Type: _Union_Int_x_Float_f
+  Type: <typedef>_Union_Int_x_Float_f
   Fields:
-    System.Int32 _Union_Int_x_Float_f::x
-    System.Single _Union_Int_x_Float_f::f
+    System.Int32 <typedef>_Union_Int_x_Float_f::x
+    System.Single <typedef>_Union_Int_x_Float_f::f

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.SingleFieldStructWithUnionDefinition.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.SingleFieldStructWithUnionDefinition.verified.txt
@@ -5,12 +5,12 @@
       Locals:
         <typedef>foo V_0
       IL_0000: ldloca.s V_0
-      IL_0002: ldflda _Union_Int_x_Float_f <typedef>foo::_Union_Int_x_Float_f
+      IL_0002: ldflda <typedef>_Union_Int_x_Float_f <typedef>foo::_Union_Int_x_Float_f
       IL_0007: ldc.r4 5.2
-      IL_000c: stfld System.Single _Union_Int_x_Float_f::f
+      IL_000c: stfld System.Single <typedef>_Union_Int_x_Float_f::f
       IL_0011: ldloca.s V_0
-      IL_0013: ldflda _Union_Int_x_Float_f <typedef>foo::_Union_Int_x_Float_f
-      IL_0018: ldfld System.Int32 _Union_Int_x_Float_f::x
+      IL_0013: ldflda <typedef>_Union_Int_x_Float_f <typedef>foo::_Union_Int_x_Float_f
+      IL_0018: ldfld System.Int32 <typedef>_Union_Int_x_Float_f::x
       IL_001d: ret
 
     System.Int32 <Module>::<SyntheticEntrypoint>()
@@ -25,9 +25,9 @@
 
   Type: <typedef>foo
   Fields:
-    _Union_Int_x_Float_f <typedef>foo::_Union_Int_x_Float_f
+    <typedef>_Union_Int_x_Float_f <typedef>foo::_Union_Int_x_Float_f
 
-  Type: _Union_Int_x_Float_f
+  Type: <typedef>_Union_Int_x_Float_f
   Fields:
-    System.Int32 _Union_Int_x_Float_f::x
-    System.Single _Union_Int_x_Float_f::f
+    System.Int32 <typedef>_Union_Int_x_Float_f::x
+    System.Single <typedef>_Union_Int_x_Float_f::f

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructWithUnionsAndAnons.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.StructWithUnionsAndAnons.verified.txt
@@ -8,40 +8,40 @@
       IL_0002: ldc.i4.2
       IL_0003: stfld System.Int32 <typedef>foo::_1
       IL_0008: ldloca.s V_0
-      IL_000a: ldflda _Anon_Int__2a <typedef>foo::_Anon_Int__2a
+      IL_000a: ldflda <typedef>_Anon_Int__2a <typedef>foo::_Anon_Int__2a
       IL_000f: ldc.i4.s 10
-      IL_0011: stfld System.Int32 _Anon_Int__2a::_2a
+      IL_0011: stfld System.Int32 <typedef>_Anon_Int__2a::_2a
       IL_0016: ldloca.s V_0
-      IL_0018: ldflda _Union_Long__3u_Int__4u <typedef>foo::_Union_Long__3u_Int__4u
+      IL_0018: ldflda <typedef>_Union_Long__3u_Int__4u <typedef>foo::_Union_Long__3u_Int__4u
       IL_001d: ldc.i4.s 10
       IL_001f: conv.i8
-      IL_0020: stfld System.Int64 _Union_Long__3u_Int__4u::_3u
+      IL_0020: stfld System.Int64 <typedef>_Union_Long__3u_Int__4u::_3u
       IL_0025: ldloca.s V_0
-      IL_0027: ldflda _Union_Long__5u_Int__6u <typedef>foo::uni
+      IL_0027: ldflda <typedef>_Union_Long__5u_Int__6u <typedef>foo::uni
       IL_002c: ldc.i4.s 10
       IL_002e: conv.i8
-      IL_002f: stfld System.Int64 _Union_Long__5u_Int__6u::_5u
+      IL_002f: stfld System.Int64 <typedef>_Union_Long__5u_Int__6u::_5u
       IL_0034: ldloca.s V_0
-      IL_0036: ldflda _Anon_Int__7 <typedef>foo::s
+      IL_0036: ldflda <typedef>_Anon_Int__7 <typedef>foo::s
       IL_003b: ldc.i4.s 10
-      IL_003d: stfld System.Int32 _Anon_Int__7::_7
+      IL_003d: stfld System.Int32 <typedef>_Anon_Int__7::_7
       IL_0042: ldloca.s V_0
       IL_0044: ldfld System.Int32 <typedef>foo::_1
       IL_0049: ldloca.s V_0
-      IL_004b: ldflda _Anon_Int__2a <typedef>foo::_Anon_Int__2a
-      IL_0050: ldfld System.Int32 _Anon_Int__2a::_2a
+      IL_004b: ldflda <typedef>_Anon_Int__2a <typedef>foo::_Anon_Int__2a
+      IL_0050: ldfld System.Int32 <typedef>_Anon_Int__2a::_2a
       IL_0055: add
       IL_0056: ldloca.s V_0
-      IL_0058: ldflda _Union_Long__3u_Int__4u <typedef>foo::_Union_Long__3u_Int__4u
-      IL_005d: ldfld System.Int32 _Union_Long__3u_Int__4u::_4u
+      IL_0058: ldflda <typedef>_Union_Long__3u_Int__4u <typedef>foo::_Union_Long__3u_Int__4u
+      IL_005d: ldfld System.Int32 <typedef>_Union_Long__3u_Int__4u::_4u
       IL_0062: add
       IL_0063: ldloca.s V_0
-      IL_0065: ldflda _Union_Long__5u_Int__6u <typedef>foo::uni
-      IL_006a: ldfld System.Int32 _Union_Long__5u_Int__6u::_6u
+      IL_0065: ldflda <typedef>_Union_Long__5u_Int__6u <typedef>foo::uni
+      IL_006a: ldfld System.Int32 <typedef>_Union_Long__5u_Int__6u::_6u
       IL_006f: add
       IL_0070: ldloca.s V_0
-      IL_0072: ldflda _Anon_Int__7 <typedef>foo::s
-      IL_0077: ldfld System.Int32 _Anon_Int__7::_7
+      IL_0072: ldflda <typedef>_Anon_Int__7 <typedef>foo::s
+      IL_0077: ldfld System.Int32 <typedef>_Anon_Int__7::_7
       IL_007c: add
       IL_007d: ret
 
@@ -58,25 +58,25 @@
   Type: <typedef>foo
   Fields:
     System.Int32 <typedef>foo::_1
-    _Anon_Int__2a <typedef>foo::_Anon_Int__2a
-    _Union_Long__3u_Int__4u <typedef>foo::_Union_Long__3u_Int__4u
-    _Union_Long__5u_Int__6u <typedef>foo::uni
-    _Anon_Int__7 <typedef>foo::s
+    <typedef>_Anon_Int__2a <typedef>foo::_Anon_Int__2a
+    <typedef>_Union_Long__3u_Int__4u <typedef>foo::_Union_Long__3u_Int__4u
+    <typedef>_Union_Long__5u_Int__6u <typedef>foo::uni
+    <typedef>_Anon_Int__7 <typedef>foo::s
 
-  Type: _Anon_Int__2a
+  Type: <typedef>_Anon_Int__2a
   Fields:
-    System.Int32 _Anon_Int__2a::_2a
+    System.Int32 <typedef>_Anon_Int__2a::_2a
 
-  Type: _Union_Long__3u_Int__4u
+  Type: <typedef>_Union_Long__3u_Int__4u
   Fields:
-    System.Int64 _Union_Long__3u_Int__4u::_3u
-    System.Int32 _Union_Long__3u_Int__4u::_4u
+    System.Int64 <typedef>_Union_Long__3u_Int__4u::_3u
+    System.Int32 <typedef>_Union_Long__3u_Int__4u::_4u
 
-  Type: _Union_Long__5u_Int__6u
+  Type: <typedef>_Union_Long__5u_Int__6u
   Fields:
-    System.Int64 _Union_Long__5u_Int__6u::_5u
-    System.Int32 _Union_Long__5u_Int__6u::_6u
+    System.Int64 <typedef>_Union_Long__5u_Int__6u::_5u
+    System.Int32 <typedef>_Union_Long__5u_Int__6u::_6u
 
-  Type: _Anon_Int__7
+  Type: <typedef>_Anon_Int__7
   Fields:
-    System.Int32 _Anon_Int__7::_7
+    System.Int32 <typedef>_Anon_Int__7::_7

--- a/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.SuperHardStructInitialization.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenTypeTests.SuperHardStructInitialization.verified.txt
@@ -5,8 +5,8 @@
       Locals:
         Foo V_0
         Foo V_1
-        _Anon_Long__1_Long__2 V_2
-        _Anon_Long_he_Long_ha V_3
+        <typedef>_Anon_Long__1_Long__2 V_2
+        <typedef>_Anon_Long_he_Long_ha V_3
       IL_0000: ldloca V_1
       IL_0004: initobj Foo
       IL_000a: ldloca V_1
@@ -17,43 +17,43 @@
       IL_0019: stfld System.Int32 Foo::b
       IL_001e: ldloca V_1
       IL_0022: ldloca V_2
-      IL_0026: initobj _Anon_Long__1_Long__2
+      IL_0026: initobj <typedef>_Anon_Long__1_Long__2
       IL_002c: ldloca V_2
       IL_0030: ldc.i4.2
-      IL_0031: stfld System.Int64 _Anon_Long__1_Long__2::_1
+      IL_0031: stfld System.Int64 <typedef>_Anon_Long__1_Long__2::_1
       IL_0036: ldloca V_2
       IL_003a: ldc.i4.2
-      IL_003b: stfld System.Int64 _Anon_Long__1_Long__2::_2
+      IL_003b: stfld System.Int64 <typedef>_Anon_Long__1_Long__2::_2
       IL_0040: ldloc V_2
-      IL_0044: stfld _Anon_Long__1_Long__2 Foo::inner
+      IL_0044: stfld <typedef>_Anon_Long__1_Long__2 Foo::inner
       IL_0049: ldloca V_1
       IL_004d: ldloca V_3
-      IL_0051: initobj _Anon_Long_he_Long_ha
+      IL_0051: initobj <typedef>_Anon_Long_he_Long_ha
       IL_0057: ldloca V_3
       IL_005b: ldc.i4.2
-      IL_005c: stfld System.Int64 _Anon_Long_he_Long_ha::he
+      IL_005c: stfld System.Int64 <typedef>_Anon_Long_he_Long_ha::he
       IL_0061: ldloca V_3
       IL_0065: ldc.i4.2
-      IL_0066: stfld System.Int64 _Anon_Long_he_Long_ha::ha
+      IL_0066: stfld System.Int64 <typedef>_Anon_Long_he_Long_ha::ha
       IL_006b: ldloc V_3
-      IL_006f: stfld _Anon_Long_he_Long_ha Foo::other_inner
+      IL_006f: stfld <typedef>_Anon_Long_he_Long_ha Foo::other_inner
       IL_0074: ldloca V_1
-      IL_0078: ldflda _Anon_Int_anon_int Foo::_Anon_Int_anon_int
+      IL_0078: ldflda <typedef>_Anon_Int_anon_int Foo::_Anon_Int_anon_int
       IL_007d: ldc.i4.5
-      IL_007e: stfld System.Int32 _Anon_Int_anon_int::anon_int
+      IL_007e: stfld System.Int32 <typedef>_Anon_Int_anon_int::anon_int
       IL_0083: ldloca V_1
-      IL_0087: ldflda _Union_Int_integer_Float_f Foo::_Union_Int_integer_Float_f
+      IL_0087: ldflda <typedef>_Union_Int_integer_Float_f Foo::_Union_Int_integer_Float_f
       IL_008c: ldc.i4.5
-      IL_008d: stfld System.Int32 _Union_Int_integer_Float_f::integer
+      IL_008d: stfld System.Int32 <typedef>_Union_Int_integer_Float_f::integer
       IL_0092: ldloca V_1
-      IL_0096: ldflda _Union_Int_not_anon_Float_its Foo::named_union
+      IL_0096: ldflda <typedef>_Union_Int_not_anon_Float_its Foo::named_union
       IL_009b: ldc.i4.s 10
-      IL_009d: stfld System.Int32 _Union_Int_not_anon_Float_its::not_anon
+      IL_009d: stfld System.Int32 <typedef>_Union_Int_not_anon_Float_its::not_anon
       IL_00a2: ldloca V_1
-      IL_00a6: ldflda _Anon__level_2 Foo::level_1
-      IL_00ab: ldflda _Anon_Int_level_3 _Anon__level_2::level_2
+      IL_00a6: ldflda <typedef>_Anon__level_2 Foo::level_1
+      IL_00ab: ldflda <typedef>_Anon_Int_level_3 <typedef>_Anon__level_2::level_2
       IL_00b0: ldc.i4.s 10
-      IL_00b2: stfld System.Int32 _Anon_Int_level_3::level_3
+      IL_00b2: stfld System.Int32 <typedef>_Anon_Int_level_3::level_3
       IL_00b7: ldloc V_1
       IL_00bb: stloc.0
       IL_00bc: ldloca.s V_0
@@ -63,40 +63,40 @@
       IL_00ca: add
       IL_00cb: conv.i8
       IL_00cc: ldloca.s V_0
-      IL_00ce: ldflda _Anon_Long__1_Long__2 Foo::inner
-      IL_00d3: ldfld System.Int64 _Anon_Long__1_Long__2::_1
+      IL_00ce: ldflda <typedef>_Anon_Long__1_Long__2 Foo::inner
+      IL_00d3: ldfld System.Int64 <typedef>_Anon_Long__1_Long__2::_1
       IL_00d8: add
       IL_00d9: ldloca.s V_0
-      IL_00db: ldflda _Anon_Long__1_Long__2 Foo::inner
-      IL_00e0: ldfld System.Int64 _Anon_Long__1_Long__2::_2
+      IL_00db: ldflda <typedef>_Anon_Long__1_Long__2 Foo::inner
+      IL_00e0: ldfld System.Int64 <typedef>_Anon_Long__1_Long__2::_2
       IL_00e5: add
       IL_00e6: ldloca.s V_0
-      IL_00e8: ldflda _Anon_Long_he_Long_ha Foo::other_inner
-      IL_00ed: ldfld System.Int64 _Anon_Long_he_Long_ha::ha
+      IL_00e8: ldflda <typedef>_Anon_Long_he_Long_ha Foo::other_inner
+      IL_00ed: ldfld System.Int64 <typedef>_Anon_Long_he_Long_ha::ha
       IL_00f2: add
       IL_00f3: ldloca.s V_0
-      IL_00f5: ldflda _Anon_Long_he_Long_ha Foo::other_inner
-      IL_00fa: ldfld System.Int64 _Anon_Long_he_Long_ha::he
+      IL_00f5: ldflda <typedef>_Anon_Long_he_Long_ha Foo::other_inner
+      IL_00fa: ldfld System.Int64 <typedef>_Anon_Long_he_Long_ha::he
       IL_00ff: add
       IL_0100: ldloca.s V_0
-      IL_0102: ldflda _Anon__level_2 Foo::level_1
-      IL_0107: ldflda _Anon_Int_level_3 _Anon__level_2::level_2
-      IL_010c: ldfld System.Int32 _Anon_Int_level_3::level_3
+      IL_0102: ldflda <typedef>_Anon__level_2 Foo::level_1
+      IL_0107: ldflda <typedef>_Anon_Int_level_3 <typedef>_Anon__level_2::level_2
+      IL_010c: ldfld System.Int32 <typedef>_Anon_Int_level_3::level_3
       IL_0111: conv.i8
       IL_0112: add
       IL_0113: ldloca.s V_0
-      IL_0115: ldflda _Union_Int_not_anon_Float_its Foo::named_union
-      IL_011a: ldfld System.Int32 _Union_Int_not_anon_Float_its::not_anon
+      IL_0115: ldflda <typedef>_Union_Int_not_anon_Float_its Foo::named_union
+      IL_011a: ldfld System.Int32 <typedef>_Union_Int_not_anon_Float_its::not_anon
       IL_011f: conv.i8
       IL_0120: add
       IL_0121: ldloca.s V_0
-      IL_0123: ldflda _Anon_Int_anon_int Foo::_Anon_Int_anon_int
-      IL_0128: ldfld System.Int32 _Anon_Int_anon_int::anon_int
+      IL_0123: ldflda <typedef>_Anon_Int_anon_int Foo::_Anon_Int_anon_int
+      IL_0128: ldfld System.Int32 <typedef>_Anon_Int_anon_int::anon_int
       IL_012d: conv.i8
       IL_012e: add
       IL_012f: ldloca.s V_0
-      IL_0131: ldflda _Union_Int_integer_Float_f Foo::_Union_Int_integer_Float_f
-      IL_0136: ldfld System.Int32 _Union_Int_integer_Float_f::integer
+      IL_0131: ldflda <typedef>_Union_Int_integer_Float_f Foo::_Union_Int_integer_Float_f
+      IL_0136: ldfld System.Int32 <typedef>_Union_Int_integer_Float_f::integer
       IL_013b: conv.i8
       IL_013c: add
       IL_013d: ret
@@ -115,41 +115,41 @@
   Fields:
     System.Int32 Foo::a
     System.Int32 Foo::b
-    _Anon_Long__1_Long__2 Foo::inner
-    _Anon_Long_he_Long_ha Foo::other_inner
-    _Union_Int_integer_Float_f Foo::_Union_Int_integer_Float_f
-    _Anon_Int_anon_int Foo::_Anon_Int_anon_int
-    _Union_Int_not_anon_Float_its Foo::named_union
-    _Anon__level_2 Foo::level_1
+    <typedef>_Anon_Long__1_Long__2 Foo::inner
+    <typedef>_Anon_Long_he_Long_ha Foo::other_inner
+    <typedef>_Union_Int_integer_Float_f Foo::_Union_Int_integer_Float_f
+    <typedef>_Anon_Int_anon_int Foo::_Anon_Int_anon_int
+    <typedef>_Union_Int_not_anon_Float_its Foo::named_union
+    <typedef>_Anon__level_2 Foo::level_1
 
-  Type: _Anon_Long__1_Long__2
+  Type: <typedef>_Anon_Long__1_Long__2
   Fields:
-    System.Int64 _Anon_Long__1_Long__2::_1
-    System.Int64 _Anon_Long__1_Long__2::_2
+    System.Int64 <typedef>_Anon_Long__1_Long__2::_1
+    System.Int64 <typedef>_Anon_Long__1_Long__2::_2
 
-  Type: _Anon_Long_he_Long_ha
+  Type: <typedef>_Anon_Long_he_Long_ha
   Fields:
-    System.Int64 _Anon_Long_he_Long_ha::he
-    System.Int64 _Anon_Long_he_Long_ha::ha
+    System.Int64 <typedef>_Anon_Long_he_Long_ha::he
+    System.Int64 <typedef>_Anon_Long_he_Long_ha::ha
 
-  Type: _Union_Int_integer_Float_f
+  Type: <typedef>_Union_Int_integer_Float_f
   Fields:
-    System.Int32 _Union_Int_integer_Float_f::integer
-    System.Single _Union_Int_integer_Float_f::f
+    System.Int32 <typedef>_Union_Int_integer_Float_f::integer
+    System.Single <typedef>_Union_Int_integer_Float_f::f
 
-  Type: _Anon_Int_anon_int
+  Type: <typedef>_Anon_Int_anon_int
   Fields:
-    System.Int32 _Anon_Int_anon_int::anon_int
+    System.Int32 <typedef>_Anon_Int_anon_int::anon_int
 
-  Type: _Union_Int_not_anon_Float_its
+  Type: <typedef>_Union_Int_not_anon_Float_its
   Fields:
-    System.Int32 _Union_Int_not_anon_Float_its::not_anon
-    System.Single _Union_Int_not_anon_Float_its::its
+    System.Int32 <typedef>_Union_Int_not_anon_Float_its::not_anon
+    System.Single <typedef>_Union_Int_not_anon_Float_its::its
 
-  Type: _Anon_Int_level_3
+  Type: <typedef>_Anon__level_2
   Fields:
-    System.Int32 _Anon_Int_level_3::level_3
+    <typedef>_Anon_Int_level_3 <typedef>_Anon__level_2::level_2
 
-  Type: _Anon__level_2
+  Type: <typedef>_Anon_Int_level_3
   Fields:
-    _Anon_Int_level_3 _Anon__level_2::level_2
+    System.Int32 <typedef>_Anon_Int_level_3::level_3

--- a/Cesium.CodeGen/Contexts/AssemblyContext.cs
+++ b/Cesium.CodeGen/Contexts/AssemblyContext.cs
@@ -330,17 +330,33 @@ public class AssemblyContext
         return field;
     }
 
-    internal void GenerateType(TranslationUnitContext context, string name, IGeneratedType type)
+    internal void GenerateType(TranslationUnitContext context, string name, StructType type)
     {
         if (!_generatedTypes.ContainsKey(type))
         {
             var typeReference = type.StartEmit(name, context);
             _generatedTypes.Add(type, typeReference);
+            foreach (var member in type.Members)
+            {
+                if (member.Type is StructType structType)
+                {
+                    structType.EmitType(context);
+                }
+
+                if (member.Type is Ir.Types.PointerType { Base: StructType structTypePtr })
+                {
+                    structTypePtr.EmitType(context);
+                }
+            }
+
             type.FinishEmit(typeReference, name, context);
         }
     }
 
-    internal TypeReference? GetTypeReference(IGeneratedType type) => _generatedTypes.GetValueOrDefault(type);
+    internal TypeReference? GetTypeReference(IGeneratedType type)
+    {
+        return _generatedTypes.GetValueOrDefault(type);
+    }
 
     private struct ByteArrayWrapper
     {

--- a/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
+++ b/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
@@ -101,7 +101,7 @@ public class TranslationUnitContext
 
     internal void GenerateType(string name, IGeneratedType type)
     {
-        AssemblyContext.GenerateType(this, name, type);
+        AssemblyContext.GenerateType(this, name, (StructType)type);
     }
 
     internal void AddTypeDefinition(string name, IType type)

--- a/Cesium.CodeGen/Ir/Expressions/Values/LValueInstanceField.cs
+++ b/Cesium.CodeGen/Ir/Expressions/Values/LValueInstanceField.cs
@@ -136,7 +136,8 @@ internal sealed class LValueInstanceField : LValueField
                 var resolved = field.FieldType.Resolve();
                 if (resolved == null) continue;
                 if (resolved.IsPrimitive) continue; // They don't have fields, so skip them
-                if ((resolved.Name.StartsWith("_Union_") || resolved.Name.StartsWith("_Anon_")) && RecursiveBuildPath(fieldName, field, list))
+                if ((resolved.Name.StartsWith("<typedef>_Union_") || resolved.Name.StartsWith("<typedef>_Anon_") || resolved.Name.StartsWith("_Union_") || resolved.Name.StartsWith("_Anon_"))
+                    && RecursiveBuildPath(fieldName, field, list))
                 {
                     list.Add(field);
                     return true;

--- a/Cesium.IntegrationTests/structs/structs_forward_declarations.c
+++ b/Cesium.IntegrationTests/structs/structs_forward_declarations.c
@@ -1,0 +1,16 @@
+typedef struct FwDeclared FwDeclared;
+
+typedef struct Decl Decl;
+struct Decl {
+    int x;
+};
+
+struct FwDeclared {
+    Decl var;
+};
+
+int main(void) 
+{
+  struct FwDeclared fw;
+  return 42;
+}


### PR DESCRIPTION
when type was forward declared before child type which used inside that declared type later on, codegen was broken. This lead to simplification of the struct emit, since no need to special case anon types. This lead to changes in naming which I think is reasonable, since that way always anon types prefixed with <typedef>