### PR TITLE
Spedup parsing of some expressions.

### DIFF
--- a/Cesium.CodeGen/Ir/Expressions/CommaExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/CommaExpression.cs
@@ -14,6 +14,10 @@ internal sealed class CommaExpression : IExpression
     private readonly IExpression _left;
     private readonly IExpression _right;
 
+    internal IExpression Left => _left;
+
+    internal IExpression Right => _right;
+
     internal CommaExpression(IExpression left, IExpression right)
     {
         _left = left;
@@ -26,21 +30,21 @@ internal sealed class CommaExpression : IExpression
         _right = expression.Right.ToIntermediate(scope);
     }
 
-    public IExpression Lower(IDeclarationScope scope) => new CommaExpression(_left.Lower(scope), _right.Lower(scope));
+    public IExpression Lower(IDeclarationScope scope) => new CommaExpression(Left.Lower(scope), Right.Lower(scope));
 
     public void EmitTo(IEmitScope scope)
     {
         var bodyProcessor = scope.Method.Body.GetILProcessor();
 
-        _left.EmitTo(scope);
+        Left.EmitTo(scope);
 
-        if (_left.GetExpressionType((IDeclarationScope)scope) is not PrimitiveType { Kind: PrimitiveTypeKind.Void })
+        if (Left.GetExpressionType((IDeclarationScope)scope) is not PrimitiveType { Kind: PrimitiveTypeKind.Void })
         {
             bodyProcessor.Emit(OpCodes.Pop);
         }
 
-        _right.EmitTo(scope);
+        Right.EmitTo(scope);
     }
 
-    public IType GetExpressionType(IDeclarationScope scope) => _right.GetExpressionType(scope);
+    public IType GetExpressionType(IDeclarationScope scope) => Right.GetExpressionType(scope);
 }

--- a/Cesium.CodeGen/Ir/Expressions/TypeCastExpression.cs
+++ b/Cesium.CodeGen/Ir/Expressions/TypeCastExpression.cs
@@ -10,6 +10,7 @@ using Cesium.CodeGen.Ir.Expressions.BinaryOperators;
 using Cesium.CodeGen.Ir.Expressions.Constants;
 using Cesium.CodeGen.Ir.Types;
 using Cesium.Core;
+using JetBrains.Annotations;
 using Mono.Cecil.Cil;
 using BinaryOperatorExpression = Cesium.CodeGen.Ir.Expressions.BinaryOperators.BinaryOperatorExpression;
 using C = Cesium.CodeGen.Ir.Types.CTypeSystem;
@@ -95,6 +96,21 @@ internal sealed class TypeCastExpression : IExpression
                 if (Expression is UnaryOperatorExpression { Operator: UnaryOperator.Promotion } unaryExpression)
                 {
                     return new BinaryOperatorExpression(new IdentifierExpression(namedType.TypeName), BinaryOperator.Add, unaryExpression.Target).Lower(scope);
+                }
+
+                if (Expression is CommaExpression commaExpression)
+                {
+                    List<IExpression> expressions = new();
+                    var newCommaExpression = commaExpression;
+                    do
+                    {
+                        commaExpression = newCommaExpression;
+                        expressions.Add(commaExpression.Left);
+                        newCommaExpression = commaExpression.Right as CommaExpression;
+                    }
+                    while (newCommaExpression is not null);
+                    expressions.Add(commaExpression.Right);
+                    return new Expressions.FunctionCallExpression(new IdentifierExpression(namedType.TypeName), null, expressions).Lower(scope);
                 }
             }
         }

--- a/Cesium.Parser.Tests/ParserTests/DeclarationParserTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/DeclarationParserTests.cs
@@ -25,7 +25,7 @@ public class DeclarationParserTests : ParserTestBase
     public Task InitializerDeclarationTest() => DoDeclarationParserTest("int x = 0;");
 
     [Fact]
-    public Task InitializerHexDeclarationTest() => DoDeclarationParserTest("int x = 0x22;");
+    public Task InitializerHexDeclarationTest() => DoDeclarationParserTest("int x = 0xffui8;");
 
     [Fact]
     public Task MultiDeclaration() => DoDeclarationParserTest("int x = 0, y = 2 + 2;");

