### PR TITLE
Add parsing of function specifiers

### DIFF
--- a/Cesium.Ast/Declarations.cs
+++ b/Cesium.Ast/Declarations.cs
@@ -49,6 +49,9 @@ public sealed record EnumDeclaration(string Identifier, Expression? Constant);
 // 6.7.3 Type qualifiers
 public sealed record TypeQualifier(string Name) : ISpecifierQualifierListItem;
 
+// 6.7.4 Function specifiers
+public sealed record FunctionSpecifier(string SpecifierType) : IDeclarationSpecifier;
+
 // 6.7.7 Type names
 public sealed record TypeName(SpecifierQualifierList SpecifierQualifierList, AbstractDeclarator? AbstractDeclarator = null);
 public sealed record AbstractDeclarator(Pointer? Pointer = null, IDirectAbstractDeclarator? DirectAbstractDeclarator = null);

--- a/Cesium.Parser.Tests/ParserTests/FullParserTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/FullParserTests.cs
@@ -192,4 +192,10 @@ int main(void) { foo x; x.x = 42; return 0; }");
 
     [Fact]
     public Task StaticFunction() => DoTest(@"static int foo() { return 123; }");
+
+    [Fact]
+    public Task InlineFunction() => DoTest(@"inline int foo() { return 123; }");
+
+    [Fact]
+    public Task NoReturnFunction() => DoTest(@"_Noreturn void foo() { }");
 }

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.InlineFunction.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.InlineFunction.verified.txt
@@ -1,0 +1,47 @@
+﻿{
+  "$type": "Cesium.Ast.TranslationUnit, Cesium.Ast",
+  "Declarations": [
+    {
+      "$type": "Cesium.Ast.FunctionDefinition, Cesium.Ast",
+      "Specifiers": [
+        {
+          "$type": "Cesium.Ast.FunctionSpecifier, Cesium.Ast",
+          "SpecifierType": "inline"
+        },
+        {
+          "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+          "TypeName": "int"
+        }
+      ],
+      "Declarator": {
+        "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+        "Pointer": null,
+        "DirectDeclarator": {
+          "$type": "Cesium.Ast.IdentifierListDirectDeclarator, Cesium.Ast",
+          "Base": {
+            "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+            "Identifier": "foo",
+            "Base": null
+          },
+          "Identifiers": null
+        }
+      },
+      "Declarations": null,
+      "Statement": {
+        "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",
+        "Block": [
+          {
+            "$type": "Cesium.Ast.ReturnStatement, Cesium.Ast",
+            "Expression": {
+              "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
+              "Constant": {
+                "Kind": "IntLiteral",
+                "Text": "123"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.NoReturnFunction.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.NoReturnFunction.verified.txt
@@ -1,0 +1,36 @@
+﻿{
+  "$type": "Cesium.Ast.TranslationUnit, Cesium.Ast",
+  "Declarations": [
+    {
+      "$type": "Cesium.Ast.FunctionDefinition, Cesium.Ast",
+      "Specifiers": [
+        {
+          "$type": "Cesium.Ast.FunctionSpecifier, Cesium.Ast",
+          "SpecifierType": "_Noreturn"
+        },
+        {
+          "$type": "Cesium.Ast.SimpleTypeSpecifier, Cesium.Ast",
+          "TypeName": "void"
+        }
+      ],
+      "Declarator": {
+        "$type": "Cesium.Ast.Declarator, Cesium.Ast",
+        "Pointer": null,
+        "DirectDeclarator": {
+          "$type": "Cesium.Ast.IdentifierListDirectDeclarator, Cesium.Ast",
+          "Base": {
+            "$type": "Cesium.Ast.IdentifierDirectDeclarator, Cesium.Ast",
+            "Identifier": "foo",
+            "Base": null
+          },
+          "Identifiers": null
+        }
+      },
+      "Declarations": null,
+      "Statement": {
+        "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",
+        "Block": []
+      }
+    }
+  ]
+}

--- a/Cesium.Parser/CParser.cs
+++ b/Cesium.Parser/CParser.cs
@@ -162,19 +162,11 @@ public partial class CParser
 
     // TODO[#207]: 6.5.3 Unary operators
     // unary-expression:
-    //    postfix-expression
+    //    _Alignof ( type-name )
     [Rule("unary_expression: '++' unary_expression")]
     [Rule("unary_expression: '--' unary_expression")]
     private static Expression MakePrefixIncrementExpression(ICToken prefixOperator, Expression target) =>
         new PrefixIncrementDecrementExpression(prefixOperator, target);
-
-    // TODO[#207]:
-    // unary-expression:
-    //    * unary-expression
-    //    unary-operator cast-expression
-    //    sizeof unary-expression
-    //    sizeof ( type-name )
-    //    _Alignof ( type-name )
 
     [Rule("unary_expression: '*' cast_expression")]
     private static Expression MakeIndirectionExpression(ICToken _, Expression target) =>
@@ -377,9 +369,13 @@ public partial class CParser
     [Rule("declaration_specifier: storage_class_specifier")]
     [Rule("declaration_specifier: type_specifier")]
     [Rule("declaration_specifier: type_qualifier")]
+    [Rule("declaration_specifier: function_specifier")]
     private static IDeclarationSpecifier MakeDeclarationSpecifier(IDeclarationSpecifier specifier) => specifier;
 
-    // TODO[#207]: [Rule("declaration_specifier: function_specifier")]
+    [Rule("function_specifier: KeywordInline")]
+    [Rule("function_specifier: KeywordNoReturn")]
+    private static IDeclarationSpecifier MakeFunctionSpecifier(ICToken token) => new FunctionSpecifier(token.Text);
+
     // TODO[#207]: [Rule("declaration_specifier: alignment_specifier")]
 
     [Rule("init_declarator_list: init_declarator")]


### PR DESCRIPTION
They are harless in a sense that we can not even implement them. Inline can be taken care by JIT, and _Noreturn would be handled later, since it requrie control flow analysys which we are barely have and don't have expertise at all.

Related #211
Closes #706