### PR TITLE
StreamHandle interop

### DIFF
--- a/Cesium.Runtime.Tests/StdIoFunctionTests.cs
+++ b/Cesium.Runtime.Tests/StdIoFunctionTests.cs
@@ -30,8 +30,8 @@ public class StdIoFunctionTests
         var formatEncoded = Encoding.UTF8.GetBytes(format);
 
         int exitCode;
+        var streamptr = (void*)IntPtr.Zero;
         using var buffer = new MemoryStream();
-        var streamptr = IntPtr.Zero;
         try
         {
             using var writer = new StreamWriter(buffer);
@@ -50,7 +50,7 @@ public class StdIoFunctionTests
         }
         finally
         {
-            StdIoFunctions.RemoveStream(streamptr);
+            StdIoFunctions.FreeStream(streamptr);
         }
 
         return (exitCode, Encoding.UTF8.GetString(buffer.ToArray()));

--- a/Cesium.Runtime.Tests/StdIoFunctionTests.cs
+++ b/Cesium.Runtime.Tests/StdIoFunctionTests.cs
@@ -31,7 +31,7 @@ public class StdIoFunctionTests
 
         int exitCode;
         using var buffer = new MemoryStream();
-        var handleIndex = StdIoFunctions.Handles.Count;
+        var streamptr = IntPtr.Zero;
         try
         {
             using var writer = new StreamWriter(buffer);
@@ -42,15 +42,15 @@ public class StdIoFunctionTests
                 Writer = () => writer
             };
 
-            StdIoFunctions.Handles.Add(handle);
+            streamptr = StdIoFunctions.AddStream(handle);
             fixed (byte* formatPtr = formatEncoded)
             {
-                exitCode = StdIoFunctions.FPrintF((void*)handleIndex, formatPtr, &input);
+                exitCode = StdIoFunctions.FPrintF((void*)streamptr, formatPtr, &input);
             }
         }
         finally
         {
-            StdIoFunctions.Handles.RemoveAt(handleIndex);
+            StdIoFunctions.RemoveStream(streamptr);
         }
 
         return (exitCode, Encoding.UTF8.GetString(buffer.ToArray()));

--- a/Cesium.Runtime/StdIoFunctions.cs
+++ b/Cesium.Runtime/StdIoFunctions.cs
@@ -698,7 +698,7 @@ public unsafe static class StdIoFunctions
             var gch = GCHandle.Alloc(stream);
             var handel = GCHandle.ToIntPtr(gch);
 
-            var ptr = Marshal.AllocHGlobal(sizeof(GCHandle));
+            var ptr = Marshal.AllocHGlobal(sizeof(IntPtr));
             Marshal.WriteIntPtr(ptr, handel);
             return ptr;
         }


### PR DESCRIPTION
Closes #681

GCHandles on StreamHandles are allocated on the unmanaged heap (`AllocHGlobal`). A pointer to the GCHandle is used to control the StreamHandler. Locks are also added for thread-safe interaction.

Keeps all standard streams (stdin, stdout, stderr) in list `Handles`