### PR TITLE
Add timing measurement for integration tests

### DIFF
--- a/Cesium.IntegrationTests/IntegrationTestRunner.cs
+++ b/Cesium.IntegrationTests/IntegrationTestRunner.cs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Cesium.Solution.Metadata;
 using Cesium.TestFramework;
@@ -25,7 +26,21 @@ public class IntegrationTestRunner : IClassFixture<IntegrationTestContext>, IAsy
     public Task InitializeAsync() =>
         _context.EnsureInitialized(_output);
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public Task DisposeAsync()
+    {
+        // Write timing report to file at the end of the test run
+        try
+        {
+            var filePath = TimingRecorder.Instance.WriteReportToFile();
+            _output.WriteLine($"Timing report written to: {filePath}");
+        }
+        catch (Exception ex)
+        {
+            _output.WriteLine($"Failed to write timing report: {ex.Message}");
+        }
+
+        return Task.CompletedTask;
+    }
 
     public static IEnumerable<object[]> TestCaseProvider()
     {
@@ -137,18 +152,18 @@ public class IntegrationTestRunner : IClassFixture<IntegrationTestContext>, IAsy
     {
         if (OperatingSystem.IsWindows())
         {
-            await _context.WrapTestBody(() => DoTest(TargetFramework.NetFramework, arch, [..relativeSourcePath.Select(_ => new LocalPath(_))]));
+            await _context.WrapTestBody(() => DoTestWithTiming(TargetFramework.NetFramework, arch, [..relativeSourcePath.Select(_ => new LocalPath(_))]));
         }
     }
 
     [Theory]
     [MemberData(nameof(TestCaseProvider))]
     public Task TestNet(TargetArch arch, string[] relativeSourcePath) =>
-        _context.WrapTestBody(() => DoTest(TargetFramework.Net, arch, [.. relativeSourcePath.Select(_ => new LocalPath(_))]));
+        _context.WrapTestBody(() => DoTestWithTiming(TargetFramework.Net, arch, [.. relativeSourcePath.Select(_ => new LocalPath(_))]));
 
     [Fact]
     public Task MultiFileApplicationCompiles() =>
-        _context.WrapTestBody(() => DoTest(
+        _context.WrapTestBody(() => DoTestWithTiming(
             TargetFramework.Net, TargetArch.Dynamic, new("multi-file/program.c"), new("multi-file/function.c")));
 
     [Fact]
@@ -187,6 +202,109 @@ public class IntegrationTestRunner : IClassFixture<IntegrationTestContext>, IAsy
                 Directory.Delete(outRoot.Value, recursive: true);
             }
         });
