### PR TITLE
Support exporting enum types via assembly metadata

### DIFF
--- a/Cesium.CodeGen.Tests/CodeGenEnumTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenEnumTests.cs
@@ -17,6 +17,17 @@ public class CodeGenEnumTests : CodeGenTestBase
         return VerifyMethods(moduleType);
     }
 
+    [MustUseReturnValue]
+    private static Task DoTypeTest(string source)
+    {
+        var assembly = GenerateAssembly(default, source);
+        return VerifyTypes(assembly);
+    }
+
+    [Fact]
+    public Task EnumTypeTest() => DoTypeTest(@"
+typedef enum Side { Side_L, Side_R } Side;");
+
     [Fact]
     public Task EnumDeclarationTest() => DoTest(@"
 enum Colour { Red, Green, Blue };

--- a/Cesium.CodeGen.Tests/CodeGenEnumTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenEnumTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Cesium contributors <https://github.com/ForNeVeR/Cesium>
+// SPDX-FileCopyrightText: 2025-2026 Cesium contributors <https://github.com/ForNeVeR/Cesium>
 //
 // SPDX-License-Identifier: MIT
 
@@ -17,7 +17,6 @@ public class CodeGenEnumTests : CodeGenTestBase
         return VerifyMethods(moduleType);
     }
 
-    // Currently failing tests using DoTypeTest is marked as "succeeded" so its obvious when proper implementation works in the future
     [MustUseReturnValue]
     private static Task DoTypeTest(string source)
     {
@@ -26,8 +25,16 @@ public class CodeGenEnumTests : CodeGenTestBase
     }
 
     [Fact]
-    public Task EnumTypeTest() => DoTypeTest(@"
+    public Task EnumTypedefTest() => DoTypeTest(@"
 typedef enum Side { Side_L, Side_R } Side;");
+
+    [Fact]
+    public Task EnumInitializerTest() => DoTypeTest(@"
+enum Colors { Red, Green = 5, Blue };");
+
+    [Fact]
+    public Task EnumTypeTest() => DoTypeTest(@"
+enum Side { Side_L, Side_R };");
 
     [Fact]
     public Task EnumDeclarationTest() => DoTest(@"

--- a/Cesium.CodeGen.Tests/CodeGenEnumTests.cs
+++ b/Cesium.CodeGen.Tests/CodeGenEnumTests.cs
@@ -17,6 +17,7 @@ public class CodeGenEnumTests : CodeGenTestBase
         return VerifyMethods(moduleType);
     }
 
+    // Currently failing tests using DoTypeTest is marked as "succeeded" so its obvious when proper implementation works in the future
     [MustUseReturnValue]
     private static Task DoTypeTest(string source)
     {

--- a/Cesium.CodeGen.Tests/CodeGenTestBase.cs
+++ b/Cesium.CodeGen.Tests/CodeGenTestBase.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Cesium contributors <https://github.com/ForNeVeR/Cesium>
+// SPDX-FileCopyrightText: 2025-2026 Cesium contributors <https://github.com/ForNeVeR/Cesium>
 //
 // SPDX-License-Identifier: MIT
 
@@ -219,6 +219,9 @@ public abstract class CodeGenTestBase : VerifyTestBase
                     }
 
                     result.AppendLine($"{Indent(indent + 1)}{field}");
+
+                    if (field.HasConstant)
+                        result.AppendLine($"{Indent(indent + 1)}Constant: {field.Constant}");
 
                     if (field.HasCustomAttributes)
                         PrintCustomAttributes(indent + 1, field.CustomAttributes);

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.EnumArraySizeTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.EnumArraySizeTest.verified.txt
@@ -10,10 +10,10 @@ Module: Primary
       IL_0007: stsfld System.Byte* <Module>::a
       IL_000c: ret
 
-  Type: ValueSize
+  Type: _Enum_ValueSize
   Fields:
-    System.Int32 ValueSize::value__
-    ValueSize ValueSize::Zero
+    System.Int32 _Enum_ValueSize::value__
+    _Enum_ValueSize _Enum_ValueSize::Zero
     Constant: 0
-    ValueSize ValueSize::One
+    _Enum_ValueSize _Enum_ValueSize::One
     Constant: 1

--- a/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.EnumArraySizeTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenArrayTests.EnumArraySizeTest.verified.txt
@@ -9,3 +9,11 @@ Module: Primary
       IL_0002: call System.Void* Cesium.Runtime.RuntimeHelpers::AllocateGlobalField(System.UInt32)
       IL_0007: stsfld System.Byte* <Module>::a
       IL_000c: ret
+
+  Type: ValueSize
+  Fields:
+    System.Int32 ValueSize::value__
+    ValueSize ValueSize::Zero
+    Constant: 0
+    ValueSize ValueSize::One
+    Constant: 1

--- a/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumInitializerTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumInitializerTest.verified.txt
@@ -1,12 +1,12 @@
 Module: Primary
   Type: <Module>
 
-  Type: Colors
+  Type: _Enum_Colors
   Fields:
-    System.Int32 Colors::value__
-    Colors Colors::Red
+    System.Int32 _Enum_Colors::value__
+    _Enum_Colors _Enum_Colors::Red
     Constant: 0
-    Colors Colors::Green
+    _Enum_Colors _Enum_Colors::Green
     Constant: 5
-    Colors Colors::Blue
+    _Enum_Colors _Enum_Colors::Blue
     Constant: 6

--- a/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumInitializerTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumInitializerTest.verified.txt
@@ -1,0 +1,12 @@
+Module: Primary
+  Type: <Module>
+
+  Type: Colors
+  Fields:
+    System.Int32 Colors::value__
+    Colors Colors::Red
+    Constant: 0
+    Colors Colors::Green
+    Constant: 5
+    Colors Colors::Blue
+    Constant: 6

--- a/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumTypeTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumTypeTest.verified.txt
@@ -1,0 +1,2 @@
+Module: Primary
+  Type: <Module>

--- a/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumTypeTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumTypeTest.verified.txt
@@ -1,2 +1,10 @@
 Module: Primary
   Type: <Module>
+
+  Type: Side
+  Fields:
+    System.Int32 Side::value__
+    Side Side::Side_L
+    Constant: 0
+    Side Side::Side_R
+    Constant: 1

--- a/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumTypeTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumTypeTest.verified.txt
@@ -1,10 +1,10 @@
 Module: Primary
   Type: <Module>
 
-  Type: Side
+  Type: _Enum_Side
   Fields:
-    System.Int32 Side::value__
-    Side Side::Side_L
+    System.Int32 _Enum_Side::value__
+    _Enum_Side _Enum_Side::Side_L
     Constant: 0
-    Side Side::Side_R
+    _Enum_Side _Enum_Side::Side_R
     Constant: 1

--- a/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumTypedefTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumTypedefTest.verified.txt
@@ -1,0 +1,10 @@
+Module: Primary
+  Type: <Module>
+
+  Type: Side
+  Fields:
+    System.Int32 Side::value__
+    Side Side::Side_L
+    Constant: 0
+    Side Side::Side_R
+    Constant: 1

--- a/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumTypedefTest.verified.txt
+++ b/Cesium.CodeGen.Tests/verified/CodeGenEnumTests.EnumTypedefTest.verified.txt
@@ -1,10 +1,10 @@
 Module: Primary
   Type: <Module>
 
-  Type: Side
+  Type: _Enum_Side
   Fields:
-    System.Int32 Side::value__
-    Side Side::Side_L
+    System.Int32 _Enum_Side::value__
+    _Enum_Side _Enum_Side::Side_L
     Constant: 0
-    Side Side::Side_R
+    _Enum_Side _Enum_Side::Side_R
     Constant: 1

--- a/Cesium.CodeGen/Contexts/AssemblyContext.cs
+++ b/Cesium.CodeGen/Contexts/AssemblyContext.cs
@@ -381,51 +381,57 @@ public class AssemblyContext : IDisposable
         return name;
     }
 
-    internal void GenerateType(TranslationUnitContext context, string name, StructType type)
+    internal void GenerateType(TranslationUnitContext context, string name, IGeneratedType type)
     {
         if (!_generatedTypes.ContainsKey(type))
         {
             var typeReference = type.StartEmit(name, context);
             _generatedTypes.Add(type, typeReference);
-
-            if (typeReference.Fields.Count == 0)
+            if (type is StructType structType)
             {
-                foreach (var member in type.Members)
+                if (typeReference.Fields.Count == 0)
                 {
-                    if (member.Type is StructType structType)
+                    foreach (var member in structType.Members)
                     {
-                        var typeName = this.GenerateTypeName(structType);
-                        this.GenerateType(context, typeName, structType);
-                    }
+                        if (member.Type is StructType nestedStruct)
+                        {
+                            var typeName = this.GenerateTypeName(nestedStruct);
+                            this.GenerateType(context, typeName, nestedStruct);
+                        }
 
-                    if (member.Type is PointerType { Base: StructType structTypePtr })
-                    {
-                        var typeName = this.GenerateTypeName(structTypePtr);
-                        this.GenerateType(context, typeName, structTypePtr);
+                        if (member.Type is PointerType { Base: StructType structTypePtr })
+                        {
+                            var typeName = this.GenerateTypeName(structTypePtr);
+                            this.GenerateType(context, typeName, structTypePtr);
+                        }
                     }
                 }
             }
         }
     }
 
-    internal void GenerateTypeMembers(TranslationUnitContext context, string name, StructType type)
+    internal void GenerateTypeMembers(TranslationUnitContext context, string name, IGeneratedType type)
     {
         if (!_generatedFieldsTypes.ContainsKey(type))
         {
             var typeReference = (TypeDefinition)_generatedTypes[type]!;
             _generatedFieldsTypes.Add(type, typeReference);
-            foreach (var member in type.Members)
+            // Structs can have nested structs, enum's can't
+            if (type is StructType structType)
             {
-                if (member.Type is StructType structType)
+                foreach (var member in structType.Members)
                 {
-                    var typeName = this.GenerateTypeName(structType);
-                    this.GenerateTypeMembers(context, typeName, structType);
-                }
+                    if (member.Type is StructType nestedStruct)
+                    {
+                        var typeName = this.GenerateTypeName(nestedStruct);
+                        this.GenerateTypeMembers(context, typeName, nestedStruct);
+                    }
 
-                if (member.Type is PointerType { Base: StructType structTypePtr })
-                {
-                    var typeName = this.GenerateTypeName(structTypePtr);
-                    this.GenerateTypeMembers(context, typeName, structTypePtr);
+                    if (member.Type is PointerType { Base: StructType structTypePtr })
+                    {
+                        var typeName = this.GenerateTypeName(structTypePtr);
+                        this.GenerateTypeMembers(context, typeName, structTypePtr);
+                    }
                 }
             }
 

--- a/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
+++ b/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
@@ -127,7 +127,7 @@ public class TranslationUnitContext
     private readonly Dictionary<string, IType> _types = new();
     private readonly Dictionary<string, IType> _tags = new();
 
-    internal void GenerateType(string name, StructType type)
+    internal void GenerateType(string name, IGeneratedType type)
     {
         AssemblyContext.GenerateType(this, name, type);
         AssemblyContext.GenerateTypeMembers(this, name, type);

--- a/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
+++ b/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
@@ -259,7 +259,7 @@ public class TranslationUnitContext
                 {
                     if (existingType is EnumType existingEnumType && existingEnumType.Members.Count == 0)
                     {
-
+                        existingEnumType.Members = enumType.Members;
                         return existingType;
                     }
                 }
@@ -273,6 +273,8 @@ public class TranslationUnitContext
                     }
                 }
             }
+
+            return enumType;
         }
 
         if (type is FunctionType functionType)

--- a/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
+++ b/Cesium.CodeGen/Contexts/TranslationUnitContext.cs
@@ -241,6 +241,40 @@ public class TranslationUnitContext
             return new StructType(ResolveStructMembers(structType), structType.IsUnion, structType.Identifier);
         }
 
+        if (type is EnumType enumType)
+        {
+
+            if (enumType.Members.Count == 0 && enumType.Identifier is not null)
+            {
+                if (_tags.TryGetValue(enumType.Identifier, out var existingType))
+                {
+                    return existingType;
+                }
+            }
+
+            if (enumType.Members.Count != 0 && enumType.Identifier is not null)
+            {
+                IType? existingType;
+                if (_types.TryGetValue(enumType.Identifier, out existingType))
+                {
+                    if (existingType is EnumType existingEnumType && existingEnumType.Members.Count == 0)
+                    {
+
+                        return existingType;
+                    }
+                }
+
+                if (_tags.TryGetValue(enumType.Identifier, out existingType))
+                {
+                    if (existingType is EnumType existingEnumType && existingEnumType.Members.Count == 0)
+                    {
+                        existingEnumType.Members = enumType.Members;
+                        return existingType;
+                    }
+                }
+            }
+        }
+
         if (type is FunctionType functionType)
         {
             ParametersInfo? parametersInfo = null;

--- a/Cesium.CodeGen/Ir/Emitting/BlockItemEmitting.cs
+++ b/Cesium.CodeGen/Ir/Emitting/BlockItemEmitting.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Cesium contributors <https://github.com/ForNeVeR/Cesium>
+// SPDX-FileCopyrightText: 2025-2026 Cesium contributors <https://github.com/ForNeVeR/Cesium>
 //
 // SPDX-License-Identifier: MIT
 
@@ -137,6 +137,9 @@ internal static class BlockItemEmitting
                     var (type, identifier, _) = typeDef;
                     if (type is StructType g)
                         scope.Context.GenerateType(identifier!, g);
+
+                    if (type is EnumType e)
+                        scope.Context.GenerateType(identifier!, e);
                 }
 
                 return;
@@ -148,6 +151,9 @@ internal static class BlockItemEmitting
                     var (type, identifier, _) = typeDef;
                     if (type is StructType g)
                         scope.Context.GenerateType(identifier!, g);
+
+                    if (type is EnumType e)
+                        scope.Context.GenerateType(identifier!, e);
                 }
 
                 return;

--- a/Cesium.CodeGen/Ir/Types/EnumType.cs
+++ b/Cesium.CodeGen/Ir/Types/EnumType.cs
@@ -22,7 +22,7 @@ internal sealed class EnumType : IGeneratedType, IEquatable<EnumType>, IEquatabl
     /// <inheritdoc />
     public TypeKind TypeKind => TypeKind.Enum;
 
-    internal IReadOnlyList<InitializableDeclarationInfo> Members { get; }
+    internal IReadOnlyList<InitializableDeclarationInfo> Members { get; set; }
     public string? Identifier { get; }
 
     public TypeReference Resolve(TranslationUnitContext context)

--- a/Cesium.CodeGen/Ir/Types/EnumType.cs
+++ b/Cesium.CodeGen/Ir/Types/EnumType.cs
@@ -8,7 +8,7 @@ using Mono.Cecil;
 
 namespace Cesium.CodeGen.Ir.Types;
 
-internal sealed class EnumType : IType, IEquatable<EnumType>
+internal sealed class EnumType : IGeneratedType, IEquatable<EnumType>, IEquatable<IGeneratedType>
 {
     public EnumType(IReadOnlyList<InitializableDeclarationInfo> members, string? identifier)
     {
@@ -32,6 +32,31 @@ internal sealed class EnumType : IType, IEquatable<EnumType>
         return 4;
     }
 
+    public TypeDefinition StartEmit(string name, TranslationUnitContext context)
+    {
+        var enumType = new TypeDefinition(
+            context.AssemblyContext.CompilationOptions.Namespace,
+            Identifier is null ? "<typedef>" + name : Identifier,
+            TypeAttributes.Public | TypeAttributes.Sealed,
+            context.Module.ImportReference(new TypeReference("System", "Enum", context.AssemblyContext.MscorlibAssembly.MainModule, context.AssemblyContext.MscorlibAssembly.MainModule.TypeSystem.CoreLibrary)));
+
+        context.Module.Types.Add(enumType);
+        return enumType;
+    }
+
+    public bool IsAlreadyEmitted(TranslationUnitContext context) => context.GetTypeReference(this) is not null;
+
+    public void EmitType(TranslationUnitContext context) {
+
+        var name = this.Identifier ?? "anonymous_enum";
+        context.GenerateType(name, this);
+    }
+
+    public void FinishEmit(TypeDefinition definition, string name, TranslationUnitContext context)
+    {
+
+    }
+
     public bool Equals(EnumType? other)
     {
         if (other is null) return false;
@@ -45,6 +70,16 @@ internal sealed class EnumType : IType, IEquatable<EnumType>
         }
 
         return true;
+    }
+
+    public bool Equals(IGeneratedType? other)
+    {
+        if (other is EnumType enumType)
+        {
+            return Equals(enumType);
+        }
+
+        return false;
     }
 
     public override bool Equals(object? other)

--- a/Cesium.CodeGen/Ir/Types/EnumType.cs
+++ b/Cesium.CodeGen/Ir/Types/EnumType.cs
@@ -1,9 +1,12 @@
-// SPDX-FileCopyrightText: 2025 Cesium contributors <https://github.com/ForNeVeR/Cesium>
+// SPDX-FileCopyrightText: 2025-2026 Cesium contributors <https://github.com/ForNeVeR/Cesium>
 //
 // SPDX-License-Identifier: MIT
 
 using Cesium.CodeGen.Contexts;
+using Cesium.CodeGen.Extensions;
 using Cesium.CodeGen.Ir.Declarations;
+using Cesium.CodeGen.Ir.Expressions.Constants;
+using Cesium.Core;
 using Mono.Cecil;
 
 namespace Cesium.CodeGen.Ir.Types;
@@ -54,7 +57,31 @@ internal sealed class EnumType : IGeneratedType, IEquatable<EnumType>, IEquatabl
 
     public void FinishEmit(TypeDefinition definition, string name, TranslationUnitContext context)
     {
+        var valueField = new FieldDefinition("value__",
+            FieldAttributes.Public | FieldAttributes.SpecialName | FieldAttributes.RTSpecialName, context.TypeSystem.Int32);
 
+        definition.Fields.Add(valueField);
+
+        var scope = context.GetInitializerScope();
+        foreach (var enumConstant in TranslationUnitEx.FindEnumConstants(this, scope))
+        {
+            var constant = ConstantEvaluator.GetConstantValue(enumConstant.Value, scope);
+            if (constant is not IntegerConstant integerConstant ||
+                integerConstant.Value is < int.MinValue or > int.MaxValue)
+            {
+                throw new CompilationException(
+                    $"Enumerator {enumConstant.Identifier} has a value that does not fit in a 32-bit integer.");
+            }
+
+            var field = new FieldDefinition(
+                enumConstant.Identifier,
+                FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal,
+                definition)
+            {
+                Constant = (int)integerConstant.Value
+            };
+            definition.Fields.Add(field);
+        }
     }
 
     public bool Equals(EnumType? other)

--- a/Cesium.CodeGen/Ir/Types/EnumType.cs
+++ b/Cesium.CodeGen/Ir/Types/EnumType.cs
@@ -39,7 +39,7 @@ internal sealed class EnumType : IGeneratedType, IEquatable<EnumType>, IEquatabl
     {
         var enumType = new TypeDefinition(
             context.AssemblyContext.CompilationOptions.Namespace,
-            Identifier is null ? "<typedef>" + name : Identifier,
+            Identifier is null ? "<typedef>" + name : "_Enum_" + Identifier,
             TypeAttributes.Public | TypeAttributes.Sealed,
             context.Module.ImportReference(new TypeReference("System", "Enum", context.AssemblyContext.MscorlibAssembly.MainModule, context.AssemblyContext.MscorlibAssembly.MainModule.TypeSystem.CoreLibrary)));
 

--- a/Cesium.CodeGen/Utils/CesiumMetadataImporterProvider.cs
+++ b/Cesium.CodeGen/Utils/CesiumMetadataImporterProvider.cs
@@ -39,6 +39,7 @@ public class CesiumMetadataImporter(TargetRuntimeDescriptor runtime, ModuleDefin
                 "System.Runtime.Versioning.TargetFrameworkAttribute" => runtime.GetSystemAssemblyReference(),
                 "System.Type" => runtime.GetSystemAssemblyReference(),
                 "System.ValueType" => runtime.GetSystemAssemblyReference(),
+                "System.Enum" => runtime.GetSystemAssemblyReference(),
                 _ => throw new AssertException(
                     $"I don't know what system assembly to use instead of System.Private.CoreLib " +
                     $"to import type {type.FullName}.")


### PR DESCRIPTION
Closes #1012 

Exports C `enum` declarations as CLR `enum` types. This makes `enum` member types visible in the .NET intermediate code (Side.Side_L for example) as suggested in the issue.

These changes are meta-data only, so `enum` values continue to be treated as Int32 values in generated IL code.

Supporting changes required to make this work:
- `CesiumMetadataImporterProvider`: Added `System.Enum` to the reference assembly list
- `BlockItemEmitting`: `enum` tag/typedef declarations were not sent to `GenerateType` (only structs were). Added calls for `EnumType`

Test cases:
- `EnumTypeTest`/`EnumTypedefTest`: Validate tag and typedef metadata consistency
- `EnumInitializerTest`: Validate auto increment correctly continues after writing metadata for an explicit initializer (`Enum Colors { Red, Green = 5, Blue };` Where blue then has a corresponding value of 6)
- Updated `CodeGenArrayTests.EnumArraySizeTest`: Now declares named `enum` used to size an array and emits correct metadata
- Updated `CodeGenTestBase.cs`: Extended `DumpTypes` to print `field.constant` as an extra layer of verification

Verified via `dotnet nuke TestAll`