### PR TITLE
Unify handling global and local declarations

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenArrayTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenArrayTests.cs
@@ -242,4 +242,14 @@ int main() {
 int main() {
     const char a[1 + 1] = { 255 };
 }");
+
+    [Fact]
+    public Task StringArrayTest() => DoTest(@"
+const char* a[] = { ""13"" };
+");
+
+    [Fact]
+    public Task StaticStringArrayTest() => DoTest(@"
+static const char* a[] = { ""13"" };
+");
 }

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.StaticStringArrayTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.StaticStringArrayTest.verified.txt
@@ -1,0 +1,16 @@
+﻿System.Void <Module>::.cctor()
+  IL_0000: sizeof System.Byte*
+  IL_0006: ldc.i4.1
+  IL_0007: mul
+  IL_0008: conv.u
+  IL_0009: call System.Void* Cesium.Runtime.RuntimeHelpers::AllocateGlobalField(System.UInt32)
+  IL_000e: stsfld System.Byte** testInput<Statics>::a
+  IL_0013: ldsfld System.Byte** testInput<Statics>::a
+  IL_0018: ldc.i4.0
+  IL_0019: conv.i
+  IL_001a: sizeof System.Byte*
+  IL_0020: mul
+  IL_0021: add
+  IL_0022: ldsflda <ConstantPool>/<ConstantPoolItemType3> <ConstantPool>::ConstDataBuffer0
+  IL_0027: stind.i
+  IL_0028: ret

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.StringArrayTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.StringArrayTest.verified.txt
@@ -1,0 +1,16 @@
+﻿System.Void <Module>::.cctor()
+  IL_0000: sizeof System.Byte*
+  IL_0006: ldc.i4.1
+  IL_0007: mul
+  IL_0008: conv.u
+  IL_0009: call System.Void* Cesium.Runtime.RuntimeHelpers::AllocateGlobalField(System.UInt32)
+  IL_000e: stsfld System.Byte** <Module>::a
+  IL_0013: ldsfld System.Byte** <Module>::a
+  IL_0018: ldc.i4.0
+  IL_0019: conv.i
+  IL_001a: sizeof System.Byte*
+  IL_0020: mul
+  IL_0021: add
+  IL_0022: ldsflda <ConstantPool>/<ConstantPoolItemType3> <ConstantPool>::ConstDataBuffer0
+  IL_0027: stind.i
+  IL_0028: ret

--- a/Cesium.CodeGen/Extensions/TranslationUnitEx.cs
+++ b/Cesium.CodeGen/Extensions/TranslationUnitEx.cs
@@ -52,36 +52,8 @@ internal static class TranslationUnitEx
                             || (type is StructType varStructType && varStructType.Identifier != identifier)
                             || type is NamedType)
                         {
-                            if (initializer != null)
-                            {
-                                if (initializer is UnaryOperatorExpression { Operator : UnaryOperator.AddressOf, Target: CompoundObjectInitializationExpression compoundInitializationExpression } unaryOperatorExpression)
-                                {
-                                    var variableIdentifier = new IdentifierExpression(identifier);
-                                    var variable = new DeclarationBlockItem(new(storageClass, new(type, identifier, null), null));
-                                    yield return variable;
-                                    var tempVariableName = scope.GetTmpVariable();
-                                    var tempVariableIdentifier = new IdentifierExpression(tempVariableName);
-                                    if (type is PointerType pointerType)
-                                    {
-                                        type = pointerType.Base;
-                                    }
-
-                                    var tempVariable = new DeclarationBlockItem(new(storageClass, new(type, tempVariableName, null), compoundInitializationExpression));
-                                    yield return tempVariable;
-                                    yield return new ExpressionStatement(new AssignmentExpression(variableIdentifier, AssignmentOperator.Assign, new UnaryOperatorExpression(UnaryOperator.AddressOf, tempVariableIdentifier), false));
-                                }
-                                else
-                                {
-                                    var variable = new DeclarationBlockItem(new(storageClass, new(type, identifier, null), initializer));
-                                    yield return variable;
-                                }
-                            }
-                            else
-                            {
-                                var variable = new DeclarationBlockItem(new(storageClass, new(type, identifier, null), null));
-                                yield return variable;
-                            }
-
+                            var variable = new DeclarationBlockItem(new(storageClass, new(type, identifier, null), initializer));
+                            yield return variable;
                             continue;
                         }
 

--- a/Cesium.CodeGen/Extensions/TranslationUnitEx.cs
+++ b/Cesium.CodeGen/Extensions/TranslationUnitEx.cs
@@ -52,13 +52,13 @@ internal static class TranslationUnitEx
                             || (type is StructType varStructType && varStructType.Identifier != identifier)
                             || type is NamedType)
                         {
-                            var variable = new GlobalVariableDefinition(storageClass, type, identifier);
-                            yield return variable;
                             if (initializer != null)
                             {
-                                var variableIdentifier = new IdentifierExpression(identifier);
                                 if (initializer is UnaryOperatorExpression { Operator : UnaryOperator.AddressOf, Target: CompoundObjectInitializationExpression compoundInitializationExpression } unaryOperatorExpression)
                                 {
+                                    var variableIdentifier = new IdentifierExpression(identifier);
+                                    var variable = new DeclarationBlockItem(new(storageClass, new(type, identifier, null), null));
+                                    yield return variable;
                                     var tempVariableName = scope.GetTmpVariable();
                                     var tempVariableIdentifier = new IdentifierExpression(tempVariableName);
                                     if (type is PointerType pointerType)
@@ -66,15 +66,20 @@ internal static class TranslationUnitEx
                                         type = pointerType.Base;
                                     }
 
-                                    var tempVariable = new GlobalVariableDefinition(storageClass, type, tempVariableName);
+                                    var tempVariable = new DeclarationBlockItem(new(storageClass, new(type, tempVariableName, null), compoundInitializationExpression));
                                     yield return tempVariable;
-                                    yield return new ExpressionStatement(new AssignmentExpression(tempVariableIdentifier, AssignmentOperator.Assign, compoundInitializationExpression, false));
                                     yield return new ExpressionStatement(new AssignmentExpression(variableIdentifier, AssignmentOperator.Assign, new UnaryOperatorExpression(UnaryOperator.AddressOf, tempVariableIdentifier), false));
                                 }
                                 else
                                 {
-                                    yield return new ExpressionStatement(new AssignmentExpression(variableIdentifier, AssignmentOperator.Assign, initializer, false));
+                                    var variable = new DeclarationBlockItem(new(storageClass, new(type, identifier, null), initializer));
+                                    yield return variable;
                                 }
+                            }
+                            else
+                            {
+                                var variable = new DeclarationBlockItem(new(storageClass, new(type, identifier, null), null));
+                                yield return variable;
                             }
 
                             continue;