+
+    /// <summary>
+    /// Executes a test with timing measurements.
+    /// </summary>
+    private async Task DoTestWithTiming(TargetFramework targetFramework, TargetArch arch, params LocalPath[] relativeSourcePaths)
+    {
+        var totalStopwatch = Stopwatch.StartNew();
+        long nativeCompileTimeMs = 0;
+        long nativeRunTimeMs = 0;
+        long cesiumCompileTimeMs = 0;
+        long cesiumRunTimeMs = 0;
+
+        var outRoot = Temporary.CreateTempFolder();
+        try
+        {
+            var paths = "[" + string.Join(", ", relativeSourcePaths.Select(x => $"\"{x.Value}\"")) + "]";
+            _output.WriteLine($"Building source files {paths} in directory \"{outRoot}\".");
+
+            string? inputContent = null;
+            if (relativeSourcePaths.Length > 0)
+            {
+                var inputPath = SolutionMetadata.SourceRoot / "Cesium.IntegrationTests" / relativeSourcePaths[0].WithExtension(".in");
+                if (File.Exists(inputPath.ToString()))
+                {
+                    inputContent = File.ReadAllText(inputPath.ToString());
+                }
+            }
+            var binDir = outRoot / "bin";
+            var objDir = outRoot / "obj";
+            Directory.CreateDirectory(binDir.Value);
+            Directory.CreateDirectory(objDir.Value);
+
+            var sourceFiles = relativeSourcePaths
+                .Select(x => SolutionMetadata.SourceRoot / "Cesium.IntegrationTests" / x)
+                .ToList();
+
+            // Measure native compile time
+            var nativeCompileStopwatch = Stopwatch.StartNew();
+            var nativeExecutable = await BuildExecutableWithNativeCompiler(binDir, objDir, sourceFiles);
+            nativeCompileStopwatch.Stop();
+            nativeCompileTimeMs = nativeCompileStopwatch.ElapsedMilliseconds;
+
+            // Measure native run time
+            var nativeRunStopwatch = Stopwatch.StartNew();
+            var nativeResult = await ExecUtil.Run(_output, nativeExecutable, outRoot, [], inputContent);
+            nativeRunStopwatch.Stop();
+            nativeRunTimeMs = nativeRunStopwatch.ElapsedMilliseconds;
+            Assert.Equal(42, nativeResult.ExitCode);
+            Assert.Empty(nativeResult.StandardError);
+            var nativeOutput = nativeResult.StandardOutput;
+
+            // Measure Cesium compile time
+            var cesiumCompileStopwatch = Stopwatch.StartNew();
+            var managedExecutable = await BuildExecutableWithCesium(
+                binDir,
+                objDir,
+                sourceFiles,
+                targetFramework,
+                arch);
+            cesiumCompileStopwatch.Stop();
+            cesiumCompileTimeMs = cesiumCompileStopwatch.ElapsedMilliseconds;
+
+            // Measure Cesium run time
+            var cesiumRunStopwatch = Stopwatch.StartNew();
+            var managedResult = await (targetFramework switch
+            {
+                TargetFramework.Net => DotNetCliHelper.RunDotNetDll(_output, outRoot, managedExecutable, inputContent),
+                TargetFramework.NetFramework => ExecUtil.Run(_output, managedExecutable, outRoot, [], inputContent),
+                _ => throw new ArgumentOutOfRangeException(nameof(targetFramework), targetFramework, null)
+            });
+            cesiumRunStopwatch.Stop();
+            cesiumRunTimeMs = cesiumRunStopwatch.ElapsedMilliseconds;
+            Assert.Equal(42, managedResult.ExitCode);
+            Assert.Empty(managedResult.StandardError);
+            var cesiumOutput = managedResult.StandardOutput;
+
+            // Verify outputs match
+            Assert.Equal(nativeOutput.ReplaceLineEndings("\n"), cesiumOutput.ReplaceLineEndings("\n"));
+
+            totalStopwatch.Stop();
+
+            // Record timing result
+            var timingResult = new TestTimingResult
+            {
+                TestName = $"{targetFramework}.{relativeSourcePaths.FirstOrDefault()?.Value ?? "unknown"}_{arch}",
+                SourceFile = relativeSourcePaths.FirstOrDefault()?.Value ?? "unknown",
+                TargetArch = arch.ToString(),
+                TargetFramework = targetFramework.ToString(),
+                NativeCompileTimeMs = nativeCompileTimeMs,
+                NativeRunTimeMs = nativeRunTimeMs,
+                CesiumCompileTimeMs = cesiumCompileTimeMs,
+                CesiumRunTimeMs = cesiumRunTimeMs,
+                TotalTimeMs = totalStopwatch.ElapsedMilliseconds
+            };
+
+            TimingRecorder.Instance.RecordTest(timingResult);
+            _output.WriteLine($"Timing: NativeCompile={nativeCompileTimeMs}ms, NativeRun={nativeRunTimeMs}ms, CesiumCompile={cesiumCompileTimeMs}ms, CesiumRun={cesiumRunTimeMs}ms, Total={totalStopwatch.ElapsedMilliseconds}ms");
+        }
+        finally
+        {
+            Directory.Delete(outRoot.Value, recursive: true);
+        }
+    }
 
     private async Task DoTest(TargetFramework targetFramework, TargetArch arch, params LocalPath[] relativeSourcePaths)
     {
@@ -252,6 +370,7 @@ public class IntegrationTestRunner : IClassFixture<IntegrationTestContext>, IAsy
             inputFiles,
             targetFramework,
             arch);
