### PR TITLE
Distinguish identifiers and indirection which detected as typecasts

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenBinaryExpressionTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenBinaryExpressionTests.cs
@@ -18,4 +18,38 @@ public class CodeGenBinaryExpressionTests : CodeGenTestBase
 
     [Fact]
     public Task SumIntAndBool() => DoTest(@"int main() { _Bool x = 1; _Bool y = 1; int r = 1 + (x == y); }");
+
+    [Fact]
+    public Task ConversionForConst() => DoTest(@"int main() { unsigned char x = 1; const unsigned char y = 1; int r = x + y; }");
+
+    [Fact]
+    public Task IdentifierInBrackets() => DoTest(
+        """
+        void test() {
+          char s = 1;
+          char t = (s) + 1;
+        }        
+        """
+        );
+
+    [Fact]
+    public Task ArrayIndexerInBrackets() => DoTest(
+        """
+        void test() {
+          char* s = "123";
+          char t = (s[0]) + 1;
+        }        
+        """
+        );
+
+    // *1 here thought by compiler as indirection.
+    [Fact]
+    public Task ArrayIndexerInBracketsAfterMultiply() => DoTest(
+        """
+        void test() {
+          char* s = "123";
+          char t = (s[0]) * 1;
+        }        
+        """
+        );
 }

--- a/Cesium.CodeGen.Tests/verified/CodeGenBinaryExpressionTests.ArrayIndexerInBrackets.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenBinaryExpressionTests.ArrayIndexerInBrackets.verified.txt
@@ -1,0 +1,18 @@
+﻿System.Void <Module>::test()
+  Locals:
+    System.Byte* V_0
+    System.Byte V_1
+  IL_0000: ldsflda <ConstantPool>/<ConstantPoolItemType4> <ConstantPool>::ConstDataBuffer0
+  IL_0005: stloc.0
+  IL_0006: ldloc.0
+  IL_0007: ldc.i4.1
+  IL_0008: ldc.i4.0
+  IL_0009: mul
+  IL_000a: add
+  IL_000b: ldind.i1
+  IL_000c: conv.i4
+  IL_000d: ldc.i4.1
+  IL_000e: add
+  IL_000f: conv.u1
+  IL_0010: stloc.1
+  IL_0011: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenBinaryExpressionTests.ArrayIndexerInBracketsAfterMultiply.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenBinaryExpressionTests.ArrayIndexerInBracketsAfterMultiply.verified.txt
@@ -1,0 +1,14 @@
+﻿System.Void <Module>::test()
+  Locals:
+    System.Byte* V_0
+    System.Byte V_1
+  IL_0000: ldsflda <ConstantPool>/<ConstantPoolItemType4> <ConstantPool>::ConstDataBuffer0
+  IL_0005: stloc.0
+  IL_0006: ldloc.0
+  IL_0007: ldc.i4.1
+  IL_0008: ldc.i4.1
+  IL_0009: mul
+  IL_000a: add
+  IL_000b: ldind.i1
+  IL_000c: stloc.1
+  IL_000d: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenBinaryExpressionTests.ConversionForConst.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenBinaryExpressionTests.ConversionForConst.verified.txt
@@ -1,0 +1,27 @@
+System.Int32 <Module>::main()
+  Locals:
+    System.Byte V_0
+    System.Byte V_1
+    System.Int32 V_2
+  IL_0000: ldc.i4.1
+  IL_0001: conv.u1
+  IL_0002: stloc.0
+  IL_0003: ldc.i4.1
+  IL_0004: stloc.1
+  IL_0005: ldloc.0
+  IL_0006: ldloc.1
+  IL_0007: add
+  IL_0008: conv.i4
+  IL_0009: stloc.2
+  IL_000a: ldc.i4.0
+  IL_000b: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenBinaryExpressionTests.IdentifierInBrackets.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenBinaryExpressionTests.IdentifierInBrackets.verified.txt
@@ -1,0 +1,14 @@
+﻿System.Void <Module>::test()
+  Locals:
+    System.Byte V_0
+    System.Byte V_1
+  IL_0000: ldc.i4.1
+  IL_0001: conv.u1
+  IL_0002: stloc.0
+  IL_0003: ldloc.0
+  IL_0004: conv.i4
+  IL_0005: ldc.i4.1
+  IL_0006: add
+  IL_0007: conv.u1
+  IL_0008: stloc.1
+  IL_0009: ret

