### PR TITLE
Throw ParseException on invalid escape sequence

### DIFF
--- a/Cesium.Parser.Tests/ParserTests/TokenExtensionsTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/TokenExtensionsTests.cs
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2025 Cesium contributors <https://github.com/ForNeVeR/Cesium>
+// SPDX-FileCopyrightText: 2026 Cesium contributors <https://github.com/ForNeVeR/Cesium>
 //
 // SPDX-License-Identifier: MIT
 
+using Cesium.Core;
 using Yoakke.SynKit.C.Syntax;
 using Yoakke.SynKit.Lexer;
 using Yoakke.SynKit.Text;
@@ -28,5 +29,18 @@ public class TokenExtensionsTests
         var actual = token.UnwrapStringLiteral();
 
         Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("\"\\z\"")]
+    [InlineData("\"\\j\"")]
+    [InlineData("\"\\1\"")]
+    [InlineData("\"\\ \"")]
+    public void InvalidEscapeSequenceThrows(string tokenText)
+    {
+        var token = new Token<CTokenType>(new Range(), new Location(), tokenText, CTokenType.StringLiteral);
+
+        var ex = Assert.Throws<ParseException>(token.UnwrapStringLiteral);
+        Assert.Contains("Unrecognized escape sequence", ex.Message);
     }
 }

--- a/Cesium.Parser.Tests/ParserTests/TokenExtensionsTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/TokenExtensionsTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Cesium contributors <https://github.com/ForNeVeR/Cesium>
+// SPDX-FileCopyrightText: 2025-2026 Cesium contributors <https://github.com/ForNeVeR/Cesium>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Cesium.Parser.Tests/ParserTests/TokenExtensionsTests.cs
+++ b/Cesium.Parser.Tests/ParserTests/TokenExtensionsTests.cs
@@ -21,6 +21,9 @@ public class TokenExtensionsTests
     [InlineData("\"\\\\00\"", "\\00")]
     [InlineData("\"\\00\"", "\0")]
     [InlineData("\"\\0\"", "\0")]
+    [InlineData("\"\\1\"", "\x01")]
+    [InlineData("\"\\12\"", "\n")]
+    [InlineData("\"\\123\"", "S")]
     [InlineData("\"\\x\"", "\\x")]
     public void Test(string tokenText, string expected)
     {
@@ -34,7 +37,7 @@ public class TokenExtensionsTests
     [Theory]
     [InlineData("\"\\z\"")]
     [InlineData("\"\\j\"")]
-    [InlineData("\"\\1\"")]
+    [InlineData("\"\\9\"")]
     [InlineData("\"\\ \"")]
     public void InvalidEscapeSequenceThrows(string tokenText)
     {

--- a/Cesium.Parser/TokenExtensions.cs
+++ b/Cesium.Parser/TokenExtensions.cs
@@ -103,28 +103,32 @@ public static class TokenExtensions
             case 't': span[i] = '\t'; break;
             case 'v': span[i] = '\v'; break;
             // Numeric escape sequences
-            case '0': // arbitrary octal value '\nnn'
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7': // arbitrary octal value '\nnn'
                 {
-                    if (span.Length <= i + 2 || span[i + 2] == '\0') // \0 check for 2nd..n iters.
-                    {
-                        span[i] = '\0';
-                        break;
-                    }
+                    var number = span[i + 1] - '0';
+                    var octalDigitsCount = 1;
 
-                    int number = 0;
-                    var c = span[i + shift + 1]; // get next char after 0
-                    do
+                    while (octalDigitsCount < 3 && span.Length > i + 1 + octalDigitsCount)
                     {
-                        number = number * 8 + (c - '0');
-                        shift++;
-                        if (span.Length <= i + shift + 1)
+                        var c = span[i + 1 + octalDigitsCount];
+                        if (c is < '0' or > '7')
                         {
                             break;
                         }
-                        c = span[i + shift + 1];
+
+                        number = number * 8 + (c - '0');
+                        octalDigitsCount++;
                     }
-                    while (char.IsBetween(c, '0', '7'));
+
                     span[i] = (char)number;
+                    shift = octalDigitsCount;
                     break;
                 }
             case 'x':

--- a/Cesium.Parser/TokenExtensions.cs
+++ b/Cesium.Parser/TokenExtensions.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Cesium contributors <https://github.com/ForNeVeR/Cesium>
+// SPDX-FileCopyrightText: 2025-2026 Cesium contributors <https://github.com/ForNeVeR/Cesium>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Cesium.Parser/TokenExtensions.cs
+++ b/Cesium.Parser/TokenExtensions.cs
@@ -1,9 +1,8 @@
-// SPDX-FileCopyrightText: 2025 Cesium contributors <https://github.com/ForNeVeR/Cesium>
+// SPDX-FileCopyrightText: 2026 Cesium contributors <https://github.com/ForNeVeR/Cesium>
 //
 // SPDX-License-Identifier: MIT
 
 using Cesium.Core;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Yoakke.SynKit.C.Syntax;
@@ -13,7 +12,7 @@ namespace Cesium.Parser;
 
 public static class TokenExtensions
 {
-    public unsafe static string UnwrapStringLiteral(this IToken<CTokenType> token)
+    public static unsafe string UnwrapStringLiteral(this IToken<CTokenType> token)
     {
         if (token.Kind != CTokenType.StringLiteral)
             throw new ParseException($"Non-string literal token: {token.Kind} {token.Text}");
@@ -81,7 +80,7 @@ public static class TokenExtensions
         fixed (char* p = text)
         {
             var span = new Span<char>(p + 1, text.Length - 2); // create a span for string. Also +1 for \0
-            var shift = ParseCharacter(span, 0);
+            ParseCharacter(span, 0);
             return span[0];
         }
     }
@@ -156,7 +155,7 @@ public static class TokenExtensions
                 }
             // Universal character names
             case 'u': // \unnnn
-            case 'U': // \Unnnnnnnn 
+            case 'U': // \Unnnnnnnn
                 {
                     int counter = span[i + 1] == 'U' ? 8 : 4;
                     if (span.Length <= i + counter) // no free chars no fun
@@ -188,11 +187,11 @@ public static class TokenExtensions
                 }
             default:
                 // from orig method:
-                // TODO[#295]: maybe smarter handling of this edge case with errors/warnings
                 // builder.Append('\\');
                 // --i; // don't skip next
                 // mmm, idk when that might happen
-                break;
+
+                throw new ParseException($"Unrecognized escape sequence '\\{span[i + 1]}' in string or character literal.");
         }
 
         return shift;


### PR DESCRIPTION
Closes #295

Throw `ParseException` on unrecognized escape sequences.

> ...such as `const char* x = "\"`

This specific example doesn't need a fix, as it's already handled on the lexer side (`"\"` is actually an unclosed string literal). 
However, this PR fixes a similar case: `"\ "`.