### PR TITLE
Support inline and noreturn in IR

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenMethodTests.cs
@@ -557,4 +557,7 @@ int main()
         return 1;
     }
 }");
+
+    [Fact]
+    public Task InlineFunction() => DoTest(@"inline int test () {return 1;} int main() { return 0; }");
 }

--- a/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.InlineFunction.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenMethodTests.InlineFunction.verified.txt
@@ -1,0 +1,17 @@
+﻿System.Int32 <Module>::test()
+  IL_0000: ldc.i4.1
+  IL_0001: ret
+
+System.Int32 <Module>::main()
+  IL_0000: ldc.i4.0
+  IL_0001: ret
+
+System.Int32 <Module>::<SyntheticEntrypoint>()
+  Locals:
+    System.Int32 V_0
+  IL_0000: call System.Int32 <Module>::main()
+  IL_0005: stloc.s V_0
+  IL_0007: ldloc.s V_0
+  IL_0009: call System.Void Cesium.Runtime.RuntimeHelpers::Exit(System.Int32)
+  IL_000e: ldloc.s V_0
+  IL_0010: ret

--- a/Cesium.CodeGen/Ir/Lowering/BlockItemLowering.cs
+++ b/Cesium.CodeGen/Ir/Lowering/BlockItemLowering.cs
@@ -411,7 +411,7 @@ internal static class BlockItemLowering
                     var newDeclaration = new FunctionInfo(parameters, returnType, d.StorageClass, IsDefined: true);
                     scope.DeclareFunction(d.Name, newDeclaration);
 
-                    return new FunctionDefinition(d.Name, d.StorageClass, resolvedFunctionType, d.Statement);
+                    return new FunctionDefinition(d.Name, d.StorageClass, resolvedFunctionType, d.Statement, d.Inline, d.NoReturn);
                 }
             case GlobalVariableDefinition d:
                 {


### PR DESCRIPTION
Since codegen of inline functions was not working in #705, then instead of just removing specifiers, I put them into IR, and let somebody utilize it if needed.