--- a/Cesium.CodeGen/Ir/Emitting/BlockItemEmitting.cs
+++ b/Cesium.CodeGen/Ir/Emitting/BlockItemEmitting.cs
@@ -73,14 +73,7 @@ internal static class BlockItemEmitting
             }
             case GlobalVariableDefinition d:
             {
-                var field = scope.ResolveGlobalField(d.Identifier);
-                // Declaration of the empty variable.
-                if (d.Type is InPlaceArrayType declredArrayType)
-                {
-                    declredArrayType.EmitInitializer(scope);
-                    scope.StSFld(field);
-                }
-
+                scope.ResolveGlobalField(d.Identifier);
                 return;
             }
             case EnumConstantDefinition:

--- a/Cesium.CodeGen/Ir/Lowering/BlockItemLowering.cs
+++ b/Cesium.CodeGen/Ir/Lowering/BlockItemLowering.cs
@@ -251,6 +251,10 @@ internal static class BlockItemLowering
 
                         type = scope.ResolveType(type);
                         scope.AddVariable(storageClass, identifier, type, null);
+                        if (scope is GlobalConstructorScope)
+                        {
+                            newItems.Add(new GlobalVariableDefinition(storageClass, type, identifier));
+                        }
 
                         var initializerExpression = initializer;
                         if (initializerExpression != null)
@@ -412,13 +416,6 @@ internal static class BlockItemLowering
 
                     return new FunctionDefinition(d.Name, d.StorageClass, resolvedFunctionType, d.Statement, d.Inline, d.NoReturn);
                 }
-            case GlobalVariableDefinition d:
-                {
-                    var resolvedType = scope.ResolveType(d.Type);
-                    scope.AddVariable(d.StorageClass, d.Identifier, resolvedType, null);
-
-                    return d;
-                }
             case EnumConstantDefinition d:
                 {
                     var resolvedType = scope.ResolveType(d.Type);
@@ -426,6 +423,7 @@ internal static class BlockItemLowering
 
                     return d;
                 }
+            case GlobalVariableDefinition:
             case GoToStatement:
                 {
                     // already lowered

--- a/Cesium.IntegrationTests/array/array_initialization.c
+++ b/Cesium.IntegrationTests/array/array_initialization.c
@@ -61,6 +61,10 @@ int testGlobalIntArray() {
     return 1;
 }
 
+char* global_c[10] = { "string", "other" };
+
+static char* static_c[] = { "string", "other" };
+
 int main(int argc, char *argv[])
 {
     if (!testIntArray()) {


### PR DESCRIPTION
Now GlobalVariableDefinition used only during emitting phase, to indicate that we should define global field. Fixes #720