+
         var managedResult = await (targetFramework switch
         {
             TargetFramework.Net => DotNetCliHelper.RunDotNetDll(_output, outRoot, managedExecutable, inputContent),

--- a/Cesium.TestFramework/TimingRecorder.cs
+++ b/Cesium.TestFramework/TimingRecorder.cs
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2025 Cesium contributors <https://github.com/ForNeVeR/Cesium>
+//
+// SPDX-License-Identifier: MIT
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using TruePath;
+
+namespace Cesium.TestFramework;
+
+/// <summary>
+/// Records timing information for integration tests and generates reports.
+/// Thread-safe singleton implementation.
+/// </summary>
+public sealed class TimingRecorder : IDisposable
+{
+    private static readonly Lazy<TimingRecorder> _instance = new(() => new TimingRecorder());
+    private readonly object _lock = new();
+    private readonly List<TestTimingResult> _results = new();
+    private readonly Stopwatch _totalStopwatch = new();
+    private bool _disposed;
+
+    /// <summary>
+    /// Gets the singleton instance of the TimingRecorder.
+    /// </summary>
+    public static TimingRecorder Instance => _instance.Value;
+
+    private TimingRecorder()
+    {
+        _totalStopwatch.Start();
+    }
+
+    /// <summary>
+    /// Records a test timing result.
+    /// </summary>
+    public void RecordTest(TestTimingResult result)
+    {
+        lock (_lock)
+        {
+            _results.Add(result);
+        }
+    }
+
+    /// <summary>
+    /// Gets the current operating system name.
+    /// </summary>
+    public static string GetOsName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return "Windows";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return "Linux";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return "macOS";
+        return "Unknown";
+    }
+
+    /// <summary>
+    /// Generates a timing report from all recorded results.
+    /// </summary>
+    public TimingReport GenerateReport()
+    {
+        lock (_lock)
+        {
+            var summary = new TimingSummary
+            {
+                TotalTests = _results.Count,
+                TotalNativeCompileTimeMs = _results.Sum(r => r.NativeCompileTimeMs),
+                TotalNativeRunTimeMs = _results.Sum(r => r.NativeRunTimeMs),
+                TotalCesiumCompileTimeMs = _results.Sum(r => r.CesiumCompileTimeMs),
+                TotalCesiumRunTimeMs = _results.Sum(r => r.CesiumRunTimeMs),
+                TotalTimeMs = _results.Sum(r => r.TotalTimeMs),
+                Os = GetOsName()
+            };
+
+            return new TimingReport
+            {
+                Os = GetOsName(),
+                Timestamp = DateTime.UtcNow.ToString("o"),
+                Tests = new List<TestTimingResult>(_results),
+                Summary = summary
+            };
+        }
+    }
+
+    /// <summary>
+    /// Writes the timing report to a JSON file.
+    /// The file is written to the current working directory with a name like:
+    /// integration-test-timing-Windows-20250401T120000Z.json
+    /// </summary>
+    public string WriteReportToFile()
+    {
+        var report = GenerateReport();
+        var fileName = $"integration-test-timing-{report.Os}-{DateTime.UtcNow:yyyyMMdd'T'HHmmss'Z'}.json";
+        var filePath = AbsolutePath.CurrentWorkingDirectory / fileName;
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        var json = JsonSerializer.Serialize(report, options);
+        File.WriteAllText(filePath.Value, json);
+
+        return filePath.Value;
+    }
+
+    /// <summary>
+    /// Clears all recorded results.
+    /// </summary>
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _results.Clear();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _totalStopwatch.Stop();
+        _disposed = true;
+    }
+}
+
+/// <summary>
+/// Helper class to measure time for a single operation.
+/// </summary>
+public class OperationTimer : IDisposable
+{
+    private readonly Stopwatch _stopwatch;
+    private readonly Action<long> _recordAction;
+    private bool _disposed;
+
+    public OperationTimer(Action<long> recordAction)
+    {
+        _recordAction = recordAction;
+        _stopwatch = Stopwatch.StartNew();
+    }
+
+    /// <summary>
+    /// Gets the elapsed time in milliseconds.
+    /// </summary>
+    public long ElapsedMilliseconds => _stopwatch.ElapsedMilliseconds;
+
+    /// <summary>
+    /// Stops the timer and records the elapsed time.
+    /// </summary>
+    public void Stop()
+    {
+        if (_disposed)
+            return;
+
+        _stopwatch.Stop();
+        _recordAction(_stopwatch.ElapsedMilliseconds);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        Stop();
+        _disposed = true;
+    }
+}