--- a/Cesium.Parser.Tests/ParserTests/verified/DeclarationParserTests.CompoundStructInitializer.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/DeclarationParserTests.CompoundStructInitializer.verified.txt
@@ -26,11 +26,8 @@
           {
             "$type": "Cesium.Ast.AssignmentInitializer, Cesium.Ast",
             "Expression": {
-              "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-              "Constant": {
-                "Kind": "Identifier",
-                "Text": "TY_INT"
-              }
+              "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+              "Identifier": "TY_INT"
             },
             "Designation": null
           }

--- a/Cesium.Parser.Tests/ParserTests/verified/DeclarationParserTests.InitializerHexDeclarationTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/DeclarationParserTests.InitializerHexDeclarationTest.verified.txt
@@ -24,7 +24,7 @@
           "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
           "Constant": {
             "Kind": "IntLiteral",
-            "Text": "0x22"
+            "Text": "0xffui8"
           }
         },
         "Designation": null

--- a/Cesium.Parser.Tests/ParserTests/verified/DeclarationParserTests.InitializerWithCast.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/DeclarationParserTests.InitializerWithCast.verified.txt
@@ -41,11 +41,8 @@
             {
               "$type": "Cesium.Ast.AssignmentInitializer, Cesium.Ast",
               "Expression": {
-                "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                "Constant": {
-                  "Kind": "Identifier",
-                  "Text": "TY_INT"
-                }
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "TY_INT"
               },
               "Designation": null
             }

