### PR TITLE
Decrease Microsoft.Build.Utilities.Core to 17.11.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,6 @@
     <PackageVersion Include="Yoakke.SynKit.Parser.Generator" Version="2024.1.6-15.18.30-nightly" />
     <PackageVersion Include="Yoakke.SynKit.Text" Version="2024.1.6-15.18.30-nightly" />
     <PackageVersion Include="Nuke.Common" Version="8.1.4" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.9" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,6 @@
     <PackageVersion Include="Yoakke.SynKit.Parser.Generator" Version="2024.1.6-15.18.30-nightly" />
     <PackageVersion Include="Yoakke.SynKit.Text" Version="2024.1.6-15.18.30-nightly" />
     <PackageVersion Include="Nuke.Common" Version="8.1.4" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.9" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This MSBuild package version comes from .net9 that can cause issues in runtime due to assemblies mismatch. 