### PR TITLE
Simplify declarations

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenPrimitiveTypeTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenPrimitiveTypeTests.cs
@@ -29,10 +29,10 @@ public class CodeGenPrimitiveTypeTests : CodeGenTestBase
         var source = $"{typeString} x;";
         var parser = new CParser(new CLexer(source));
         var ast = parser.ParseDeclaration().Ok.Value;
-        var declarationInfo = (ScopedIdentifierDeclaration)IScopedDeclarationInfo.Of((Declaration)ast);
-        var item = declarationInfo.Items.Single();
+        var item = (ScopedIdentifierDeclaration)IScopedDeclarationInfo.Of((Declaration)ast).Single();
         var type = (PrimitiveType)item.Declaration.Type;
         Assert.Equal(expectedKind, type.Kind);
+        Assert.Equal(StorageClass.Auto, item.StorageClass);
     }
 
     [Fact]

--- a/Cesium.CodeGen/Extensions/BlockItemEx.cs
+++ b/Cesium.CodeGen/Extensions/BlockItemEx.cs
@@ -28,11 +28,12 @@ internal static class BlockItemEx
 
     private static IBlockItem ToIntermediate(Ast.Declaration d)
     {
-        return IScopedDeclarationInfo.Of(d) switch
+        return new CompoundStatement(IScopedDeclarationInfo.Of(d).Select(_ => _ switch
         {
-            ScopedIdentifierDeclaration declaration => new DeclarationBlockItem(declaration),
+            ScopedIdentifierDeclaration declaration => (IBlockItem)new DeclarationBlockItem(declaration),
             TypeDefDeclaration typeDefDeclaration => new TypeDefBlockItem(typeDefDeclaration),
             _ => throw new WipException(212, $"Unknown kind of declaration: {d}."),
-        };
+        }).ToList(), null)
+        { InheritScope = true };
     }
 }

--- a/Cesium.CodeGen/Ir/BlockItems/CompoundStatement.cs
+++ b/Cesium.CodeGen/Ir/BlockItems/CompoundStatement.cs
@@ -7,6 +7,8 @@ internal record CompoundStatement : IBlockItem
 {
     public IEmitScope? EmitScope { get; }
 
+    public bool InheritScope { get; set; }
+
     public CompoundStatement(List<IBlockItem> items, IEmitScope? emitScope = null)
     {
         EmitScope = emitScope;

--- a/Cesium.CodeGen/Ir/Lowering/BlockItemLowering.cs
+++ b/Cesium.CodeGen/Ir/Lowering/BlockItemLowering.cs
@@ -217,7 +217,7 @@ internal static class BlockItemLowering
                 }
             case CompoundStatement c:
                 {
-                    var blockScope = new BlockScope((IEmitScope)scope, null, null);
+                    var blockScope = c.InheritScope ? scope : new BlockScope((IEmitScope)scope, null, null);
 
                     var newNestedStatements = new List<IBlockItem>();
                     foreach (var stmt in c.Statements)
@@ -225,7 +225,7 @@ internal static class BlockItemLowering
                         newNestedStatements.Add(Lower(blockScope, stmt));
                     }
 
-                    return new CompoundStatement(newNestedStatements, blockScope);
+                    return new CompoundStatement(newNestedStatements, (IEmitScope)blockScope);
                 }
             case ContinueStatement:
                 {
@@ -234,10 +234,9 @@ internal static class BlockItemLowering
                 }
             case DeclarationBlockItem d:
                 {
-                    var (storageClass, items) = d.Declaration;
+                    var (storageClass, declaration, initializer) = d.Declaration;
                     var newItems = new List<IBlockItem>();
 
-                    foreach (var (declaration, initializer) in items)
                     {
                         var (type, identifier, cliImportMemberName) = declaration;
 
@@ -486,11 +485,9 @@ internal static class BlockItemLowering
                     var dbi = new DeclarationBlockItem(
                         new ScopedIdentifierDeclaration(
                             StorageClass.Auto,
-                            new List<InitializableDeclarationInfo>
-                            {
-                                new(new LocalDeclarationInfo(testExpression.GetExpressionType(scope), "$switch_tmp", null),
-                                testExpression)
-                            }));
+                            new LocalDeclarationInfo(testExpression.GetExpressionType(scope), "$switch_tmp", null),
+                            testExpression
+                        ));
 
                     targetStmts.Add(Lower(switchScope, dbi));
 


### PR DESCRIPTION
We somehow have 3 types of large IR structures, expressions, block items and declarations. If expression and block items is somewhat simple things, which follow rules, declaration is a thing in it's own which behave as block item, but do not have any lowering, even if they have tree structure. This simplifies declarations a bit, and remove nesting. Place multiple declarations into compound statement.

I'm not sure that this is last refactoring of this area, but at least this is gives idea of what should be done.