--- a/Cesium.Parser.Tests/ParserTests/verified/DeclarationParserTests.InitializerWithCastAddAddress.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/DeclarationParserTests.InitializerWithCastAddAddress.verified.txt
@@ -48,11 +48,8 @@
               {
                 "$type": "Cesium.Ast.AssignmentInitializer, Cesium.Ast",
                 "Expression": {
-                  "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                  "Constant": {
-                    "Kind": "Identifier",
-                    "Text": "TY_INT"
-                  }
+                  "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                  "Identifier": "TY_INT"
                 },
                 "Designation": null
               }

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.AbsCallTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.AbsCallTest.verified.txt
@@ -51,11 +51,8 @@
                   "Expression": {
                     "$type": "Cesium.Ast.FunctionCallExpression, Cesium.Ast",
                     "Function": {
-                      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                      "Constant": {
-                        "Kind": "Identifier",
-                        "Text": "abs"
-                      }
+                      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                      "Identifier": "abs"
                     },
                     "Arguments": [
                       {

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.AddressOfTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.AddressOfTest.verified.txt
@@ -80,11 +80,8 @@
                     "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
                     "Operator": "&",
                     "Target": {
-                      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                      "Constant": {
-                        "Kind": "Identifier",
-                        "Text": "x"
-                      }
+                      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                      "Identifier": "x"
                     }
                   },
                   "Designation": null

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.CliImport.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.CliImport.verified.txt
@@ -86,11 +86,8 @@
                   "Expression": {
                     "$type": "Cesium.Ast.FunctionCallExpression, Cesium.Ast",
                     "Function": {
-                      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                      "Constant": {
-                        "Kind": "Identifier",
-                        "Text": "foo"
-                      }
+                      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                      "Identifier": "foo"
                     },
                     "Arguments": null
                   },
@@ -106,11 +103,8 @@
               "Left": {
                 "$type": "Cesium.Ast.FunctionCallExpression, Cesium.Ast",
                 "Function": {
-                  "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                  "Constant": {
-                    "Kind": "Identifier",
-                    "Text": "foo"
-                  }
+                  "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                  "Identifier": "foo"
                 },
                 "Arguments": null
               },

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.FunctionCallTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.FunctionCallTest.verified.txt
@@ -89,11 +89,8 @@
                   "Expression": {
                     "$type": "Cesium.Ast.FunctionCallExpression, Cesium.Ast",
                     "Function": {
-                      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                      "Constant": {
-                        "Kind": "Identifier",
-                        "Text": "foo"
-                      }
+                      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                      "Identifier": "foo"
                     },
                     "Arguments": null
                   },
@@ -109,11 +106,8 @@
               "Left": {
                 "$type": "Cesium.Ast.FunctionCallExpression, Cesium.Ast",
                 "Function": {
-                  "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                  "Constant": {
-                    "Kind": "Identifier",
-                    "Text": "foo"
-                  }
+                  "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                  "Identifier": "foo"
                 },
                 "Arguments": null
               },

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.PostfixConstantIncrementTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.PostfixConstantIncrementTest.verified.txt
@@ -65,11 +65,8 @@
             "Expression": {
               "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
               "Left": {
-                "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                "Constant": {
-                  "Kind": "Identifier",
-                  "Text": "x"
-                }
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "x"
               },
               "Operator": "=",
               "Right": {
@@ -91,11 +88,8 @@
           {
             "$type": "Cesium.Ast.ReturnStatement, Cesium.Ast",
             "Expression": {
-              "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-              "Constant": {
-                "Kind": "Identifier",
-                "Text": "x"
-              }
+              "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+              "Identifier": "x"
             }
           }
         ]

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.PostfixVariableIncrementTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.PostfixVariableIncrementTest.verified.txt
@@ -65,11 +65,8 @@
             "Expression": {
               "$type": "Cesium.Ast.PostfixIncrementDecrementExpression, Cesium.Ast",
               "Target": {
-                "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                "Constant": {
-                  "Kind": "Identifier",
-                  "Text": "x"
-                }
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "x"
               },
               "PostfixOperator": {
                 "Kind": "Increment",
@@ -80,11 +77,8 @@
           {
             "$type": "Cesium.Ast.ReturnStatement, Cesium.Ast",
             "Expression": {
-              "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-              "Constant": {
-                "Kind": "Identifier",
-                "Text": "x"
-              }
+              "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+              "Identifier": "x"
             }
           }
         ]

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.PrefixIncrementTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.PrefixIncrementTest.verified.txt
@@ -69,22 +69,16 @@
                 "Text": "++"
               },
               "Target": {
-                "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                "Constant": {
-                  "Kind": "Identifier",
-                  "Text": "x"
-                }
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "x"
               }
             }
           },
           {
             "$type": "Cesium.Ast.ReturnStatement, Cesium.Ast",
             "Expression": {
-              "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-              "Constant": {
-                "Kind": "Identifier",
-                "Text": "x"
-              }
+              "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+              "Identifier": "x"
             }
           }
         ]

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StringLiteral.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StringLiteral.verified.txt
@@ -31,11 +31,8 @@
             "Expression": {
               "$type": "Cesium.Ast.FunctionCallExpression, Cesium.Ast",
               "Function": {
-                "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                "Constant": {
-                  "Kind": "Identifier",
-                  "Text": "test"
-                }
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "test"
               },
               "Arguments": [
                 {

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessGet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessGet.verified.txt
@@ -133,11 +133,8 @@
                   "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
                   "Operator": "&",
                   "Target": {
-                    "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                    "Constant": {
-                      "Kind": "Identifier",
-                      "Text": "x"
-                    }
+                    "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                    "Identifier": "x"
                   }
                 }
               },

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessSet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessSet.verified.txt
@@ -135,11 +135,8 @@
                     "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
                     "Operator": "&",
                     "Target": {
-                      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                      "Constant": {
-                        "Kind": "Identifier",
-                        "Text": "x"
-                      }
+                      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                      "Identifier": "x"
                     }
                   }
                 },

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithMemberAccessGet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithMemberAccessGet.verified.txt
@@ -128,11 +128,8 @@
             "Expression": {
               "$type": "Cesium.Ast.MemberAccessExpression, Cesium.Ast",
               "Target": {
-                "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                "Constant": {
-                  "Kind": "Identifier",
-                  "Text": "x"
-                }
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "x"
               },
               "Identifier": {
                 "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithMemberAccessSet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithMemberAccessSet.verified.txt
@@ -130,11 +130,8 @@
               "Left": {
                 "$type": "Cesium.Ast.MemberAccessExpression, Cesium.Ast",
                 "Target": {
-                  "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                  "Constant": {
-                    "Kind": "Identifier",
-                    "Text": "x"
-                  }
+                  "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                  "Identifier": "x"
                 },
                 "Identifier": {
                   "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithPointerMemberAccessGet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithPointerMemberAccessGet.verified.txt
@@ -132,11 +132,8 @@
             "Expression": {
               "$type": "Cesium.Ast.PointerMemberAccessExpression, Cesium.Ast",
               "Target": {
-                "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                "Constant": {
-                  "Kind": "Identifier",
-                  "Text": "x"
-                }
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "x"
               },
               "Identifier": {
                 "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithPointerMemberAccessSet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructUsageWithPointerMemberAccessSet.verified.txt
@@ -134,11 +134,8 @@
               "Left": {
                 "$type": "Cesium.Ast.PointerMemberAccessExpression, Cesium.Ast",
                 "Target": {
-                  "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                  "Constant": {
-                    "Kind": "Identifier",
-                    "Text": "x"
-                  }
+                  "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                  "Identifier": "x"
                 },
                 "Identifier": {
                   "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.VariableArithmeticTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.VariableArithmeticTest.verified.txt
@@ -65,21 +65,15 @@
             "Expression": {
               "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
               "Left": {
-                "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                "Constant": {
-                  "Kind": "Identifier",
-                  "Text": "x"
-                }
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "x"
               },
               "Operator": "=",
               "Right": {
                 "$type": "Cesium.Ast.ArithmeticBinaryOperatorExpression, Cesium.Ast",
                 "Left": {
-                  "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                  "Constant": {
-                    "Kind": "Identifier",
-                    "Text": "x"
-                  }
+                  "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                  "Identifier": "x"
                 },
                 "Operator": "+",
                 "Right": {
@@ -97,11 +91,8 @@
             "Expression": {
               "$type": "Cesium.Ast.ArithmeticBinaryOperatorExpression, Cesium.Ast",
               "Left": {
-                "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                "Constant": {
-                  "Kind": "Identifier",
-                  "Text": "x"
-                }
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "x"
               },
               "Operator": "+",
               "Right": {

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.VariableTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.VariableTest.verified.txt
@@ -65,11 +65,8 @@
             "Expression": {
               "$type": "Cesium.Ast.ArithmeticBinaryOperatorExpression, Cesium.Ast",
               "Left": {
-                "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-                "Constant": {
-                  "Kind": "Identifier",
-                  "Text": "x"
-                }
+                "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+                "Identifier": "x"
               },
               "Operator": "+",
               "Right": {

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.AddressOfInParens.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.AddressOfInParens.verified.txt
@@ -10,11 +10,8 @@
           "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
           "Operator": "&",
           "Target": {
-            "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-            "Constant": {
-              "Kind": "Identifier",
-              "Text": "x"
-            }
+            "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+            "Identifier": "x"
           }
         }
       },

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ArrayAssigment.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ArrayAssigment.verified.txt
@@ -43,11 +43,8 @@
         "Left": {
           "$type": "Cesium.Ast.SubscriptingExpression, Cesium.Ast",
           "Base": {
-            "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-            "Constant": {
-              "Kind": "Identifier",
-              "Text": "a"
-            }
+            "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+            "Identifier": "a"
           },
           "Index": {
             "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_Empty.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_Empty.verified.txt
@@ -13,11 +13,8 @@
         "Text": "++"
       },
       "Target": {
-        "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-        "Constant": {
-          "Kind": "Identifier",
-          "Text": "i"
-        }
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "i"
       }
     }
   }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_Full.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_Full.verified.txt
@@ -4,11 +4,8 @@
   "InitExpression": {
     "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     },
     "Operator": "=",
     "Right": {
@@ -22,11 +19,8 @@
   "TestExpression": {
     "$type": "Cesium.Ast.ComparisonBinaryOperatorExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     },
     "Operator": "<",
     "Right": {
@@ -44,11 +38,8 @@
       "Text": "++"
     },
     "Target": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     }
   },
   "Body": {
@@ -60,11 +51,8 @@
         "Text": "++"
       },
       "Target": {
-        "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-        "Constant": {
-          "Kind": "Identifier",
-          "Text": "i"
-        }
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "i"
       }
     }
   }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_MultiLineBody.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_MultiLineBody.verified.txt
