### PR TITLE
Add parsing of restrict

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenPointersTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenPointersTests.cs
@@ -110,6 +110,12 @@ public class CodeGenPointersTests : CodeGenTestBase
         "__builtin_offsetof_instance: struct type \"undeclared\" has no members - is it declared?"
     );
 
+    [Fact]
+    public Task RestrictPointerDeclaration() => DoTest(@"
+int * restrict a;
+int m(int * restrict a, int * restrict b) { return 0; }
+");
+
     /* TODO[#390]: Tests below rely on preprocessor, which is not supported in tests now
 
     [Fact]

--- a/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.RestrictPointerDeclaration.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenPointersTests.RestrictPointerDeclaration.verified.txt
@@ -1,0 +1,3 @@
+﻿System.Int32 <Module>::m(System.Int32* a, System.Int32* b)
+  IL_0000: ldc.i4.0
+  IL_0001: ret

--- a/Cesium.CodeGen/Ir/Declarations/LocalDeclarationInfo.cs
+++ b/Cesium.CodeGen/Ir/Declarations/LocalDeclarationInfo.cs
@@ -163,11 +163,31 @@ internal sealed record LocalDeclarationInfo(
         if (pointer == null) return type;
 
         var (typeQualifiers, childPointer) = pointer;
+        var processed = 0;
+        bool? isConst = null;
+        bool? isRestrict = null;
         if (typeQualifiers != null)
-            if (typeQualifiers.Value.Length == 1 && typeQualifiers.Value[0].Name != "const")
-                throw new WipException(215, $"Complex pointer type is not supported, yet: {pointer}.");
+        {
+            foreach (var tq in typeQualifiers.Value)
+            {
+                if (tq.Name == "const")
+                {
+                    isConst = true;
+                    processed++;
+                }
 
-        type = new PointerType(type);
+                if (tq.Name == "restrict")
+                {
+                    isRestrict = true;
+                    processed++;
+                }
+            }
+
+            if (typeQualifiers.Value.Length != processed)
+                throw new WipException(215, $"Complex pointer type is not supported, yet: {pointer}.");
+        }
+
+        type = new PointerType(type) { IsConst = isConst ?? false, IsRestricted = isRestrict ?? false };
         if (childPointer != null)
             type = ProcessPointer(childPointer, type);
 

--- a/Cesium.CodeGen/Ir/Types/PointerType.cs
+++ b/Cesium.CodeGen/Ir/Types/PointerType.cs
@@ -13,6 +13,10 @@ internal sealed class PointerType : IType, IEquatable<PointerType>
 
     public IType Base { get; }
 
+    public bool IsRestricted { get; set; }
+
+    public bool IsConst { get; set; }
+
     public PointerType(IType @base)
     {
         this.Base = @base;


### PR DESCRIPTION
I do not plan to have aliasin analysis in near future, but given the code which I compile was "verified" using other compiler, let's pretend we are fine.

Also this is allows me properly annotate standard library, currenly I strip restrict from definitions, and that would be additional work in the future.