### PR TITLE
Supply global.json

### DIFF
--- a/Cesium.Sdk.Tests/SdkTestBase.cs
+++ b/Cesium.Sdk.Tests/SdkTestBase.cs
@@ -149,7 +149,7 @@ public abstract class SdkTestBase : IDisposable
         File.WriteAllText(globalJsonPath, $$"""
             {
                 "sdk": {
-                    "version": "8.0.0",
+                    "version": "9.0.0",
                     "rollForward": "latestFeature",
                     "allowPrerelease": false
                 },

--- a/Cesium.Sdk.Tests/SdkTestBase.cs
+++ b/Cesium.Sdk.Tests/SdkTestBase.cs
@@ -148,6 +148,11 @@ public abstract class SdkTestBase : IDisposable
     {
         File.WriteAllText(globalJsonPath, $$"""
             {
+                "sdk": {
+                    "version": "8.0.0",
+                    "rollForward": "latestFeature",
+                    "allowPrerelease": false
+                },
                 "msbuild-sdks": {
                     "Cesium.Sdk" : "{{packageVersion}}"
                 }


### PR DESCRIPTION
This only fix Sdk tests and not Integration tests which a behave funny.

I prefer to go with #729 at least initially, and if there appetite for pursuing this, continue working on this PR. 