@@ -4,11 +4,8 @@
   "InitExpression": {
     "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     },
     "Operator": "=",
     "Right": {
@@ -22,11 +19,8 @@
   "TestExpression": {
     "$type": "Cesium.Ast.ComparisonBinaryOperatorExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     },
     "Operator": "<",
     "Right": {
@@ -44,11 +38,8 @@
       "Text": "++"
     },
     "Target": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     }
   },
   "Body": {
@@ -59,21 +50,15 @@
         "Expression": {
           "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
           "Left": {
-            "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-            "Constant": {
-              "Kind": "Identifier",
-              "Text": "i"
-            }
+            "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+            "Identifier": "i"
           },
           "Operator": "=",
           "Right": {
             "$type": "Cesium.Ast.ArithmeticBinaryOperatorExpression, Cesium.Ast",
             "Left": {
-              "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-              "Constant": {
-                "Kind": "Identifier",
-                "Text": "i"
-              }
+              "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+              "Identifier": "i"
             },
             "Operator": "-",
             "Right": {
@@ -91,21 +76,15 @@
         "Expression": {
           "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
           "Left": {
-            "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-            "Constant": {
-              "Kind": "Identifier",
-              "Text": "i"
-            }
+            "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+            "Identifier": "i"
           },
           "Operator": "=",
           "Right": {
             "$type": "Cesium.Ast.ArithmeticBinaryOperatorExpression, Cesium.Ast",
             "Left": {
-              "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-              "Constant": {
-                "Kind": "Identifier",
-                "Text": "i"
-              }
+              "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+              "Identifier": "i"
             },
             "Operator": "+",
             "Right": {

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_NoInit.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_NoInit.verified.txt
@@ -5,11 +5,8 @@
   "TestExpression": {
     "$type": "Cesium.Ast.ComparisonBinaryOperatorExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     },
     "Operator": "<",
     "Right": {
@@ -27,11 +24,8 @@
       "Text": "++"
     },
     "Target": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     }
   },
   "Body": {
@@ -43,11 +37,8 @@
         "Text": "++"
       },
       "Target": {
-        "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-        "Constant": {
-          "Kind": "Identifier",
-          "Text": "i"
-        }
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "i"
       }
     }
   }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_NoTest.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_NoTest.verified.txt