--- a/Cesium.TestFramework/TimingResult.cs
+++ b/Cesium.TestFramework/TimingResult.cs
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2025 Cesium contributors <https://github.com/ForNeVeR/Cesium>
+//
+// SPDX-License-Identifier: MIT
+
+using System.Text.Json.Serialization;
+
+namespace Cesium.TestFramework;
+
+/// <summary>
+/// Represents timing information for a single test case.
+/// </summary>
+public class TestTimingResult
+{
+    /// <summary>
+    /// Name of the test.
+    /// </summary>
+    [JsonPropertyName("testName")]
+    public string TestName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Source file being tested.
+    /// </summary>
+    [JsonPropertyName("sourceFile")]
+    public string SourceFile { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Target architecture (Bit32, Bit64, Wide, Dynamic).
+    /// </summary>
+    [JsonPropertyName("targetArch")]
+    public string? TargetArch { get; set; }
+
+    /// <summary>
+    /// Target framework (NetFramework, Net).
+    /// </summary>
+    [JsonPropertyName("targetFramework")]
+    public string? TargetFramework { get; set; }
+
+    /// <summary>
+    /// Time to compile with native compiler (cl.exe or gcc), in milliseconds.
+    /// </summary>
+    [JsonPropertyName("nativeCompileTimeMs")]
+    public long NativeCompileTimeMs { get; set; }
+
+    /// <summary>
+    /// Time to run the native executable, in milliseconds.
+    /// </summary>
+    [JsonPropertyName("nativeRunTimeMs")]
+    public long NativeRunTimeMs { get; set; }
+
+    /// <summary>
+    /// Time to compile with Cesium compiler, in milliseconds.
+    /// </summary>
+    [JsonPropertyName("cesiumCompileTimeMs")]
+    public long CesiumCompileTimeMs { get; set; }
+
+    /// <summary>
+    /// Time to run the Cesium-generated executable, in milliseconds.
+    /// </summary>
+    [JsonPropertyName("cesiumRunTimeMs")]
+    public long CesiumRunTimeMs { get; set; }
+
+    /// <summary>
+    /// Total test time in milliseconds.
+    /// </summary>
+    [JsonPropertyName("totalTimeMs")]
+    public long TotalTimeMs { get; set; }
+}
+
+/// <summary>
+/// Summary statistics for all tests.
+/// </summary>
+public class TimingSummary
+{
+    /// <summary>
+    /// Total number of tests executed.
+    /// </summary>
+    [JsonPropertyName("totalTests")]
+    public int TotalTests { get; set; }
+
+    /// <summary>
+    /// Total time spent compiling with native compiler, in milliseconds.
+    /// </summary>
+    [JsonPropertyName("totalNativeCompileTimeMs")]
+    public long TotalNativeCompileTimeMs { get; set; }
+
+    /// <summary>
+    /// Total time spent running native executables, in milliseconds.
+    /// </summary>
+    [JsonPropertyName("totalNativeRunTimeMs")]
+    public long TotalNativeRunTimeMs { get; set; }
+
+    /// <summary>
+    /// Total time spent compiling with Cesium compiler, in milliseconds.
+    /// </summary>
+    [JsonPropertyName("totalCesiumCompileTimeMs")]
+    public long TotalCesiumCompileTimeMs { get; set; }
+
+    /// <summary>
+    /// Total time spent running Cesium executables, in milliseconds.
+    /// </summary>
+    [JsonPropertyName("totalCesiumRunTimeMs")]
+    public long TotalCesiumRunTimeMs { get; set; }
+
+    /// <summary>
+    /// Total execution time for all tests, in milliseconds.
+    /// </summary>
+    [JsonPropertyName("totalTimeMs")]
+    public long TotalTimeMs { get; set; }
+
+    /// <summary>
+    /// Operating system the tests ran on.
+    /// </summary>
+    [JsonPropertyName("os")]
+    public string Os { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Complete timing report for a test run.
+/// </summary>
+public class TimingReport
+{
+    /// <summary>
+    /// Operating system the tests ran on.
+    /// </summary>
+    [JsonPropertyName("os")]
+    public string Os { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Timestamp of the test run (ISO 8601 format).
+    /// </summary>
+    [JsonPropertyName("timestamp")]
+    public string Timestamp { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Individual test timing results.
+    /// </summary>
+    [JsonPropertyName("tests")]
+    public List<TestTimingResult> Tests { get; set; } = new();
+
+    /// <summary>
+    /// Summary statistics.
+    /// </summary>
+    [JsonPropertyName("summary")]
+    public TimingSummary Summary { get; set; } = new();
+}


### PR DESCRIPTION
## Summary
This PR addresses issue #985 by adding timing measurement for integration tests.

## Changes
- Added `TimingResult.cs` and `TimingRecorder.cs` in `Cesium.TestFramework` to record test timing information
- Modified `IntegrationTestRunner.cs` to measure time for each test stage:
  - Native compiler compile time
  - Native executable run time
  - Cesium compiler compile time
  - Cesium executable run time
- Timing results are written to a JSON file (`integration-test-timing-{OS}-{timestamp}.json`) at the end of the test run

## Output Format
The JSON file contains:
- Operating system name (Windows/Linux/macOS)
- Timestamp (ISO 8601 format)
- Individual test timing results with:
  - Test name
  - Source file
  - Target architecture (Bit32/Bit64/Wide/Dynamic)
  - Target framework (NetFramework/Net)
  - Native compile time (ms)
  - Native run time (ms)
  - Cesium compile time (ms)
  - Cesium run time (ms)
  - Total test time (ms)
- Summary statistics including totals for each stage

## Purpose
This allows CI teams to download the timing results and analyze which stages of the integration tests are taking the most time, helping to identify optimization opportunities.

## Example Output
```json
{
  "os": "Windows",
  "timestamp": "2025-04-01T12:00:00Z",
  "tests": [
    {
      "testName": "Net.hello.c_Bit32",
      "sourceFile": "hello.c",
      "targetArch": "Bit32",
      "targetFramework": "Net",
      "nativeCompileTimeMs": 1234,
      "nativeRunTimeMs": 56,
      "cesiumCompileTimeMs": 789,
      "cesiumRunTimeMs": 23,
      "totalTimeMs": 2102
    }
  ],
  "summary": {
    "totalTests": 100,
    "totalNativeCompileTimeMs": 12345,
    "totalCesiumCompileTimeMs": 67890,
    "totalTimeMs": 80235
  }
}
```

Fixes #985