### PR TITLE
Add support for array of strings initialization.

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenArrayTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenArrayTests.cs
@@ -227,6 +227,17 @@ int main() {
 }");
 
     [Fact]
+    public Task ArrayStringComparison() => DoTest(@"
+int main() {
+    const char* a[1] = { ""A"" };
+    if (a[0]) {
+        return 0;
+    }
+
+    return 1;
+}"); 
+    
+    [Fact]
     public Task ConstExpressionSizeArrayTest() => DoTest(@"
 int main() {
     const char a[1 + 1] = { 255 };

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayStringComparison.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.ArrayStringComparison.verified.txt
@@ -1,0 +1,40 @@
+﻿System.Int32 <Module>::main()
+  Locals:
+    System.Byte** V_0
+  IL_0000: sizeof System.Byte*
+  IL_0006: ldc.i4.1
+  IL_0007: mul
+  IL_0008: conv.u
+  IL_0009: localloc
+  IL_000b: stloc.0
+  IL_000c: ldloc.0
+  IL_000d: ldc.i4.0
+  IL_000e: conv.i
+  IL_000f: sizeof System.Byte*
+  IL_0015: mul
+  IL_0016: add
+  IL_0017: ldsflda <ConstantPool>/<ConstantPoolItemType2> <ConstantPool>::ConstDataBuffer0
+  IL_001c: stind.i
+  IL_001d: ldloc.0
+  IL_001e: ldc.i4.0
+  IL_001f: conv.i
+  IL_0020: sizeof System.Byte*
+  IL_0026: mul
+  IL_0027: add
+  IL_0028: ldind.i
+  IL_0029: brfalse IL_0030
+  IL_002e: ldc.i4.0
+  IL_002f: ret
+  IL_0030: nop
+  IL_0031: ldc.i4.1
+  IL_0032: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen/Ir/BlockItems/InitializationBlockItem.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/InitializationBlockItem.cs
@@ -1,9 +1,0 @@
-using Cesium.CodeGen.Ir.Expressions;
-
-namespace Cesium.CodeGen.Ir.BlockItems;
-
-internal record InitializerPart(IExpression? PrimaryInitializer, IExpression? SecondaryInitializer);
-
-internal record InitializationBlockItem(ICollection<InitializerPart> Items) : IBlockItem
-{
-}

--- a/Cesium.CodeGen/Ir/ControlFlow/ControlFlowChecker.cs
+++ b/Cesium.CodeGen/Ir/ControlFlow/ControlFlowChecker.cs
@@ -32,7 +32,6 @@ internal sealed class ControlFlowChecker
         {
             case ExpressionStatement:
             case AmbiguousBlockItem:
-            case InitializationBlockItem:
                 return Atom();
             case LabelStatement label:
             {
@@ -207,7 +206,6 @@ internal sealed class ControlFlowChecker
             case AmbiguousBlockItem:
             case BreakStatement:
             case ContinueStatement:
-            case InitializationBlockItem:
             case TagBlockItem:
             case TypeDefBlockItem:
             case ReturnStatement:

--- a/Cesium.CodeGen/Ir/Emitting/BlockItemEmitting.cs
+++ b/Cesium.CodeGen/Ir/Emitting/BlockItemEmitting.cs
@@ -150,16 +150,6 @@ internal static class BlockItemEmitting
 
                 return;
             }
-            case InitializationBlockItem i:
-            {
-                foreach (var (primInt, secInt) in i.Items)
-                {
-                    primInt?.EmitTo(scope);
-                    secInt?.EmitTo(scope);
-                }
-
-                return;
-            }
             case LabelStatement s:
             {
                 var instruction = scope.ResolveLabel(s.Identifier);

--- a/Cesium.CodeGen/Ir/Expressions/CompoundInitializationExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/CompoundInitializationExpression.cs
@@ -9,18 +9,19 @@ namespace Cesium.CodeGen.Ir.Expressions;
 internal sealed class CompoundInitializationExpression : IExpression
 {
     private readonly IType _type;
-    private readonly ArrayInitializerExpression _arrayInitializer;
+
+    internal ArrayInitializerExpression ArrayInitializer { get; }
 
     public CompoundInitializationExpression(IType type, ArrayInitializerExpression arrayInitializer)
     {
         _type = type;
-        _arrayInitializer = arrayInitializer;
+        ArrayInitializer = arrayInitializer;
     }
 
     public void EmitTo(IEmitScope scope)
     {
         using var stream = new MemoryStream();
-        foreach (var i in _arrayInitializer.Initializers)
+        foreach (var i in ArrayInitializer.Initializers)
         {
             if (i is null)
                 throw new NotImplementedException("Empty initializer item reached");
@@ -107,5 +108,5 @@ internal sealed class CompoundInitializationExpression : IExpression
 
     public IType GetExpressionType(IDeclarationScope scope) => _type;
 
-    public IExpression Lower(IDeclarationScope scope) => new CompoundInitializationExpression(scope.ResolveType(_type), _arrayInitializer.InlineConstantExpressions(scope));
+    public IExpression Lower(IDeclarationScope scope) => new CompoundInitializationExpression(scope.ResolveType(_type), ArrayInitializer.InlineConstantExpressions(scope));
 }

--- a/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/SubscriptingExpression.cs
@@ -19,7 +19,7 @@ internal sealed class SubscriptingExpression : IValueExpression
         _index = index.ToIntermediate();
     }
 
-    private SubscriptingExpression(IExpression expression, IExpression index)
+    public SubscriptingExpression(IExpression expression, IExpression index)
     {
         _expression = expression;
         _index = index;


### PR DESCRIPTION
This was require removal of special block item Initialization, and replace it with regular CompoundBlockExpression. That allow us unroll initialization expression into set of assignment. Without that we cannot introduce struct initialization later on.