### PR TITLE
Rename ParenExpression to ParenthesizedExpression

### DIFF
--- a/Cesium.Ast/Expressions.cs
+++ b/Cesium.Ast/Expressions.cs
@@ -16,7 +16,7 @@ public sealed record StringLiteralListExpression(ImmutableArray<IToken<CTokenTyp
 // 6.5.1 Primary expressions
 public sealed record IdentifierExpression(string Identifier) : Expression;
 public sealed record ConstantLiteralExpression(IToken<CTokenType> Constant) : Expression;
-public sealed record ParenExpression(Expression Contents) : Expression;
+public sealed record ParenthesizedExpression(Expression Contents) : Expression;
 
 // 6.5.2 Postfix operators
 public sealed record SubscriptingExpression(Expression Base, Expression Index) : Expression;

--- a/Cesium.CodeGen/Extensions/ExpressionEx.cs
+++ b/Cesium.CodeGen/Extensions/ExpressionEx.cs
@@ -35,7 +35,7 @@ internal static class ExpressionEx
         StringLiteralListExpression e => new Ir.Expressions.StringLiteralListExpression(e),
         ConstantLiteralExpression { Constant.Kind: CTokenType.Identifier } e => new Ir.Expressions.IdentifierExpression(e),
         ConstantLiteralExpression e => new Ir.Expressions.ConstantLiteralExpression(e),
-        ParenExpression e => ToIntermediate(e.Contents, scope),
+        ParenthesizedExpression e => ToIntermediate(e.Contents, scope),
 
         TypeCastOrNamedFunctionCallExpression e => new Ir.Expressions.TypeCastOrNamedFunctionCallExpression(e, scope),
         FunctionCallExpression e => new Ir.Expressions.FunctionCallExpression(e, scope),

--- a/Cesium.Compiler/AstDumper.cs
+++ b/Cesium.Compiler/AstDumper.cs
@@ -320,9 +320,9 @@ internal sealed class AstDumper : AstVisitor
         base.Visit(constantLiteralExpression);
     }
 
-    protected override void Visit(ParenExpression expression)
+    protected override void Visit(ParenthesizedExpression expression)
     {
-        Enter("ParenExpression");
+        Enter("ParenthesizedExpression");
         base.Visit(expression);
         Exit();
     }

--- a/Cesium.Compiler/AstVisitor.cs
+++ b/Cesium.Compiler/AstVisitor.cs
@@ -481,7 +481,7 @@ internal abstract class AstVisitor
             case ConstantLiteralExpression expr:
                 Visit(expr);
                 break;
-            case ParenExpression expr:
+            case ParenthesizedExpression expr:
                 Visit(expr);
                 break;
             case SubscriptingExpression expr:
@@ -549,7 +549,7 @@ internal abstract class AstVisitor
     {
     }
 
-    protected virtual void Visit(ParenExpression expression)
+    protected virtual void Visit(ParenthesizedExpression expression)
     {
         Visit(expression.Contents);
     }

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessGet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessGet.verified.txt
@@ -128,7 +128,7 @@
             "Expression": {
               "$type": "Cesium.Ast.PointerMemberAccessExpression, Cesium.Ast",
               "Target": {
-                "$type": "Cesium.Ast.ParenExpression, Cesium.Ast",
+                "$type": "Cesium.Ast.ParenthesizedExpression, Cesium.Ast",
                 "Contents": {
                   "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
                   "Operator": "&",

--- a/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessSet.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/FullParserTests.StructAddressWithPointerMemberAccessSet.verified.txt
@@ -130,7 +130,7 @@
               "Left": {
                 "$type": "Cesium.Ast.PointerMemberAccessExpression, Cesium.Ast",
                 "Target": {
-                  "$type": "Cesium.Ast.ParenExpression, Cesium.Ast",
+                  "$type": "Cesium.Ast.ParenthesizedExpression, Cesium.Ast",
                   "Contents": {
                     "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
                     "Operator": "&",

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.AddressOfInParens.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.AddressOfInParens.verified.txt
@@ -5,7 +5,7 @@
     "Left": {
       "$type": "Cesium.Ast.PointerMemberAccessExpression, Cesium.Ast",
       "Target": {
-        "$type": "Cesium.Ast.ParenExpression, Cesium.Ast",
+        "$type": "Cesium.Ast.ParenthesizedExpression, Cesium.Ast",
         "Contents": {
           "$type": "Cesium.Ast.UnaryOperatorExpression, Cesium.Ast",
           "Operator": "&",

--- a/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SizeOfIdentifier.verified.txt
+++ b/Cesium.Parser.Tests/ParserTests/verified/StatementParserTests.SizeOfIdentifier.verified.txt
@@ -30,7 +30,7 @@
       "Expression": {
         "$type": "Cesium.Ast.UnaryExpressionSizeOfOperatorExpression, Cesium.Ast",
         "TargetExpession": {
-          "$type": "Cesium.Ast.ParenExpression, Cesium.Ast",
+          "$type": "Cesium.Ast.ParenthesizedExpression, Cesium.Ast",
           "Contents": {
             "$type": "Cesium.Ast.IdentifierExpression, Cesium.Ast",
             "Identifier": "size"

--- a/Cesium.Parser/CParser.cs
+++ b/Cesium.Parser/CParser.cs
@@ -94,7 +94,8 @@ public partial class CParser
         new StringLiteralListExpression(literalExpressionList);
 
     [Rule("primary_expression: '(' expression ')'")]
-    private static Expression MakeParens(IToken _, Expression expression, IToken __) => new ParenExpression(expression);
+    private static Expression MakeParenthesizedExpression(IToken _, Expression expression, IToken __) =>
+        new ParenthesizedExpression(expression);
 
     [Rule("primary_expression: constant")]
     private static Expression MakeConstantExpression(ICToken constant) => new ConstantLiteralExpression(constant);
@@ -116,7 +117,7 @@ public partial class CParser
         ArgumentExpressionList? arguments,
         IToken __)
     {
-        if (function is ParenExpression { Contents: ConstantLiteralExpression { Constant: CToken { Kind: CTokenType.Identifier, Text: var name } } } &&
+        if (function is ParenthesizedExpression { Contents: ConstantLiteralExpression { Constant: CToken { Kind: CTokenType.Identifier, Text: var name } } } &&
             arguments != null && arguments.Value.Length > 0)
         {
             return new TypeCastOrNamedFunctionCallExpression(name, arguments.Value);


### PR DESCRIPTION
Small change to make it more readable.