--- a/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BinaryOperatorExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/BinaryOperators/BinaryOperatorExpression.cs
@@ -60,7 +60,9 @@ internal sealed class BinaryOperatorExpression : IExpression
         }
 
         if (!Operator.IsComparison() || (leftType.IsNumeric() && rightType.IsNumeric() && !leftType.IsEnum() && !rightType.IsEnum() && !leftType.IsBool() && !rightType.IsBool()))
-        { 
+        {
+            leftType = leftType.EraseConstType();
+            rightType = rightType.EraseConstType();
             var commonType = TypeSystemEx.GetCommonNumericType(leftType, rightType);
             if (!leftType.IsEqualTo(commonType))
             {
@@ -175,6 +177,8 @@ internal sealed class BinaryOperatorExpression : IExpression
 
         // both bitwise and arithmetic operators obey same arithmetic conversions
         // https://en.cppreference.com/w/c/language/operator_arithmetic
+        leftType = leftType.EraseConstType();
+        rightType = rightType.EraseConstType();
         return TypeSystemEx.GetCommonNumericType(leftType, rightType);
     }
 

--- a/Cesium.CodeGen/Ir/Expressions/IndirectionExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/IndirectionExpression.cs
@@ -8,22 +8,22 @@ namespace Cesium.CodeGen.Ir.Expressions;
 
 internal sealed class IndirectionExpression : IExpression, IValueExpression
 {
-    private readonly IExpression _target;
+    internal IExpression Target { get; }
 
     public IndirectionExpression(IExpression target)
     {
-        _target = target;
+        Target = target;
     }
 
     internal IndirectionExpression(Ast.IndirectionExpression expression)
     {
         expression.Deconstruct(out var target);
-        _target = target.ToIntermediate();
+        Target = target.ToIntermediate();
     }
 
     public IExpression Lower(IDeclarationScope scope)
     {
-        var lowered = new IndirectionExpression(_target.Lower(scope));
+        var lowered = new IndirectionExpression(Target.Lower(scope));
         return new GetValueExpression(lowered.Resolve(scope));
     }
 
@@ -33,11 +33,11 @@ internal sealed class IndirectionExpression : IExpression, IValueExpression
 
     public IValue Resolve(IDeclarationScope scope)
     {
-        var targetType = _target.GetExpressionType(scope);
+        var targetType = Target.GetExpressionType(scope);
         return targetType switch
         {
-            InPlaceArrayType arrayType => new LValueIndirection(_target, new PointerType(arrayType.Base)),
-            PointerType pointerType => new LValueIndirection(_target, pointerType),
+            InPlaceArrayType arrayType => new LValueIndirection(Target, new PointerType(arrayType.Base)),
+            PointerType pointerType => new LValueIndirection(Target, pointerType),
             _ => throw new CompilationException($"Required a pointer or an array type, got {targetType} instead.")
         };
     }

--- a/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
@@ -19,7 +19,7 @@ internal sealed class SubscriptingExpression : IValueExpression
         _index = index.ToIntermediate();
     }
 
-    private SubscriptingExpression(IExpression expression, IExpression index)
+    public SubscriptingExpression(IExpression expression, IExpression index)
     {
         _expression = expression;
         _index = index;


### PR DESCRIPTION
Currently compiler do not know, if `(x)` is typecase or some identifier in the brackets, so we probe registered types. Also ignore constant specifiers when trying to find constant property on the type.