@@ -4,11 +4,8 @@
   "InitExpression": {
     "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     },
     "Operator": "=",
     "Right": {
@@ -27,11 +24,8 @@
       "Text": "++"
     },
     "Target": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     }
   },
   "Body": {
@@ -43,11 +37,8 @@
         "Text": "++"
       },
       "Target": {
-        "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-        "Constant": {
-          "Kind": "Identifier",
-          "Text": "i"
-        }
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "i"
       }
     }
   }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_NoUpdate.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_NoUpdate.verified.txt
@@ -4,11 +4,8 @@
   "InitExpression": {
     "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     },
     "Operator": "=",
     "Right": {
@@ -22,11 +19,8 @@
   "TestExpression": {
     "$type": "Cesium.Ast.ComparisonBinaryOperatorExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     },
     "Operator": "<",
     "Right": {
@@ -47,11 +41,8 @@
         "Text": "++"
       },
       "Target": {
-        "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-        "Constant": {
-          "Kind": "Identifier",
-          "Text": "i"
-        }
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "i"
       }
     }
   }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_OnlyCondition.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_OnlyCondition.verified.txt
@@ -5,11 +5,8 @@
   "TestExpression": {
     "$type": "Cesium.Ast.ComparisonBinaryOperatorExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     },
     "Operator": "<",
     "Right": {
@@ -30,11 +27,8 @@
         "Text": "++"
       },
       "Target": {
-        "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-        "Constant": {
-          "Kind": "Identifier",
-          "Text": "i"
-        }
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "i"
       }
     }
   }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_OnlyInit.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_OnlyInit.verified.txt
@@ -4,11 +4,8 @@
   "InitExpression": {
     "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     },
     "Operator": "=",
     "Right": {
@@ -30,11 +27,8 @@
         "Text": "++"
       },
       "Target": {
-        "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-        "Constant": {
-          "Kind": "Identifier",
-          "Text": "i"
-        }
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "i"
       }
     }
   }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_OnlyUpdate.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ForStatement_OnlyUpdate.verified.txt
