### PR TITLE
fix(preprocessor): prevent crash on nested macro calls with trailing whitespace

### DIFF
--- a/Cesium.Parser.Tests/PreprocessorTests/PreprocessorTests.cs
+++ b/Cesium.Parser.Tests/PreprocessorTests/PreprocessorTests.cs
@@ -507,6 +507,14 @@ int main() { foo(0) return 0; }
 ");
 
     [Fact, NoVerify]
+    public Task NestedMacroDeferredExpansion() => DoPreprocess(
+@"#define EMPTY()
+#define DEFER(id) id EMPTY()
+#define FAIL() DEFER ( EMPTY ) ( )
+FAIL()
+");
+
+    [Fact, NoVerify]
     public Task IfExpressionCannotConsumeNonInteger()
     {
         return Assert.ThrowsAsync<PreprocessorException>(() => DoPreprocess(

--- a/Cesium.Parser.Tests/PreprocessorTests/PreprocessorTests.cs
+++ b/Cesium.Parser.Tests/PreprocessorTests/PreprocessorTests.cs
@@ -506,7 +506,7 @@ int main() { char* x = foo(int x; printf(""some string"")); }
 int main() { foo(0) return 0; }
 ");
 
-    [Fact, NoVerify]
+    [Fact]
     public Task NestedMacroDeferredExpansion() => DoPreprocess(
 @"#define EMPTY()
 #define DEFER(id) id EMPTY()

--- a/Cesium.Preprocessor/MacroExpansionEngine.cs
+++ b/Cesium.Preprocessor/MacroExpansionEngine.cs
@@ -141,7 +141,7 @@ public class MacroExpansionEngine(IWarningProcessor warningProcessor, IMacroCont
             do
             {
                 currentToken = lexer.Consume();
-            } while (currentToken is { Kind: CPreprocessorTokenType.WhiteSpace or CPreprocessorTokenType.Comment });
+            } while (!lexer.IsEnd && currentToken is { Kind: CPreprocessorTokenType.WhiteSpace or CPreprocessorTokenType.Comment });
 
             return currentToken;
         }
@@ -152,6 +152,12 @@ public class MacroExpansionEngine(IWarningProcessor warningProcessor, IMacroCont
             var index = 0;
             do
             {
+                if (lexer.IsEndAt(index))
+                    return new Token<CPreprocessorTokenType>(
+                        new Range(),
+                        new Location(),
+                        string.Empty,
+                        CPreprocessorTokenType.End);
                 currentToken = lexer.Peek(index++);
             } while (currentToken is { Kind: CPreprocessorTokenType.WhiteSpace or CPreprocessorTokenType.Comment });
 

--- a/Cesium.Preprocessor/TransactionalLexer.cs
+++ b/Cesium.Preprocessor/TransactionalLexer.cs
@@ -21,6 +21,11 @@ internal class TransactionalLexer(
     public IToken<CPreprocessorTokenType> Peek(int idx = 0) => _allTokens[_nextTokenToReturn + idx];
     public bool IsEnd => _nextTokenToReturn >= _allTokens.Count || Peek() is { Kind: CPreprocessorTokenType.End };
 
+    /// <summary>Returns true if peeking at <paramref name="offset"/> positions ahead would exceed the token stream.</summary>
+    public bool IsEndAt(int offset) =>
+        _nextTokenToReturn + offset >= _allTokens.Count
+        || _allTokens[_nextTokenToReturn + offset] is { Kind: CPreprocessorTokenType.End };
+
     /// <remarks>For error reporting purposes only.</remarks>
     public IToken<CPreprocessorTokenType>? LastToken => _allTokens.LastOrDefault();
 


### PR DESCRIPTION
## Summary

Fixes #963

### Root Cause

When a function-like macro (e.g. `EMPTY()`) appears in a replacement list that gets re-expanded, and the expansion produces a token stream that ends with trailing whitespace after the macro name, the local `Consume()` helper in `ParseArguments` would keep looping past the end of the stream, causing an `IndexOutOfRangeException`.

**Reproduction:**
```c
#define EMPTY()
#define DEFER(id) id EMPTY()
#define FAIL() DEFER ( EMPTY ) ( )
FAIL()
```

**Crash trace:**
1. `FAIL()` expands to `DEFER ( EMPTY ) ( )`
2. Each token of this replacement is expanded individually via `ExpandMacros`
3. When `DEFER(EMPTY)` is processed, the argument `EMPTY` is expanded in its own isolated token stream `[EMPTY]`
4. The result `EMPTY EMPTY()` is then re-expanded
5. The second `EMPTY` gets its own isolated stream `[EMPTY, space, EMPTY, (, )]`  
6. Inside this stream, `ExpandMacros` tries to expand the first `EMPTY`, calls `ParseArguments`, which needs to look for `(`
7. `ParseArguments`'s local `Consume()` skips whitespace — consuming `space` then attempting another `lexer.Consume()` past the end of the stream → **crash**

### Fix

- **`MacroExpansionEngine.cs`**: Add `!lexer.IsEnd` guard to the whitespace-skipping loop in the local `Consume()` helper. Add `IsEndAt(index)` guard to the local `Peek()` helper.
- **`TransactionalLexer.cs`**: Add `IsEndAt(int offset)` method for safe bounds checking at arbitrary peek offsets.
- **`PreprocessorTests.cs`**: Add regression test `NestedMacroDeferredExpansion` that exercises the fixed code path.