@@ -10,11 +10,8 @@
       "Text": "++"
     },
     "Target": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "i"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "i"
     }
   },
   "Body": {
@@ -26,11 +23,8 @@
         "Text": "++"
       },
       "Target": {
-        "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-        "Constant": {
-          "Kind": "Identifier",
-          "Text": "i"
-        }
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "i"
       }
     }
   }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.IndirectionGet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.IndirectionGet.verified.txt
@@ -3,21 +3,15 @@
   "Expression": {
     "$type": "Cesium.Ast.AssignmentExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "x"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "x"
     },
     "Operator": "=",
     "Right": {
       "$type": "Cesium.Ast.IndirectionExpression, Cesium.Ast",
       "Target": {
-        "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-        "Constant": {
-          "Kind": "Identifier",
-          "Text": "y"
-        }
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "y"
       }
     }
   }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.IndirectionSet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.IndirectionSet.verified.txt
@@ -5,11 +5,8 @@
     "Left": {
       "$type": "Cesium.Ast.IndirectionExpression, Cesium.Ast",
       "Target": {
-        "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-        "Constant": {
-          "Kind": "Identifier",
-          "Text": "x"
-        }
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "x"
       }
     },
     "Operator": "=",

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.NotFuncCall.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.NotFuncCall.verified.txt
@@ -6,11 +6,8 @@
     "Target": {
       "$type": "Cesium.Ast.FunctionCallExpression, Cesium.Ast",
       "Function": {
-        "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-        "Constant": {
-          "Kind": "Identifier",
-          "Text": "test"
-        }
+        "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+        "Identifier": "test"
       },
       "Arguments": null
     }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ReturnVariableArithmetic.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.ReturnVariableArithmetic.verified.txt
@@ -3,11 +3,8 @@
   "Expression": {
     "$type": "Cesium.Ast.ArithmeticBinaryOperatorExpression, Cesium.Ast",
     "Left": {
-      "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-      "Constant": {
-        "Kind": "Identifier",
-        "Text": "x"
-      }
+      "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+      "Identifier": "x"
     },
     "Operator": "+",
     "Right": {

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SizeOfIdentifier.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SizeOfIdentifier.verified.txt
@@ -32,11 +32,8 @@
         "TargetExpession": {
           "$type": "Cesium.Ast.ParenExpression, Cesium.Ast",
           "Contents": {
-            "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-            "Constant": {
-              "Kind": "Identifier",
-              "Text": "size"
-            }
+            "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+            "Identifier": "size"
           }
         }
       }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SizeOfVariable.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SizeOfVariable.verified.txt
@@ -30,11 +30,8 @@
       "Expression": {
         "$type": "Cesium.Ast.UnaryExpressionSizeOfOperatorExpression, Cesium.Ast",
         "TargetExpession": {
-          "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-          "Constant": {
-            "Kind": "Identifier",
-            "Text": "size"
-          }
+          "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+          "Identifier": "size"
         }
       }
     }

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SwitchStatement_Empty.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SwitchStatement_Empty.verified.txt
@@ -1,11 +1,8 @@
 {
   "$type": "Cesium.Ast.SwitchStatement, Cesium.Ast",
   "Expression": {
-    "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-    "Constant": {
-      "Kind": "Identifier",
-      "Text": "x"
-    }
+    "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+    "Identifier": "x"
   },
   "Body": {
     "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SwitchStatement_FallthroughCase.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SwitchStatement_FallthroughCase.verified.txt
@@ -1,11 +1,8 @@
 {
   "$type": "Cesium.Ast.SwitchStatement, Cesium.Ast",
   "Expression": {
-    "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-    "Constant": {
-      "Kind": "Identifier",
-      "Text": "x"
-    }
+    "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+    "Identifier": "x"
   },
   "Body": {
     "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SwitchStatement_MultiCases.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SwitchStatement_MultiCases.verified.txt
@@ -1,11 +1,8 @@
 {
   "$type": "Cesium.Ast.SwitchStatement, Cesium.Ast",
   "Expression": {
-    "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-    "Constant": {
-      "Kind": "Identifier",
-      "Text": "x"
-    }
+    "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+    "Identifier": "x"
   },
   "Body": {
     "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SwitchStatement_MultiCasesWithDefault.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SwitchStatement_MultiCasesWithDefault.verified.txt
@@ -1,11 +1,8 @@
 {
   "$type": "Cesium.Ast.SwitchStatement, Cesium.Ast",
   "Expression": {
-    "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-    "Constant": {
-      "Kind": "Identifier",
-      "Text": "x"
-    }
+    "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+    "Identifier": "x"
   },
   "Body": {
     "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SwitchStatement_OneCase.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SwitchStatement_OneCase.verified.txt
@@ -1,11 +1,8 @@
 {
   "$type": "Cesium.Ast.SwitchStatement, Cesium.Ast",
   "Expression": {
-    "$type": "Cesium.Ast.ConstantLiteralExpression, Cesium.Ast",
-    "Constant": {
-      "Kind": "Identifier",
-      "Text": "x"
-    }
+    "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
+    "Identifier": "x"
   },
   "Body": {
     "$type": "Cesium.Ast.CompoundStatement, Cesium.Ast",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,12 +23,12 @@ SPDX-License-Identifier: MIT
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageVersion Include="Yoakke.SynKit.C.Syntax" Version="2025.4.1-3.13.18-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Lexer" Version="2025.4.1-3.13.18-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Lexer.Generator" Version="2025.4.1-3.13.18-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Parser" Version="2025.4.1-3.13.18-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Parser.Generator" Version="2025.4.1-3.13.18-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Text" Version="2025.4.1-3.13.18-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.C.Syntax" Version="2025.4.27-3.32.52-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Lexer" Version="2025.4.27-3.32.52-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Lexer.Generator" Version="2025.4.27-3.32.52-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Parser" Version="2025.4.27-3.32.52-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Parser.Generator" Version="2025.4.27-3.32.52-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Text" Version="2025.4.27-3.32.52-nightly" />
     <PackageVersion Include="Nuke.Common" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.13.9" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,12 +23,12 @@ SPDX-License-Identifier: MIT
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageVersion Include="Yoakke.SynKit.C.Syntax" Version="2024.12.4-18.22.20-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Lexer" Version="2024.12.4-18.22.20-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Lexer.Generator" Version="2024.12.4-18.22.20-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Parser" Version="2024.12.4-18.22.20-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Parser.Generator" Version="2024.12.4-18.22.20-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Text" Version="2024.12.4-18.22.20-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.C.Syntax" Version="2025.4.1-3.13.18-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Lexer" Version="2025.4.1-3.13.18-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Lexer.Generator" Version="2025.4.1-3.13.18-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Parser" Version="2025.4.1-3.13.18-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Parser.Generator" Version="2025.4.1-3.13.18-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Text" Version="2025.4.1-3.13.18-nightly" />
     <PackageVersion Include="Nuke.Common" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.13.9" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,12 +23,12 @@ SPDX-License-Identifier: MIT
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-    <PackageVersion Include="Yoakke.SynKit.C.Syntax" Version="2025.4.27-3.32.52-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Lexer" Version="2025.4.27-3.32.52-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Lexer.Generator" Version="2025.4.27-3.32.52-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Parser" Version="2025.4.27-3.32.52-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Parser.Generator" Version="2025.4.27-3.32.52-nightly" />
-    <PackageVersion Include="Yoakke.SynKit.Text" Version="2025.4.27-3.32.52-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.C.Syntax" Version="2025.9.28-11.7.0-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Lexer" Version="2025.9.28-11.7.0-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Lexer.Generator" Version="2025.9.28-11.7.0-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Parser" Version="2025.9.28-11.7.0-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Parser.Generator" Version="2025.9.28-11.7.0-nightly" />
+    <PackageVersion Include="Yoakke.SynKit.Text" Version="2025.9.28-11.7.0-nightly" />
     <PackageVersion Include="Nuke.Common" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.8" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />


### PR DESCRIPTION
Expression in question:
```
void test() {
l_1846 = (int16_t)((uint32_t)(l_6 == ((int32_t)(!l_6) % (int32_t)l_6)) << (uint32_t)l_6) - (int16_t)(l_6 < ((int16_t)((((int32_t)l_14 >> (int32_t)26) == ((uint32_t)((int16_t)func_19(l_6, l_6, l_6, l_6, l_14) << (int16_t)l_14) % (uint32_t)0x5DA36AE3)) || l_1845) - (int16_t)l_6));
}
```

Before was 100 seconds, now 10 seconds.